### PR TITLE
Rename the harbor-pilot crate to pilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,22 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "harbor-pilot"
-version = "0.1.0"
-dependencies = [
- "crossterm 0.29.0",
- "libc",
- "nu-ansi-term",
- "reedline",
- "serde",
- "serde_json",
- "signal-hook 0.4.4",
- "toml",
- "unicode-width",
- "wire",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +974,22 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pilot"
+version = "0.1.0"
+dependencies = [
+ "crossterm 0.29.0",
+ "libc",
+ "nu-ansi-term",
+ "reedline",
+ "serde",
+ "serde_json",
+ "signal-hook 0.4.4",
+ "toml",
+ "unicode-width",
+ "wire",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ binary:
 	cargo build -p harbor --release
 
 pilot:
-	cargo build -p harbor-pilot --release
+	cargo build -p pilot --release
 
 check: binary pilot
 	test/scripts/check.sh

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,7 @@ pilot ./ad-hoc.duckdb             → summon an ephemeral berth, connect (D9)
 
 The workspace is three crates: **`harbor`** (bin + library — the engine folded
 in beside the CLI), **`wire`** (the frozen protocol contract, shared with
-pilot), and **`harbor-pilot`** (the `pilot` client, links no engine).
+pilot), and **`pilot`** (the client, links no engine).
 
 ---
 

--- a/crates/pilot/Cargo.toml
+++ b/crates/pilot/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "harbor-pilot"
+name = "pilot"
 version = "0.1.0"
 edition = "2024"
 description = "pilot — the Harbor client: fleet-aware SQL over UDS and HTTP"


### PR DESCRIPTION
The package was `harbor-pilot` while its directory (`crates/pilot/`) and binary (`pilot`) already dropped the prefix. Rename the package to `pilot` so the workspace reads `harbor, wire, pilot`. Three touch points: the package name, `make pilot`'s `-p` flag, and a PLAN.md mention. `cargo metadata` resolves to `harbor, pilot, wire`; the binary is unchanged.