### PR TITLE
make ui / make setup — run the DuckDB UI on the dylib setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # into every ~/.duckdb/cli/<ver>/. pilot never links an engine and works against
 # all of them.
 
-.PHONY: all binary pilot check check_quick install fetch-duckdb clean
+.PHONY: all binary pilot check check_quick install fetch-duckdb ui setup clean
 
 # The libduckdb the dynamic build links against — the version installed under
 # ~/.duckdb/cli/<ver>/. Only the library is needed (the crate ships pregenerated
@@ -57,12 +57,23 @@ install: binary pilot
 
 # Pull DuckDB's official v2.0-dev nightly (libduckdb + headers + duckdb CLI) from
 # artifacts.duckdb.org into $(DUCKDB_LIB); the baked rpath then resolves the
-# library in place. `make fetch-duckdb UI=1` instead pulls a pinned, matched
-# engine+UI pair from our releases (the ui extension only loads against the exact
-# engine it was built with). CI links the same official nightly via
-# .github/actions/duckdb. See PLAN.md D11.
+# library in place. CI links the same official nightly via .github/actions/duckdb.
+# The matched UI extension is built against this by `make ui`. See PLAN.md D11.
 fetch-duckdb:
-	DEST=$(DUCKDB_LIB) UI=$(UI) scripts/fetch-duckdb.sh
+	DEST=$(DUCKDB_LIB) scripts/fetch-duckdb.sh
+
+# Build the DuckDB UI extension against the exact nightly now in $(DUCKDB_LIB)
+# and install it where `LOAD ui` finds it by name. Everything derives from that
+# one engine, so the UI, the dylib, and harbor are synchronized by construction.
+# See scripts/build-ui-extension.sh (and PLAN.md D11).
+ui:
+	DUCKDB_LIB=$(DUCKDB_LIB) scripts/build-ui-extension.sh
+
+# Reconstruct ~/.duckdb from scratch: fetch the engine, build + install harbor
+# and pilot beside it, and build the matched UI extension. One command to go
+# from an empty ~/.duckdb to a working v2 fleet with the UI.
+setup: fetch-duckdb binary pilot install ui
+	@echo "setup: ~/.duckdb ready — harbor, pilot, and the UI all on $(notdir $(DUCKDB_LIB))"
 
 clean:
 	cargo clean

--- a/PLAN.md
+++ b/PLAN.md
@@ -189,11 +189,22 @@ newer official `alpha38069`, and against upstream stable `v1.5.5` — the C API 
 stable across the line (D1's version-agnostic property, exercised, not asserted).
 
 `make fetch-duckdb` (→ `scripts/fetch-duckdb.sh`) pulls the same official nightly
-into `~/.duckdb/cli/2.0.0/` for local work. Its one fork-coupled exception is
-`UI=1`: the `ui` extension loads *only* against the precise engine it was
-compiled with, and the nightly moves daily, so the two must travel as a pinned,
-matched pair from our releases until the UI factory publishes against the
-nightly. Everything else is upstream.
+into `~/.duckdb/cli/2.0.0/` for local work; `make setup` chains it with the
+binary build, `install`, and `make ui`, taking an empty `~/.duckdb` to a working
+fleet in one command.
+
+`make ui` (→ `scripts/build-ui-extension.sh`) builds the UI extension out-of-tree
+against the *exact* nightly just installed: read its commit, fetch DuckDB's
+headers at that commit (cached), compile only the ~11 UI sources, link
+dynamically (`-undefined dynamic_lookup` — symbols resolve from harbor's
+in-process libduckdb at load), and install to
+`~/.duckdb/extensions/<version>/<platform>/` so `LOAD ui` resolves it by name.
+No engine compile (~6s cached vs the 1,511-file, 20–40 min from-source build);
+the version lock the C++ ABI demands is satisfied *by construction*, since
+engine, dylib, and extension all derive from one nightly. The UI source is a
+duckdb-ui checkout carrying the v2 fixes — our fork until duckdb/duckdb-ui#242
+lands, then official. Verified end to end: `harbor serve --unsigned --init 'LOAD
+ui' --init 'FROM start_ui_server()'` serves the UI at `http://localhost:4213/`.
 
 **The UI extension can be dynamic — and should be.** DuckDB ships loadable
 extensions *statically* (each embeds a private copy of DuckDB, ~37MB, portable

--- a/README.md
+++ b/README.md
@@ -198,6 +198,25 @@ $ harbor serve mydata.duckdb --token secret
 harbor 0.10.0: berth "mydata" serving mydata.duckdb on ~/.harbor/mydata.sock (duckdb v2.0.0-alpha38069, memory_limit 2GB)
 ```
 
+`make setup` does the whole thing in one shot — fetch the engine, build and install
+`harbor` + `pilot` beside it, and build the matched DuckDB UI extension — taking an
+empty `~/.duckdb` to a working fleet.
+
+### Browser UI
+
+harbor can host the DuckDB UI over a berth. `make ui` builds the `ui` extension
+against the *exact* engine harbor runs (out-of-tree — only the extension, seconds,
+no engine compile) and installs it where `LOAD ui` finds it by name. Then:
+
+```console
+$ harbor serve mydata.duckdb --unsigned \
+    --init "LOAD ui" --init "FROM start_ui_server()"     # UI at http://localhost:4213/
+```
+
+Because harbor carries `libduckdb` in-process, the dynamically-linked extension
+resolves its DuckDB symbols at load, and everything — engine, harbor, extension —
+derives from one nightly, so the versions match by construction (PLAN.md D11).
+
 `harbor serve` runs in the foreground. `harbor add mydata.duckdb` spawns a
 **detached** berth and returns once it answers `/ready`; `harbor ls` lists the
 fleet, `harbor stop <name>` drains and `CHECKPOINT`s, `harbor rm <name>` clears

--- a/scripts/build-ui-extension.sh
+++ b/scripts/build-ui-extension.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# build-ui-extension.sh — build the DuckDB UI extension against the EXACT engine
+# harbor runs, and install it into DuckDB's extension directory
+# (~/.duckdb/extensions/<version>/<platform>/) so `LOAD ui` resolves it by name,
+# in harbor and the plain duckdb CLI alike.
+#
+# This is the payoff of the dylib approach: harbor, libduckdb, and the UI
+# extension all derive from ONE nightly, so the version lock the C++ ABI demands
+# is satisfied by construction. No full-engine compile — we fetch the matching
+# DuckDB *headers* at the engine's exact commit and compile only the ~11 UI
+# sources, linking dynamically (symbols resolve from harbor's in-process
+# libduckdb at load). Seconds, not the 20–40 min a from-source engine build costs.
+#
+#   make ui                     # build against ~/.duckdb/cli/2.0.0
+#   DUCKDB_UI_DIR=... make ui    # point at a different UI checkout
+#
+# Requires: the UI source (a duckdb-ui checkout with the v2 fixes — our fork
+# until duckdb/duckdb-ui#242 lands), a C++ compiler, git, gh, and OpenSSL.
+
+set -euo pipefail
+
+DUCKDB_LIB=${DUCKDB_LIB:-$HOME/.duckdb/cli/2.0.0}
+UI_DIR=${DUCKDB_UI_DIR:-$HOME/Data/Code/duckdb-ui}
+CACHE=${DUCKDB_SRC_CACHE:-$HOME/.cache/duckdb-src}
+OPENSSL=${OPENSSL:-$(brew --prefix openssl@3 2>/dev/null || echo /opt/homebrew/opt/openssl@3)}
+say() { printf '  %s\n' "$*"; }
+
+[ -x "$DUCKDB_LIB/duckdb" ] || { echo "build-ui: no duckdb CLI at $DUCKDB_LIB (run make fetch-duckdb)" >&2; exit 2; }
+[ -d "$UI_DIR/src" ]        || { echo "build-ui: no UI source at $UI_DIR (set DUCKDB_UI_DIR)" >&2; exit 2; }
+
+# 1. the engine's exact version + commit — everything synchronizes off this
+read -r version source_id _ < <("$DUCKDB_LIB/duckdb" -no-init -csv -noheader -c "PRAGMA version" | tr ',' ' ')
+say "engine: $version ($source_id)"
+sha=$(gh api "repos/duckdb/duckdb/commits/$source_id" --jq .sha 2>/dev/null) \
+  || { echo "build-ui: could not resolve $source_id to a full SHA" >&2; exit 3; }
+
+case "$(uname -s)/$(uname -m)" in
+  Darwin/*)                  plat=osx_arm64  ;;
+  Linux/x86_64)              plat=linux_amd64 ;;
+  Linux/aarch64|Linux/arm64) plat=linux_arm64 ;;
+  *) echo "build-ui: unsupported platform" >&2; exit 2 ;;
+esac
+
+# DuckDB resolves `LOAD ui` by name from extensions/<version>/<platform>/, so
+# install there. Keyed by the exact nightly, matching the engine it was built
+# against; a version bump makes a new dir (old ones are safe to delete).
+OUT=${OUT:-$HOME/.duckdb/extensions/$version/$plat/ui.duckdb_extension}
+mkdir -p "$(dirname "$OUT")"
+
+# 2. DuckDB headers at that exact commit (cached by SHA, fetched once)
+ddb="$CACHE/$sha"
+if [ ! -d "$ddb/src/include" ]; then
+  say "fetching DuckDB headers @ ${sha:0:10} (one-time)"
+  rm -rf "$ddb"; mkdir -p "$ddb"
+  ( cd "$ddb" && git init -q && git remote add origin https://github.com/duckdb/duckdb.git \
+      && git fetch -q --depth 1 origin "$sha" && git checkout -q FETCH_HEAD )
+else
+  say "headers cached: $ddb"
+fi
+
+# 3. include dirs — DuckDB's curated extension include set, exactly what its
+#    build exports (NOT all of third_party: globbing pulls in brotli, whose
+#    `include/version` file shadows the C++ standard <version> header). This set
+#    is stable across nightlies; add here only if a future engine needs it.
+tp="$ddb/third_party"
+incs=(
+  -I"$ddb/src/include"
+  -I"$tp/fsst" -I"$tp/fmt/include" -I"$tp/hyperloglog" -I"$tp/fastpforlib"
+  -I"$tp/skiplist" -I"$tp/ska_sort" -I"$tp/fast_float" -I"$tp/re2"
+  -I"$tp/miniz" -I"$tp/utf8proc/include" -I"$tp/concurrentqueue" -I"$tp/pcg"
+  -I"$tp/pdqsort" -I"$tp/tdigest" -I"$tp/mbedtls/include" -I"$tp/httplib"
+  -I"$tp/jaro_winkler" -I"$tp/vergesort" -I"$tp/yyjson/include" -I"$tp/zstd/include"
+  -I"$UI_DIR/src/include" -I"$UI_DIR/third_party/httplib"
+  -isystem "$OPENSSL/include"
+)
+
+# 4. version stamps the source expects (cosmetic — reported by ui_version())
+IFS=. read -r maj min pat <<<"${version#v}"; pat=${pat%%-*}
+seq=$(git -C "$UI_DIR" rev-list --count HEAD 2>/dev/null || echo 0)
+gsha=$(git -C "$UI_DIR" rev-parse --short=10 HEAD 2>/dev/null || echo unknown)
+defs=(-DDUCKDB_BUILD_LOADABLE_EXTENSION
+      -DDUCKDB_MAJOR_VERSION="$maj" -DDUCKDB_MINOR_VERSION="$min" -DDUCKDB_PATCH_VERSION="${pat:-0}"
+      -DUI_EXTENSION_GIT_SHA="\"$gsha\"" -DUI_EXTENSION_SEQ_NUM="\"$seq\"" -DEXT_VERSION_UI="\"$gsha\"" -DNDEBUG)
+
+# 5. compile the ~11 UI sources in parallel, link dynamically
+work=$(mktemp -d "${TMPDIR:-/tmp}/build-ui.XXXXXX"); trap 'rm -rf "$work"' EXIT
+# bash 3.2 (macOS default) has no mapfile — read the list the portable way.
+srcs=(); while IFS= read -r f; do srcs+=("$f"); done < <(find "$UI_DIR/src" -name '*.cpp' | sort)
+say "compiling ${#srcs[@]} sources"
+pids=(); objs=()
+for src in "${srcs[@]}"; do
+  obj="$work/$(basename "$src").o"; objs+=("$obj")
+  clang++ -std=c++17 -O2 -fPIC -fvisibility=hidden "${defs[@]}" "${incs[@]}" -c "$src" -o "$obj" &
+  pids+=($!)
+done
+fail=0; for p in "${pids[@]}"; do wait "$p" || fail=1; done
+[ "$fail" = 0 ] || { echo "build-ui: a source failed to compile against $version" >&2; exit 4; }
+
+raw="$work/ui.raw"
+clang++ -bundle -undefined dynamic_lookup -o "$raw" "${objs[@]}" -L"$OPENSSL/lib" -lssl -lcrypto
+say "linked ($(du -h "$raw" | cut -f1)) — links no engine"
+
+# 6. stamp DuckDB extension metadata, matched to the running engine
+python3 "$UI_DIR/extension-ci-tools/scripts/append_extension_metadata.py" \
+  -l "$raw" -n ui -dv "$version" -p "$plat" --abi-type CPP -ev "$gsha" -o "$OUT" >/dev/null
+say "-> $OUT"
+echo "build-ui: ui.duckdb_extension ready for $version"

--- a/scripts/fetch-duckdb.sh
+++ b/scripts/fetch-duckdb.sh
@@ -5,36 +5,23 @@
 # harbor carries no engine (PLAN.md D1); this fetches one for it to link, along
 # with the two headers (kept for reference — the crate ships pregenerated
 # bindings, so the build never reads them) and the duckdb CLI that builds
-# fixtures. Two modes:
-#
-#   make fetch-duckdb        DuckDB's official v2.0-dev nightly, from
-#                            artifacts.duckdb.org — the current 2.0 line straight
-#                            from upstream. The common case: a working engine,
-#                            no fork, nothing to pin. `/latest/` is the v2.0-dev
-#                            channel today (it reported v2.0.0-alpha38069 when
-#                            this was written); if main ever rolls past 2.0, pin
-#                            the v2.0 channel URL below.
-#
-#   make fetch-duckdb UI=1   the matched engine+UI pair, pinned, from our own
-#                            releases. The UI extension loads ONLY against the
-#                            exact engine it was built with, and the official
-#                            nightly moves daily, so the two must travel together
-#                            as a frozen pair until the UI factory publishes
-#                            against the nightly.
+# fixtures. The source is DuckDB's official v2.0-dev nightly, from
+# artifacts.duckdb.org — the current 2.0 line straight from upstream, no fork,
+# nothing to pin. `/latest/` is the v2.0-dev channel today (it reported
+# v2.0.0-alpha38069 when this was written); if main ever rolls past 2.0, pin the
+# v2.0 channel URL below. The matched UI extension is built separately against
+# whatever this installs — see scripts/build-ui-extension.sh (`make ui`).
 #
 # Override DEST to install elsewhere.
 
 set -euo pipefail
 
 dest=${DEST:-$HOME/.duckdb/cli/2.0.0}
-want_ui=${UI:-0}
 
-# The engine and the UI release spell platforms differently (osx vs osx_arm64,
-# linux-amd64 vs linux_amd64); carry both spellings per host.
 case "$(uname -s)/$(uname -m)" in
-  Darwin/*)                  duck_plat=osx;         ui_plat=osx_arm64   ;;
-  Linux/x86_64)              duck_plat=linux-amd64; ui_plat=linux_amd64 ;;
-  Linux/aarch64|Linux/arm64) duck_plat=linux-arm64; ui_plat=linux_arm64 ;;
+  Darwin/*)                  duck_plat=osx         ;;
+  Linux/x86_64)              duck_plat=linux-amd64 ;;
+  Linux/aarch64|Linux/arm64) duck_plat=linux-arm64 ;;
   *) echo "fetch-duckdb: unsupported platform $(uname -s)/$(uname -m)" >&2; exit 2 ;;
 esac
 
@@ -45,13 +32,7 @@ grab()  { find "$work" -type f -name "$1" 2>/dev/null | head -1; }
 place() { local s; s=$(grab "$1") || true; [ -n "$s" ] && install -m "$2" "$s" "$dest/$1" && say "-> $dest/$1"; return 0; }
 
 # ---- the engine: one "binaries" zip, two sub-zips nested inside -------------
-if [ "$want_ui" = 1 ]; then
-  version=${DUCKDB_VERSION:-v2.0.0-alpha37626}       # the pinned matched pair
-  engine_url="https://github.com/shreeve/duckdb-harbor/releases/download/duckdb-$version/duckdb-$version-binaries-$duck_plat.zip"
-else
-  engine_url=${ENGINE_URL:-https://artifacts.duckdb.org/latest/duckdb-binaries-$duck_plat.zip}
-fi
-
+engine_url=${ENGINE_URL:-https://artifacts.duckdb.org/latest/duckdb-binaries-$duck_plat.zip}
 say "fetching $engine_url"
 curl -fsSL -o "$work/binaries.zip" "$engine_url"
 ( cd "$work" && unzip -oq binaries.zip )        # -> libduckdb-*.zip, duckdb_cli-*.zip
@@ -64,18 +45,6 @@ place libduckdb.so       0755
 place duckdb             0755
 place duckdb.h           0644
 place duckdb_extension.h 0644
-
-# ---- optional: the UI extension, from the same pinned release --------------
-if [ "$want_ui" = 1 ]; then
-  ui_asset="ui-duckdb-$version-$ui_plat.zip"
-  say "fetching $ui_asset"
-  curl -fsSL -o "$work/ui.zip" \
-    "https://github.com/shreeve/duckdb-ui/releases/download/ui-$version/$ui_asset"
-  ( cd "$work" && unzip -oq ui.zip )
-  ext=$(grab 'ui.duckdb_extension') || true
-  [ -n "$ext" ] && install -m 0644 "$ext" "$dest/ui.duckdb_extension" \
-    && say "-> $dest/ui.duckdb_extension"
-fi
 
 # ---- point cli/latest at what we just refreshed ----------------------------
 # Only when we filled the canonical dir — a throwaway DEST elsewhere (a scratch


### PR DESCRIPTION
The DuckDB UI now runs on the standalone/dylib approach (no extension-era harbor, no from-source engine build), and `~/.duckdb` can be rebuilt from scratch with one command.

## New
- **`scripts/build-ui-extension.sh`** (`make ui`) — builds the `ui` extension **out-of-tree** against the *exact* nightly in `~/.duckdb/cli/2.0.0`: read its commit → fetch DuckDB headers at that commit (cached in `~/.cache/duckdb-src`) → compile only the ~11 UI sources → link `-undefined dynamic_lookup` (symbols resolve from harbor's in-process libduckdb) → stamp CPP-ABI metadata → install to `~/.duckdb/extensions/<version>/<platform>/` so `LOAD ui` resolves **by name**. ~6s cached, 856K, embeds no engine.
- **`make setup`** = `fetch-duckdb + binary + pilot + install + ui` — empty `~/.duckdb` → working fleet + UI in ~16s.

## Verified
```
harbor serve db.duckdb --unsigned --init "LOAD ui" --init "FROM start_ui_server()"
# UI at http://localhost:4213/  → HTTP 200
```
The version lock the C++ ABI demands is satisfied **by construction** — engine, dylib, and extension all derive from one nightly.

## Cleanup
`fetch-duckdb.sh` drops its now-obsolete `UI=1` pinned-fork-pair branch (`make ui` supersedes it, and it pointed at a stale alpha). README + PLAN.md D11 updated; the UI source is a duckdb-ui checkout with the v2 fixes (our fork until duckdb/duckdb-ui#242 lands).

Docs-and-scripts + one Makefile change; harbor/pilot/wire code untouched.