### PR TITLE
Split the full suite into its own workflow (off PRs)

### DIFF
--- a/.github/workflows/FullSuite.yml
+++ b/.github/workflows/FullSuite.yml
@@ -1,0 +1,49 @@
+#
+# Full suite — every suite (make check), including the slow resilience ones the
+# quick gate skips: fuzz, stress (restarts the server repeatedly), deployment,
+# asserts. Runs after a merge to main and nightly — NOT on pull requests, which
+# get the quick gate (Tests.yml). Kept out of the PR event on purpose, so it
+# never shows up as a skipped check on a PR.
+#
+# Same engine as the quick gate (the shared .github/actions/duckdb composite
+# action); the suite list lives in the Makefile (check).
+#
+name: Full suite
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: full-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  full:
+    name: full suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: ./.github/actions/duckdb
+
+      - name: Build the fixture database
+        run: test/scripts/fixture.sh sample.duckdb
+
+      - name: All suites
+        run: make check
+
+      - name: Server log on failure
+        if: failure()
+        run: cat /tmp/harbor-check.*/server.log 2>/dev/null || true

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,22 +1,17 @@
 #
-# The repository's own test suites (test/scripts/check.sh), run against the
-# shipped build: harbor is dynamically linked (no bundled DuckDB), so CI fetches
-# a libduckdb to link against and a duckdb CLI to build fixtures with, then runs
-# the make targets. The suite list lives in the Makefile (check_quick / check),
-# not here, so it never drifts; the engine is fetched by the local composite
-# action (.github/actions/duckdb) — upstream's latest, no version pinned.
+# Quick gate — the sub-minute suite, on every PR (and manual runs). It is the
+# only check a pull request shows. The full suite (fuzz, stress, deployment,
+# asserts) is a separate workflow, FullSuite.yml, that runs on main and nightly,
+# so it never appears here as a skipped check.
 #
-# Two jobs: a quick gate on every PR, and the full suite on main and nightly
-# (resilience restarts the server repeatedly; a five-minute job is fine there).
+# The suite list lives in the Makefile (check_quick), not here; the engine is
+# fetched by the local composite action (.github/actions/duckdb) — DuckDB's
+# official v2 nightly.
 #
 name: Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-  schedule:
-    - cron: '0 7 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -47,30 +42,6 @@ jobs:
 
       - name: Quick suites
         run: make check_quick
-
-      - name: Server log on failure
-        if: failure()
-        run: cat /tmp/harbor-check.*/server.log 2>/dev/null || true
-
-  full:
-    name: full suite
-    # PRs get the quick gate; the full run is for main and the nightly cron.
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - uses: ./.github/actions/duckdb
-
-      - name: Build the fixture database
-        run: test/scripts/fixture.sh sample.duckdb
-
-      - name: All suites
-        run: make check
 
       - name: Server log on failure
         if: failure()


### PR DESCRIPTION
Fixes the "full suite — Skipped" noise on every PR.

## Before
`Tests.yml` had two jobs: `quick` and `full`, with `full` gated by `if: github.event_name != 'pull_request'`. A job-level `if` still **registers** as a check, so every PR showed **full suite — Skipped** — a job that never runs on PRs, cluttering the checks list.

## After
- **`Tests.yml`** (quick gate) now triggers only on `pull_request` + `workflow_dispatch`. It's the single check a PR shows.
- **`FullSuite.yml`** (new) runs the full suite (`make check` — fuzz, stress, deployment, asserts) on `push: [main]` + the nightly cron. It has no `pull_request` trigger, so it never appears on a PR.

Same coverage after every merge and nightly; PRs get one clean check. Both workflows share the `.github/actions/duckdb` engine fetch.

**This PR is its own proof** — it should show only "quick gate", with no skipped "full suite" entry.