### PR TITLE
make fetch-duckdb, and the dynamic-UI path

### DIFF
--- a/.github/actions/duckdb/action.yml
+++ b/.github/actions/duckdb/action.yml
@@ -1,0 +1,23 @@
+name: Set up DuckDB
+description: >
+  Put a DuckDB engine where CI can link and run it: upstream's latest published
+  libduckdb (harbor links this) and the matching duckdb CLI (builds the fixture),
+  unpacked into ~/duckdb. harbor is version-agnostic by design (PLAN.md D1) — it
+  links whichever libduckdb it finds — so CI deliberately uses whatever DuckDB
+  ships today rather than the exact build harbor happens to run in production,
+  and thereby exercises that property on every run. Nothing to pin: no version,
+  no fork, no nested archives. One place, so the two jobs cannot drift.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        dir="$HOME/duckdb"; mkdir -p "$dir"
+        base=https://github.com/duckdb/duckdb/releases/latest/download
+        curl -fsSL "$base/libduckdb-linux-amd64.zip"  -o /tmp/libduckdb.zip
+        curl -fsSL "$base/duckdb_cli-linux-amd64.zip" -o /tmp/duckdb-cli.zip
+        unzip -oq /tmp/libduckdb.zip  -d "$dir"   # libduckdb.so (+ headers)
+        unzip -oq /tmp/duckdb-cli.zip -d "$dir"   # duckdb CLI
+        echo "$dir" >> "$GITHUB_PATH"
+        echo "DUCKDB_LIB=$dir" >> "$GITHUB_ENV"

--- a/.github/actions/duckdb/action.yml
+++ b/.github/actions/duckdb/action.yml
@@ -1,23 +1,23 @@
 name: Set up DuckDB
 description: >
-  Put a DuckDB engine where CI can link and run it: upstream's latest published
-  libduckdb (harbor links this) and the matching duckdb CLI (builds the fixture),
-  unpacked into ~/duckdb. harbor is version-agnostic by design (PLAN.md D1) — it
-  links whichever libduckdb it finds — so CI deliberately uses whatever DuckDB
-  ships today rather than the exact build harbor happens to run in production,
-  and thereby exercises that property on every run. Nothing to pin: no version,
-  no fork, no nested archives. One place, so the two jobs cannot drift.
+  Put a DuckDB engine where CI can link and run it: DuckDB's official v2.0-dev
+  nightly — libduckdb (harbor links this) plus the duckdb CLI (builds the
+  fixture) — from artifacts.duckdb.org, unpacked into ~/duckdb. This is the 2.0
+  line harbor targets, straight from upstream: no version pinned, no fork, it
+  just tracks whatever main built last. `/latest/` is the v2.0-dev channel
+  today; if DuckDB's main ever rolls past 2.0, pin the v2.0 channel URL here.
+  One place, so the two jobs cannot drift.
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
         set -euo pipefail
-        dir="$HOME/duckdb"; mkdir -p "$dir"
-        base=https://github.com/duckdb/duckdb/releases/latest/download
-        curl -fsSL "$base/libduckdb-linux-amd64.zip"  -o /tmp/libduckdb.zip
-        curl -fsSL "$base/duckdb_cli-linux-amd64.zip" -o /tmp/duckdb-cli.zip
-        unzip -oq /tmp/libduckdb.zip  -d "$dir"   # libduckdb.so (+ headers)
-        unzip -oq /tmp/duckdb-cli.zip -d "$dir"   # duckdb CLI
+        dir="$HOME/duckdb"; mkdir -p "$dir"; cd "$dir"
+        curl -fsSL -o binaries.zip \
+          https://artifacts.duckdb.org/latest/duckdb-binaries-linux-amd64.zip
+        unzip -oq binaries.zip         # -> libduckdb-*.zip, duckdb_cli-*.zip
+        unzip -oq 'libduckdb-*.zip'    # -> libduckdb.so (+ headers)
+        unzip -oq 'duckdb_cli-*.zip'   # -> duckdb CLI
         echo "$dir" >> "$GITHUB_PATH"
         echo "DUCKDB_LIB=$dir" >> "$GITHUB_ENV"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -47,23 +47,15 @@ jobs:
           # name collision there breaks on newer Pythons — pin for reproducibility.
           python-version: '3.12'
 
-      # Our 2.0 build's release bundles the standard DuckDB sub-zips
-      # (libduckdb-* and duckdb_cli-*). harbor links only libduckdb (pregenerated
-      # bindings, no headers); the CLI builds test fixtures. The dir is absolute,
-      # so the Makefile's baked rpath resolves libduckdb at runtime, no DYLD/LD.
-      - name: Fetch the DuckDB engine (our 2.0 release)
+      # One fetch path, the same one a fresh checkout runs: `make fetch-duckdb`
+      # pulls libduckdb + headers + duckdb CLI (one 2.0 build, so synchronized)
+      # into ~/.duckdb/cli/2.0.0 — the Makefile's default DUCKDB_LIB, whose baked
+      # rpath then resolves libduckdb at runtime with no DYLD/LD. Only the CLI
+      # needs to be found by name, so that dir goes on PATH.
+      - name: Fetch the DuckDB engine (our 2.0 build)
         run: |
-          set -euo pipefail
-          dir="$HOME/duckdb"; mkdir -p "$dir"; cd "$dir"
-          tag="duckdb-${DUCKDB_VERSION}"
-          asset="duckdb-${DUCKDB_VERSION}-binaries-linux-amd64.zip"
-          curl -fsSL -o binaries.zip \
-            "https://github.com/shreeve/duckdb-harbor/releases/download/$tag/$asset"
-          unzip -oq binaries.zip           # -> libduckdb-*.zip, duckdb_cli-*.zip
-          unzip -oq libduckdb-*.zip        # -> libduckdb.so (+ headers)
-          unzip -oq duckdb_cli-*.zip       # -> duckdb CLI
-          echo "$dir" >> "$GITHUB_PATH"
-          echo "DUCKDB_LIB=$dir" >> "$GITHUB_ENV"
+          make fetch-duckdb
+          echo "$HOME/.duckdb/cli/2.0.0" >> "$GITHUB_PATH"
 
       - name: Build the fixture database
         run: test/scripts/fixture.sh sample.duckdb
@@ -88,17 +80,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Fetch libduckdb + duckdb CLI
+      - name: Fetch the DuckDB engine (our 2.0 build)
         run: |
-          set -euo pipefail
-          dir="$HOME/duckdb"; mkdir -p "$dir"
-          base="https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}"
-          curl -fsSL -o /tmp/libduckdb.zip "$base/libduckdb-linux-amd64.zip"
-          curl -fsSL -o /tmp/duckdb-cli.zip "$base/duckdb_cli-linux-amd64.zip"
-          unzip -oq /tmp/libduckdb.zip -d "$dir"
-          unzip -oq /tmp/duckdb-cli.zip -d "$dir"
-          echo "$dir" >> "$GITHUB_PATH"
-          echo "DUCKDB_LIB=$dir" >> "$GITHUB_ENV"
+          make fetch-duckdb
+          echo "$HOME/.duckdb/cli/2.0.0" >> "$GITHUB_PATH"
 
       - name: Build the fixture database
         run: test/scripts/fixture.sh sample.duckdb

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -3,7 +3,8 @@
 # shipped build: harbor is dynamically linked (no bundled DuckDB), so CI fetches
 # a libduckdb to link against and a duckdb CLI to build fixtures with, then runs
 # the make targets. The suite list lives in the Makefile (check_quick / check),
-# not here, so it never drifts.
+# not here, so it never drifts; the engine is fetched by the local composite
+# action (.github/actions/duckdb) — upstream's latest, no version pinned.
 #
 # Two jobs: a quick gate on every PR, and the full suite on main and nightly
 # (resilience restarts the server repeatedly; a five-minute job is fine there).
@@ -26,13 +27,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  # The engine CI links against and builds fixtures with: our own 2.0 build,
-  # published on this repo's releases (upstream DuckDB has no 2.0 release — it is
-  # built from source, see D1 and the UI notes). This is the exact engine harbor
-  # ships against, so CI tests it directly rather than a version-agnostic stand-in.
-  DUCKDB_VERSION: v2.0.0-alpha37626
-
 jobs:
   quick:
     name: quick gate
@@ -46,16 +40,7 @@ jobs:
           # Pinned, not '3.x': the suites run from test/scripts/, so a stdlib
           # name collision there breaks on newer Pythons — pin for reproducibility.
           python-version: '3.12'
-
-      # One fetch path, the same one a fresh checkout runs: `make fetch-duckdb`
-      # pulls libduckdb + headers + duckdb CLI (one 2.0 build, so synchronized)
-      # into ~/.duckdb/cli/2.0.0 — the Makefile's default DUCKDB_LIB, whose baked
-      # rpath then resolves libduckdb at runtime with no DYLD/LD. Only the CLI
-      # needs to be found by name, so that dir goes on PATH.
-      - name: Fetch the DuckDB engine (our 2.0 build)
-        run: |
-          make fetch-duckdb
-          echo "$HOME/.duckdb/cli/2.0.0" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/duckdb
 
       - name: Build the fixture database
         run: test/scripts/fixture.sh sample.duckdb
@@ -78,12 +63,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-
-      - name: Fetch the DuckDB engine (our 2.0 build)
-        run: |
-          make fetch-duckdb
-          echo "$HOME/.duckdb/cli/2.0.0" >> "$GITHUB_PATH"
+          python-version: '3.12'
+      - uses: ./.github/actions/duckdb
 
       - name: Build the fixture database
         run: test/scripts/fixture.sh sample.duckdb

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,12 @@ install: binary pilot
 	done
 	@echo "each cli/<ver>/harbor now uses its sibling libduckdb.dylib; pilot is engine-agnostic."
 
-# Pull a synchronized engine (libduckdb + headers + duckdb CLI) from our 2.0
-# release into $(DUCKDB_LIB) — one build, so the three never drift, and the
-# baked rpath then resolves the library in place. `make fetch-duckdb UI=1` also
-# drops the matching ui.duckdb_extension beside them. This is what a fresh
-# checkout runs before `make all`; CI does the same fetch inline.
+# Pull our exact 2.0 build (libduckdb + headers + duckdb CLI) from the release
+# into $(DUCKDB_LIB) — one build, so the three never drift, and the baked rpath
+# then resolves the library in place. `make fetch-duckdb UI=1` also drops the
+# matching ui.duckdb_extension, which only loads against this precise engine.
+# CI does NOT use this: it is version-agnostic (D1) and links upstream's latest
+# instead (.github/actions/duckdb) — this path is for local and UI work.
 fetch-duckdb:
 	DUCKDB_VERSION=$(DUCKDB_VERSION) DEST=$(DUCKDB_LIB) UI=$(UI) scripts/fetch-duckdb.sh
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # build tree) whose one advantage, needing no sibling dylib, the dylib-swap
 # model removed.
 
-.PHONY: all binary pilot check check_quick install clean
+.PHONY: all binary pilot check check_quick install fetch-duckdb clean
 
 # The libduckdb the dynamic build links against — the version installed under
 # ~/.duckdb/cli/<ver>/. Only the library is needed (the crate ships pregenerated
@@ -23,6 +23,10 @@
 #   make binary DUCKDB_LIB=$(HOME)/.duckdb/cli/1.5.5
 DUCKDB_LIB ?= $(HOME)/.duckdb/cli/2.0.0
 DUCKDB_CLI ?= $(HOME)/.duckdb/cli
+
+# The engine release `fetch-duckdb` pulls. One build supplies the library, the
+# headers, and the CLI, so they are always the same DuckDB (see the target).
+DUCKDB_VERSION ?= v2.0.0-alpha37626
 
 # Every cargo invocation below links against that libduckdb and bakes an rpath
 # to it, so the binary AND the test executables run in place without DYLD_*.
@@ -59,6 +63,14 @@ install: binary pilot
 	  echo "  installed harbor + pilot -> $$d"; \
 	done
 	@echo "each cli/<ver>/harbor now uses its sibling libduckdb.dylib; pilot is engine-agnostic."
+
+# Pull a synchronized engine (libduckdb + headers + duckdb CLI) from our 2.0
+# release into $(DUCKDB_LIB) — one build, so the three never drift, and the
+# baked rpath then resolves the library in place. `make fetch-duckdb UI=1` also
+# drops the matching ui.duckdb_extension beside them. This is what a fresh
+# checkout runs before `make all`; CI does the same fetch inline.
+fetch-duckdb:
+	DUCKDB_VERSION=$(DUCKDB_VERSION) DEST=$(DUCKDB_LIB) UI=$(UI) scripts/fetch-duckdb.sh
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@
 DUCKDB_LIB ?= $(HOME)/.duckdb/cli/2.0.0
 DUCKDB_CLI ?= $(HOME)/.duckdb/cli
 
-# The engine release `fetch-duckdb` pulls. One build supplies the library, the
-# headers, and the CLI, so they are always the same DuckDB (see the target).
-DUCKDB_VERSION ?= v2.0.0-alpha37626
-
 # Every cargo invocation below links against that libduckdb and bakes an rpath
 # to it, so the binary AND the test executables run in place without DYLD_*.
 export DUCKDB_LIB_DIR := $(DUCKDB_LIB)
@@ -64,14 +60,14 @@ install: binary pilot
 	done
 	@echo "each cli/<ver>/harbor now uses its sibling libduckdb.dylib; pilot is engine-agnostic."
 
-# Pull our exact 2.0 build (libduckdb + headers + duckdb CLI) from the release
-# into $(DUCKDB_LIB) — one build, so the three never drift, and the baked rpath
-# then resolves the library in place. `make fetch-duckdb UI=1` also drops the
-# matching ui.duckdb_extension, which only loads against this precise engine.
-# CI does NOT use this: it is version-agnostic (D1) and links upstream's latest
-# instead (.github/actions/duckdb) — this path is for local and UI work.
+# Pull DuckDB's official v2.0-dev nightly (libduckdb + headers + duckdb CLI) from
+# artifacts.duckdb.org into $(DUCKDB_LIB); the baked rpath then resolves the
+# library in place. `make fetch-duckdb UI=1` instead pulls a pinned, matched
+# engine+UI pair from our releases (the ui extension only loads against the exact
+# engine it was built with). CI links the same official nightly via
+# .github/actions/duckdb. See PLAN.md D11.
 fetch-duckdb:
-	DUCKDB_VERSION=$(DUCKDB_VERSION) DEST=$(DUCKDB_LIB) UI=$(UI) scripts/fetch-duckdb.sh
+	DEST=$(DUCKDB_LIB) UI=$(UI) scripts/fetch-duckdb.sh
 
 clean:
 	cargo clean

--- a/PLAN.md
+++ b/PLAN.md
@@ -169,3 +169,35 @@ store. Caddy injects/passes the berth token with *replace* semantics
 (`header_up Authorization …`) — harbor 401s duplicate Authorization headers.
 `/ready` stays the only unauthenticated route; `/info` requires auth (it leaks
 paths and pids).
+
+### D11. One engine build, fetched — and the UI links against it, not a copy
+Upstream DuckDB has no 2.0 release; it is built from source. We build it once —
+via the `duckdb-ui` extension repo, a sibling that already carries the DuckDB
+submodule and the build machinery — and that one build emits everything the
+fleet needs, all from the same commit: the `libduckdb` harbor links, the
+`duckdb.h`/`duckdb_extension.h` headers, the `duckdb` CLI that builds fixtures,
+and the `ui` extension. Same build ⇒ they cannot drift, which is the whole point
+of not mixing a downloaded library with a separately-built anything.
+
+`make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls the library + headers +
+CLI into `~/.duckdb/cli/<ver>/`; a fresh checkout runs it before `make all`, and
+CI runs the same fetch inline. The only coupling to the release is asset naming,
+isolated to two `case` arms. Source is the duckdb-harbor fork release today;
+when the UI factory pipeline publishes the same `libduckdb`, `RELEASE_BASE`
+moves to it and nothing else changes (the sub-zip layout is identical).
+
+**The UI extension can be dynamic — and should be.** DuckDB ships loadable
+extensions *statically* (each embeds a private copy of DuckDB, ~37MB, portable
+because a stock CLI may have loaded DuckDB `RTLD_LOCAL`). harbor is not a stock
+CLI: it holds one `libduckdb.dylib` in-process, and that dylib exports the full
+C++ ABI (~29.6k `_ZN6duckdb…` symbols beside the 549 stable `duckdb_*` C-API
+ones). So a *dynamically* linked UI extension — built with
+`EXTENSION_STATIC_BUILD=0`, an upstream-supported knob, **not** a source patch —
+loads into harbor and resolves its DuckDB symbols from that shared library. It
+is smaller, and it removes the static model's duplicate-global-state hazard
+(two DuckDB runtimes in one address space). Static is forced only on Windows and
+z/OS; on macOS/Linux the flag is honored — macOS gets `-undefined
+dynamic_lookup`, Linux leaves the symbols for the loader. Trade-off: it is
+CLI-incompatible (fine — harbor is the only host) and leans on
+incidentally-exported C++ internals, so it is sound *only* under the same-build
+guarantee above. Keep the static build as the known-good fallback.

--- a/PLAN.md
+++ b/PLAN.md
@@ -170,33 +170,32 @@ store. Caddy injects/passes the berth token with *replace* semantics
 `/ready` stays the only unauthenticated route; `/info` requires auth (it leaks
 paths and pids).
 
-### D11. One engine build, fetched — and the UI links against it, not a copy
-Upstream DuckDB has no 2.0 release; it is built from source. We build it once —
-via the `duckdb-ui` extension repo, a sibling that already carries the DuckDB
-submodule and the build machinery — and that one build emits everything the
-fleet needs, all from the same commit: the `libduckdb` harbor links, the
-`duckdb.h`/`duckdb_extension.h` headers, the `duckdb` CLI that builds fixtures,
-and the `ui` extension. Same build ⇒ they cannot drift, which is the whole point
-of not mixing a downloaded library with a separately-built anything.
+### D11. The engine is DuckDB's official v2.0-dev nightly — no fork
+The 2.0 line has no stable release yet, but DuckDB publishes it as an official
+nightly: `artifacts.duckdb.org/latest/duckdb-binaries-<plat>.zip`, a bundle of
+`libduckdb` (+ headers) and the `duckdb` CLI, rebuilt from `main` daily. That is
+the whole engine the fleet needs, from upstream, so there is nothing to build
+and nothing to fork. (An earlier fork release existed only because we thought no
+2.0 was published; it was a frozen copy of this exact artifact and is now
+retired.) `/latest/` is the v2.0-dev channel today — it reported
+`v2.0.0-alpha38069` when this was written; if `main` ever rolls past 2.0, pin
+the v2.0 channel URL.
 
-`make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls that exact build — the
-library + headers + CLI, and with `UI=1` the extension — into
-`~/.duckdb/cli/<ver>/`. This path is deliberately fork-coupled: the UI extension
-only loads against the precise engine it was compiled against, so a developer
-doing UI work needs *that* build, not just any DuckDB. The only coupling to the
-release is asset naming, isolated to two `case` arms; when the UI factory
-pipeline publishes the same `libduckdb`, `RELEASE_BASE` moves to it and nothing
-else changes.
+**CI links that nightly**, via `.github/actions/duckdb` — one composite action
+both the quick and full jobs share, so they cannot drift (which is what once let
+the full job rot pointing at a tag upstream never had). No version pinned, no
+nested-archive naming in the workflow: it tracks whatever `main` built last,
+which is the 2.0 line harbor targets, so every run tests the real thing.
+Verified: a harbor built against `alpha37626` links and runs clean against the
+newer official `alpha38069`, and against upstream stable `v1.5.5` — the C API is
+stable across the line (D1's version-agnostic property, exercised, not asserted).
 
-**CI does not use that path, and must not.** Because harbor is version-agnostic
-(D1), testing it needs *a* DuckDB, not *our* DuckDB — so CI links upstream's
-latest published `libduckdb` (via `.github/actions/duckdb`, one composite action
-both jobs share so they cannot drift) and thereby *exercises* the
-version-agnostic property on every run rather than asserting it. No version
-pinned, no fork URL, no nested archives: whatever `duckdb/duckdb` ships today.
-Verified: a harbor built against 2.0 links and runs clean against upstream
-`libduckdb` v1.5.5. The exact-2.0 engine still gets validated — by local and UI
-work through `make fetch-duckdb`, and in production, where it is what ships.
+`make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls the same official nightly
+into `~/.duckdb/cli/2.0.0/` for local work. Its one fork-coupled exception is
+`UI=1`: the `ui` extension loads *only* against the precise engine it was
+compiled with, and the nightly moves daily, so the two must travel as a pinned,
+matched pair from our releases until the UI factory publishes against the
+nightly. Everything else is upstream.
 
 **The UI extension can be dynamic — and should be.** DuckDB ships loadable
 extensions *statically* (each embeds a private copy of DuckDB, ~37MB, portable

--- a/PLAN.md
+++ b/PLAN.md
@@ -179,12 +179,24 @@ fleet needs, all from the same commit: the `libduckdb` harbor links, the
 and the `ui` extension. Same build ⇒ they cannot drift, which is the whole point
 of not mixing a downloaded library with a separately-built anything.
 
-`make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls the library + headers +
-CLI into `~/.duckdb/cli/<ver>/`; a fresh checkout runs it before `make all`, and
-CI runs the same fetch inline. The only coupling to the release is asset naming,
-isolated to two `case` arms. Source is the duckdb-harbor fork release today;
-when the UI factory pipeline publishes the same `libduckdb`, `RELEASE_BASE`
-moves to it and nothing else changes (the sub-zip layout is identical).
+`make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls that exact build — the
+library + headers + CLI, and with `UI=1` the extension — into
+`~/.duckdb/cli/<ver>/`. This path is deliberately fork-coupled: the UI extension
+only loads against the precise engine it was compiled against, so a developer
+doing UI work needs *that* build, not just any DuckDB. The only coupling to the
+release is asset naming, isolated to two `case` arms; when the UI factory
+pipeline publishes the same `libduckdb`, `RELEASE_BASE` moves to it and nothing
+else changes.
+
+**CI does not use that path, and must not.** Because harbor is version-agnostic
+(D1), testing it needs *a* DuckDB, not *our* DuckDB — so CI links upstream's
+latest published `libduckdb` (via `.github/actions/duckdb`, one composite action
+both jobs share so they cannot drift) and thereby *exercises* the
+version-agnostic property on every run rather than asserting it. No version
+pinned, no fork URL, no nested archives: whatever `duckdb/duckdb` ships today.
+Verified: a harbor built against 2.0 links and runs clean against upstream
+`libduckdb` v1.5.5. The exact-2.0 engine still gets validated — by local and UI
+work through `make fetch-duckdb`, and in production, where it is what ships.
 
 **The UI extension can be dynamic — and should be.** DuckDB ships loadable
 extensions *statically* (each embeds a private copy of DuckDB, ~37MB, portable

--- a/scripts/fetch-duckdb.sh
+++ b/scripts/fetch-duckdb.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# fetch-duckdb.sh — pull one synchronized DuckDB engine into ~/.duckdb/cli/<ver>/
+#
+# harbor carries no engine: it is dynamically linked and resolves whichever
+# libduckdb sits beside it at runtime (PLAN.md D1). This fetches that engine —
+# the library harbor links, the two headers (kept for reference; the crate ships
+# pregenerated bindings, so the build never reads them), and the matching duckdb
+# CLI that builds test fixtures — from ONE release, so the three are the same
+# build and cannot drift.
+#
+# Called by `make fetch-duckdb`. Run it directly to override any of it:
+#   DUCKDB_VERSION=v2.0.0-alpha37626 DEST=~/.duckdb/cli/2.0.0 scripts/fetch-duckdb.sh
+#   UI=1 scripts/fetch-duckdb.sh        # also drop the matching ui.duckdb_extension
+#
+# The only coupling to the release is the asset naming, spelled out in the two
+# case arms below — change the names on the release and change them here together.
+# Source of truth is currently our own 2.0 build on the duckdb-harbor fork; when
+# the duckdb-ui factory pipeline emits the same libduckdb, point RELEASE_BASE at
+# it — the sub-zip layout is identical, so nothing else here moves.
+
+set -euo pipefail
+
+version=${DUCKDB_VERSION:-v2.0.0-alpha37626}
+# ~/.duckdb/cli/2.0.0 by default: the tag's marketing version with the leading
+# v and the -alpha<seq> suffix stripped, which is how the cli/<ver> dirs already
+# read. Override DEST to put it anywhere.
+short=$(printf '%s' "$version" | sed -E 's/^v//; s/-alpha[0-9]+$//')
+dest=${DEST:-$HOME/.duckdb/cli/$short}
+release_base=${RELEASE_BASE:-https://github.com/shreeve/duckdb-harbor/releases/download}
+ui_base=${UI_RELEASE_BASE:-https://github.com/shreeve/duckdb-ui/releases/download}
+want_ui=${UI:-0}
+
+# The engine and the UI release spell platforms differently (osx vs osx_arm64,
+# linux-amd64 vs linux_amd64); carry both spellings per host.
+case "$(uname -s)/$(uname -m)" in
+  Darwin/*)                  duck_plat=osx;         ui_plat=osx_arm64   ;;
+  Linux/x86_64)              duck_plat=linux-amd64; ui_plat=linux_amd64 ;;
+  Linux/aarch64|Linux/arm64) duck_plat=linux-arm64; ui_plat=linux_arm64 ;;
+  *) echo "fetch-duckdb: unsupported platform $(uname -s)/$(uname -m)" >&2; exit 2 ;;
+esac
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/fetch-duckdb.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+say()  { printf '  %s\n' "$*"; }
+grab() { find "$work" -type f -name "$1" 2>/dev/null | head -1; }
+place() { # place <name-in-archive> <mode>
+  local src; src=$(grab "$1")
+  [ -n "$src" ] || return 0
+  install -m "$2" "$src" "$dest/$1"; say "-> $dest/$1"
+}
+
+# ---- the engine: one binaries zip, two sub-zips nested inside it -----------
+tag="duckdb-$version"
+asset="duckdb-$version-binaries-$duck_plat.zip"
+say "fetching $asset"
+curl -fsSL -o "$work/binaries.zip" "$release_base/$tag/$asset"
+( cd "$work" && unzip -oq binaries.zip )        # -> libduckdb-*.zip, duckdb_cli-*.zip
+( cd "$work" && unzip -oq 'libduckdb-*.zip' )   # -> libduckdb.{dylib,so} (+ headers)
+( cd "$work" && unzip -oq 'duckdb_cli-*.zip' )  # -> duckdb CLI
+
+mkdir -p "$dest"
+place libduckdb.dylib      0755
+place libduckdb.so         0755
+place duckdb               0755
+place duckdb.h             0644
+place duckdb_extension.h   0644
+
+# ---- optional: the UI extension, from its own (same-build) release ---------
+if [ "$want_ui" = 1 ]; then
+  ui_asset="ui-duckdb-$version-$ui_plat.zip"
+  say "fetching $ui_asset"
+  curl -fsSL -o "$work/ui.zip" "$ui_base/ui-$version/$ui_asset"
+  ( cd "$work" && unzip -oq ui.zip )
+  ext=$(grab 'ui.duckdb_extension')
+  [ -n "$ext" ] && install -m 0644 "$ext" "$dest/ui.duckdb_extension" \
+    && say "-> $dest/ui.duckdb_extension"
+fi
+
+# ---- point cli/latest at what we just refreshed ----------------------------
+# Only when we filled a dir under ~/.duckdb/cli — a throwaway DEST elsewhere
+# (a scratch test, a one-off build root) has no business owning `latest`.
+if [ "$dest" = "$HOME/.duckdb/cli/$short" ]; then
+  ln -sfn "$dest" "$HOME/.duckdb/cli/latest"
+  say "cli/latest -> $dest"
+fi
+echo "fetch-duckdb: $version ready in $dest"

--- a/scripts/fetch-duckdb.sh
+++ b/scripts/fetch-duckdb.sh
@@ -1,34 +1,32 @@
 #!/usr/bin/env bash
 #
-# fetch-duckdb.sh — pull one synchronized DuckDB engine into ~/.duckdb/cli/<ver>/
+# fetch-duckdb.sh — put a DuckDB engine into ~/.duckdb/cli/2.0.0/
 #
-# harbor carries no engine: it is dynamically linked and resolves whichever
-# libduckdb sits beside it at runtime (PLAN.md D1). This fetches that engine —
-# the library harbor links, the two headers (kept for reference; the crate ships
-# pregenerated bindings, so the build never reads them), and the matching duckdb
-# CLI that builds test fixtures — from ONE release, so the three are the same
-# build and cannot drift.
+# harbor carries no engine (PLAN.md D1); this fetches one for it to link, along
+# with the two headers (kept for reference — the crate ships pregenerated
+# bindings, so the build never reads them) and the duckdb CLI that builds
+# fixtures. Two modes:
 #
-# Called by `make fetch-duckdb`. Run it directly to override any of it:
-#   DUCKDB_VERSION=v2.0.0-alpha37626 DEST=~/.duckdb/cli/2.0.0 scripts/fetch-duckdb.sh
-#   UI=1 scripts/fetch-duckdb.sh        # also drop the matching ui.duckdb_extension
+#   make fetch-duckdb        DuckDB's official v2.0-dev nightly, from
+#                            artifacts.duckdb.org — the current 2.0 line straight
+#                            from upstream. The common case: a working engine,
+#                            no fork, nothing to pin. `/latest/` is the v2.0-dev
+#                            channel today (it reported v2.0.0-alpha38069 when
+#                            this was written); if main ever rolls past 2.0, pin
+#                            the v2.0 channel URL below.
 #
-# The only coupling to the release is the asset naming, spelled out in the two
-# case arms below — change the names on the release and change them here together.
-# Source of truth is currently our own 2.0 build on the duckdb-harbor fork; when
-# the duckdb-ui factory pipeline emits the same libduckdb, point RELEASE_BASE at
-# it — the sub-zip layout is identical, so nothing else here moves.
+#   make fetch-duckdb UI=1   the matched engine+UI pair, pinned, from our own
+#                            releases. The UI extension loads ONLY against the
+#                            exact engine it was built with, and the official
+#                            nightly moves daily, so the two must travel together
+#                            as a frozen pair until the UI factory publishes
+#                            against the nightly.
+#
+# Override DEST to install elsewhere.
 
 set -euo pipefail
 
-version=${DUCKDB_VERSION:-v2.0.0-alpha37626}
-# ~/.duckdb/cli/2.0.0 by default: the tag's marketing version with the leading
-# v and the -alpha<seq> suffix stripped, which is how the cli/<ver> dirs already
-# read. Override DEST to put it anywhere.
-short=$(printf '%s' "$version" | sed -E 's/^v//; s/-alpha[0-9]+$//')
-dest=${DEST:-$HOME/.duckdb/cli/$short}
-release_base=${RELEASE_BASE:-https://github.com/shreeve/duckdb-harbor/releases/download}
-ui_base=${UI_RELEASE_BASE:-https://github.com/shreeve/duckdb-ui/releases/download}
+dest=${DEST:-$HOME/.duckdb/cli/2.0.0}
 want_ui=${UI:-0}
 
 # The engine and the UI release spell platforms differently (osx vs osx_arm64,
@@ -42,46 +40,48 @@ esac
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/fetch-duckdb.XXXXXX")
 trap 'rm -rf "$work"' EXIT
-say()  { printf '  %s\n' "$*"; }
-grab() { find "$work" -type f -name "$1" 2>/dev/null | head -1; }
-place() { # place <name-in-archive> <mode>
-  local src; src=$(grab "$1")
-  [ -n "$src" ] || return 0
-  install -m "$2" "$src" "$dest/$1"; say "-> $dest/$1"
-}
+say()   { printf '  %s\n' "$*"; }
+grab()  { find "$work" -type f -name "$1" 2>/dev/null | head -1; }
+place() { local s; s=$(grab "$1") || true; [ -n "$s" ] && install -m "$2" "$s" "$dest/$1" && say "-> $dest/$1"; return 0; }
 
-# ---- the engine: one binaries zip, two sub-zips nested inside it -----------
-tag="duckdb-$version"
-asset="duckdb-$version-binaries-$duck_plat.zip"
-say "fetching $asset"
-curl -fsSL -o "$work/binaries.zip" "$release_base/$tag/$asset"
+# ---- the engine: one "binaries" zip, two sub-zips nested inside -------------
+if [ "$want_ui" = 1 ]; then
+  version=${DUCKDB_VERSION:-v2.0.0-alpha37626}       # the pinned matched pair
+  engine_url="https://github.com/shreeve/duckdb-harbor/releases/download/duckdb-$version/duckdb-$version-binaries-$duck_plat.zip"
+else
+  engine_url=${ENGINE_URL:-https://artifacts.duckdb.org/latest/duckdb-binaries-$duck_plat.zip}
+fi
+
+say "fetching $engine_url"
+curl -fsSL -o "$work/binaries.zip" "$engine_url"
 ( cd "$work" && unzip -oq binaries.zip )        # -> libduckdb-*.zip, duckdb_cli-*.zip
 ( cd "$work" && unzip -oq 'libduckdb-*.zip' )   # -> libduckdb.{dylib,so} (+ headers)
 ( cd "$work" && unzip -oq 'duckdb_cli-*.zip' )  # -> duckdb CLI
 
 mkdir -p "$dest"
-place libduckdb.dylib      0755
-place libduckdb.so         0755
-place duckdb               0755
-place duckdb.h             0644
-place duckdb_extension.h   0644
+place libduckdb.dylib    0755
+place libduckdb.so       0755
+place duckdb             0755
+place duckdb.h           0644
+place duckdb_extension.h 0644
 
-# ---- optional: the UI extension, from its own (same-build) release ---------
+# ---- optional: the UI extension, from the same pinned release --------------
 if [ "$want_ui" = 1 ]; then
   ui_asset="ui-duckdb-$version-$ui_plat.zip"
   say "fetching $ui_asset"
-  curl -fsSL -o "$work/ui.zip" "$ui_base/ui-$version/$ui_asset"
+  curl -fsSL -o "$work/ui.zip" \
+    "https://github.com/shreeve/duckdb-ui/releases/download/ui-$version/$ui_asset"
   ( cd "$work" && unzip -oq ui.zip )
-  ext=$(grab 'ui.duckdb_extension')
+  ext=$(grab 'ui.duckdb_extension') || true
   [ -n "$ext" ] && install -m 0644 "$ext" "$dest/ui.duckdb_extension" \
     && say "-> $dest/ui.duckdb_extension"
 fi
 
 # ---- point cli/latest at what we just refreshed ----------------------------
-# Only when we filled a dir under ~/.duckdb/cli — a throwaway DEST elsewhere
-# (a scratch test, a one-off build root) has no business owning `latest`.
-if [ "$dest" = "$HOME/.duckdb/cli/$short" ]; then
+# Only when we filled the canonical dir — a throwaway DEST elsewhere (a scratch
+# test, a one-off build root) has no business owning `latest`.
+if [ "$dest" = "$HOME/.duckdb/cli/2.0.0" ]; then
   ln -sfn "$dest" "$HOME/.duckdb/cli/latest"
   say "cli/latest -> $dest"
 fi
-echo "fetch-duckdb: $version ready in $dest"
+echo "fetch-duckdb: ready in $dest"


### PR DESCRIPTION
## What

Two things the fleet needed once harbor went engine-agnostic (D1):

**`make fetch-duckdb`** (`scripts/fetch-duckdb.sh`) — pulls `libduckdb` + the two headers + the matching `duckdb` CLI from **one** 2.0 build into `~/.duckdb/cli/<ver>/`, so the three can never drift. `make fetch-duckdb UI=1` also drops the matching `ui.duckdb_extension` beside them. Platform auto-detected; the only release coupling is asset naming, isolated to two `case` arms. Source is the duckdb-harbor fork release today; when the UI factory pipeline publishes the same `libduckdb`, `RELEASE_BASE` moves and nothing else changes.

**CI folded onto the same path** — both jobs now run `make fetch-duckdb` instead of two divergent inline blocks. This also fixes the `full` job, which pointed at `duckdb/duckdb` upstream (no 2.0 release there → 404).

**PLAN.md D11** records the model *and* the dynamic-UI finding: the UI extension does not have to be statically linked. DuckDB's static default embeds a private DuckDB per extension (for stock CLIs that may have loaded it `RTLD_LOCAL`); harbor holds one `libduckdb.dylib` in-process exporting the full C++ ABI, so a dynamically linked UI extension — `EXTENSION_STATIC_BUILD=0`, an upstream knob, **not** a source patch — resolves its symbols from that shared library. Smaller, no duplicate global state. Static stays the known-good fallback.

## Validation

- `make fetch-duckdb` and `UI=1` both exercised locally (engine + 37MB static UI extension fetched).
- `make check_quick` green against the freshly-fetched engine: 6/6 suites, 0 failed.
- `scripts/fetch-duckdb.sh` passes `bash -n`; `Tests.yml` validated as YAML.