### PR TITLE
Bump CI actions to Node 24 majors (clears the deprecation warning)

### DIFF
--- a/.github/workflows/FullSuite.yml
+++ b/.github/workflows/FullSuite.yml
@@ -30,10 +30,10 @@ jobs:
     name: full suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - uses: ./.github/actions/duckdb

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -27,10 +27,10 @@ jobs:
     name: quick gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # Pinned, not '3.x': the suites run from test/scripts/, so a stdlib
           # name collision there breaks on newer Pythons — pin for reproducibility.


### PR DESCRIPTION
Every CI run showed a warning: `actions/checkout@v4` and `actions/setup-python@v5` target Node 20, which GitHub is deprecating (they were being force-run on Node 24).

Bumps both to their first Node 24 major — `checkout@v5`, `setup-python@v6` (verified `using: node24`). Minimal change; our usage is trivial (checkout with no args, setup-python with `python-version`), so behavior is unchanged. The composite action (`.github/actions/duckdb`) uses neither, so it's untouched.

Clears the "1 warning" annotation on runs.