### PR TITLE
Releases: one self-contained archive per platform, built by CI

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,96 @@
+# Release — push a v* tag and three self-contained archives appear on the
+# GitHub Release: osx-arm64, linux-amd64, linux-arm64. Each is built on a
+# native runner from the same recipe as `make setup`: fetch DuckDB's official
+# v2 nightly, build harbor + pilot against it (with a RELATIVE rpath, so the
+# archive is relocatable — unlike the dev build's absolute one), compile the
+# ui extension out-of-tree against that same engine, smoke-test the packaged
+# layout, and upload. No engine compile anywhere; each job takes minutes.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-15,        plat: osx-arm64,   rpath: '@loader_path' }
+          - { runner: ubuntu-24.04,     plat: linux-amd64, rpath: '$ORIGIN' }
+          - { runner: ubuntu-24.04-arm, plat: linux-arm64, rpath: '$ORIGIN' }
+    runs-on: ${{ matrix.runner }}
+    env:
+      DUCKDB_LIB: ${{ github.workspace }}/.duckdb-engine
+    steps:
+      - uses: actions/checkout@v5
+
+      # The ui source (our fork until duckdb/duckdb-ui#242 lands) and the
+      # metadata stamper it vendors. Only that one submodule — not duckdb.
+      - uses: actions/checkout@v5
+        with:
+          repository: shreeve/duckdb-ui
+          path: duckdb-ui
+      - run: git -C duckdb-ui submodule update --init extension-ci-tools
+
+      - name: Fetch DuckDB engine (official v2 nightly)
+        run: DEST="$DUCKDB_LIB" scripts/fetch-duckdb.sh
+
+      # Relative rpath instead of the Makefile's absolute one: the binary
+      # looks beside itself and in ../lib, so the archive works anywhere.
+      - name: Build harbor + pilot
+        run: |
+          export DUCKDB_LIB_DIR="$DUCKDB_LIB"
+          export RUSTFLAGS='-C link-args=-Wl,-rpath,${{ matrix.rpath }} -C link-args=-Wl,-rpath,${{ matrix.rpath }}/../lib'
+          cargo build -p harbor -p pilot --release
+
+      - name: Build ui extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DUCKDB_UI_DIR="$PWD/duckdb-ui" OUT="$PWD/ui.duckdb_extension" \
+            scripts/build-ui-extension.sh
+
+      - name: Package
+        run: |
+          TAG="$GITHUB_REF_NAME" PLAT=${{ matrix.plat }} UI_EXT="$PWD/ui.duckdb_extension" \
+            scripts/package-release.sh
+
+      # Prove the archive as shipped: extract, run harbor from bin/ (exercises
+      # the relative rpath -> lib/), query it through pilot, LOAD the ui.
+      - name: Smoke-test packaged layout
+        run: |
+          tar -C /tmp -xzf dist/harbor-"$GITHUB_REF_NAME"-${{ matrix.plat }}.tar.gz
+          root=/tmp/harbor-"$GITHUB_REF_NAME"-${{ matrix.plat }}
+          "$root/bin/harbor" add /tmp/smoke.duckdb --name smoke --unsigned \
+            --init "LOAD '$root/extensions/ui.duckdb_extension';"
+          "$root/bin/pilot" smoke -c "SELECT 42 AS ok" --mode csv | grep -q 42
+          "$root/bin/harbor" stop smoke
+          echo "smoke: rpath, wire round-trip, and ui load all good"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: harbor-${{ github.ref_name }}-${{ matrix.plat }}
+          path: dist/*.tar.gz
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { merge-multiple: true }
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" *.tar.gz \
+            --repo "$GITHUB_REPOSITORY" --title "harbor $GITHUB_REF_NAME" \
+            --notes "harbor + pilot + ui extension, each archive self-contained \
+          and version-locked to one DuckDB v2 nightly. Extract and run in place, \
+          or ./install.sh to put the pieces in their homes."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "duckdb",
  "libc",
@@ -953,7 +953,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pilot"
-version = "0.1.0"
+version = "0.11.0"
 dependencies = [
  "crossterm 0.29.0",
  "libc",
@@ -1828,7 +1828,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.1.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 # harbor — the fleet Makefile
 #
-# One binary, dynamically linked (D1/Phase 0): harbor links an external
-# libduckdb and is version-agnostic at runtime — it resolves whichever
-# libduckdb.dylib sits beside it (@loader_path), so the same bytes serve any
-# DuckDB depending on the directory they run from. `make fetch-duckdb` pulls the
-# engine (DuckDB's official v2 nightly); `make install` drops one harbor + pilot
-# into every ~/.duckdb/cli/<ver>/. pilot never links an engine and works against
-# all of them.
+# Two binaries, dynamically linked (D1): `harbor` links an external libduckdb by
+# an absolute rpath (baked at build time), `pilot` links no engine at all. The
+# engine lives in ~/.duckdb (DuckDB's world: dylib + extensions); the two
+# binaries install onto PATH in /usr/local/bin. `make fetch-duckdb` pulls the
+# engine (DuckDB's official v2 nightly) into ~/.duckdb; `make install` copies
+# both binaries to $(BIN) (using sudo only if the dir is root-owned).
 
 .PHONY: all binary pilot check check_quick install fetch-duckdb ui setup clean
 
-# The libduckdb the dynamic build links against — the version installed under
-# ~/.duckdb/cli/<ver>/. Only the library is needed (the crate ships pregenerated
-# bindings, so there is no bindgen and no header requirement). The binary is
-# version-agnostic at runtime, so this only picks what the dev build links;
-# override to build against another, e.g.
-#   make binary DUCKDB_LIB=$(HOME)/.duckdb/cli/1.5.5
+# The libduckdb the build links against, by absolute rpath — the engine
+# `make fetch-duckdb` installs. Only the library is needed (the crate ships
+# pregenerated bindings, so there is no bindgen and no header requirement).
+# Override to link a different one.
 DUCKDB_LIB ?= $(HOME)/.duckdb/cli/2.0.0
-DUCKDB_CLI ?= $(HOME)/.duckdb/cli
+
+# Where the two binaries land — a stable dir on PATH, outside DuckDB's ~/.duckdb
+# world (which is disposable/refetchable). Override to install elsewhere.
+BIN ?= /usr/local/bin
 
 # Every cargo invocation below links against that libduckdb and bakes an rpath
 # to it, so the binary AND the test executables run in place without DYLD_*.
@@ -38,22 +38,16 @@ check: binary pilot
 check_quick: binary pilot
 	SUITES="unit types spec catalog sessions cancel" test/scripts/check.sh
 
-# Drop one dynamic harbor + the engine-agnostic pilot into every
-# ~/.duckdb/cli/<ver>/ that has a libduckdb.dylib. The dev-tree rpath is stripped
-# from the installed copy and replaced with @loader_path, so each copy resolves
-# ONLY its sibling dylib (otherwise it would prefer the build-dir dylib in every
-# dir). Re-runnable; each copy is fresh, so the strip stays idempotent.
+# Copy the two binaries onto PATH in $(BIN). harbor keeps its baked absolute
+# rpath to $(DUCKDB_LIB), so it finds libduckdb from anywhere — no @loader_path,
+# no sibling dylib. pilot links no engine and runs on any machine. sudo is used
+# only when $(BIN) is root-owned (the /usr/local/bin default on macOS).
 install: binary pilot
-	@for d in $(DUCKDB_CLI)/*/; do \
-	  case "$$d" in *latest/) continue;; esac; \
-	  [ -f "$${d}libduckdb.dylib" ] || continue; \
-	  cp target/release/harbor "$${d}harbor"; \
-	  cp target/release/pilot "$${d}pilot"; \
-	  install_name_tool -delete_rpath $(DUCKDB_LIB) "$${d}harbor" 2>/dev/null || true; \
-	  install_name_tool -add_rpath @loader_path "$${d}harbor" 2>/dev/null || true; \
-	  echo "  installed harbor + pilot -> $$d"; \
-	done
-	@echo "each cli/<ver>/harbor now uses its sibling libduckdb.dylib; pilot is engine-agnostic."
+	@sudo= ; [ -w "$(BIN)" ] || { sudo=sudo; echo "  $(BIN) is root-owned — using sudo"; }; \
+	  $$sudo install -d -m 0755 "$(BIN)"; \
+	  $$sudo install -m 0755 target/release/harbor "$(BIN)/harbor"; \
+	  $$sudo install -m 0755 target/release/pilot  "$(BIN)/pilot"; \
+	  echo "installed harbor + pilot -> $(BIN)  (on your PATH)"
 
 # Pull DuckDB's official v2.0-dev nightly (libduckdb + headers + duckdb CLI) from
 # artifacts.duckdb.org into $(DUCKDB_LIB); the baked rpath then resolves the
@@ -69,11 +63,11 @@ fetch-duckdb:
 ui:
 	DUCKDB_LIB=$(DUCKDB_LIB) scripts/build-ui-extension.sh
 
-# Reconstruct ~/.duckdb from scratch: fetch the engine, build + install harbor
-# and pilot beside it, and build the matched UI extension. One command to go
-# from an empty ~/.duckdb to a working v2 fleet with the UI.
+# Reconstruct a working fleet from scratch: fetch the engine into ~/.duckdb,
+# build + install harbor and pilot onto PATH ($(BIN)), and build the matched UI
+# extension. One command from an empty ~/.duckdb to a working v2 fleet with the UI.
 setup: fetch-duckdb binary pilot install ui
-	@echo "setup: ~/.duckdb ready — harbor, pilot, and the UI all on $(notdir $(DUCKDB_LIB))"
+	@echo "setup: engine + UI in ~/.duckdb, harbor + pilot in $(BIN) — all on $(notdir $(DUCKDB_LIB))"
 
 clean:
 	cargo clean

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,8 +37,9 @@ dynamically-linked `harbor` bytes drive whichever `libduckdb.dylib` they resolve
 at runtime (`@rpath` / `@loader_path`) — verified by one binary reporting
 v1.5.5 beside the 1.5.5 dylib and v2.0.0-alpha beside the 2.0 one. So harbor is
 **dynamic by default and version-agnostic**: one build serves a mixed fleet, the
-engine chosen by the dylib beside it (`make install` drops one harbor + pilot
-into each `~/.duckdb/cli/<ver>/`). The static `bundled` build was dropped
+engine chosen by the dylib it links (`make install` puts harbor + pilot on PATH
+in `/usr/local/bin`; harbor's baked absolute rpath resolves the engine in
+`~/.duckdb`, DuckDB's own world). The static `bundled` build was dropped
 entirely: it cost a 33MB binary and a 17GB from-source build tree for an
 advantage — needing no sibling dylib — the swap model removed. Distribution is
 `curl && chmod +x` plus the sibling dylib; the version pin *is* the dylib.

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ you.
 
 Two binaries: **`harbor`** (the server and fleet manager) and **`pilot`** (the
 client). `harbor` links an external `libduckdb` and is version-agnostic — the
-same build serves any DuckDB by the `libduckdb.dylib` sitting beside it — so a
-build needs a libduckdb to link against. `make fetch-duckdb` pulls one (DuckDB's
+same build serves any DuckDB by the `libduckdb.dylib` it resolves — so a build
+needs a libduckdb to link against. `make fetch-duckdb` pulls one (DuckDB's
 official v2 nightly) into `~/.duckdb/cli/2.0.0/`; then:
 
 ```console
@@ -198,9 +198,15 @@ $ harbor serve mydata.duckdb --token secret
 harbor 0.10.0: berth "mydata" serving mydata.duckdb on ~/.harbor/mydata.sock (duckdb v2.0.0-alpha38069, memory_limit 2GB)
 ```
 
-`make setup` does the whole thing in one shot — fetch the engine, build and install
-`harbor` + `pilot` beside it, and build the matched DuckDB UI extension — taking an
-empty `~/.duckdb` to a working fleet.
+`make setup` does the whole thing in one shot — fetch the engine into `~/.duckdb`,
+build and install `harbor` + `pilot` onto PATH in `/usr/local/bin`, and build the
+matched DuckDB UI extension — taking an empty `~/.duckdb` to a working fleet.
+
+No toolchain? Each [release](../../releases) ships one self-contained archive per
+platform (osx-arm64, linux-amd64, linux-arm64): harbor + pilot, the exact
+`libduckdb` they were built against, and the matched `ui` extension — all from
+one DuckDB v2 nightly. Extract and run `bin/harbor` in place, or `./install.sh`
+to copy the pieces into `/usr/local/{bin,lib}` and `~/.duckdb/extensions/`.
 
 ### Browser UI
 
@@ -398,11 +404,13 @@ worth knowing before it faces a browser. Request logging is available with
 **Signal handling is Unix only.** On Windows there is no `SIGTERM` drain and no
 checkpoint on exit; `harbor stop` is the way out.
 
-**The engine is the sibling `libduckdb`, not the binary.** harbor links
-dynamically and is version-agnostic — the same build serves whichever DuckDB its
-adjacent `libduckdb` provides (verified against 1.5.5 and a 2.0 dev build). The
-caveat that comes with that: point it at a library whose storage format matches
-the database file.
+**The engine is the linked `libduckdb`, not the binary.** harbor links
+dynamically and is version-agnostic — the same build serves whichever DuckDB the
+`libduckdb` it resolves provides (verified against 1.5.5 and a 2.0 dev build).
+`make install` puts harbor + pilot on PATH in `/usr/local/bin`, and harbor's
+baked rpath resolves the engine in `~/.duckdb` — DuckDB's own world, disposable
+and refetchable. The caveat that comes with that: point it at a library whose
+storage format matches the database file.
 
 ## Working on it
 

--- a/crates/harbor/Cargo.toml
+++ b/crates/harbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "harbor — DuckDB wearing a server: fleet manager + HTTP/UDS engine"
 license = "MIT"

--- a/crates/pilot/Cargo.toml
+++ b/crates/pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilot"
-version = "0.1.0"
+version = "0.11.0"
 edition = "2024"
 description = "pilot — the Harbor client: fleet-aware SQL over UDS and HTTP"
 license = "MIT"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wire"
-version = "0.1.0"
+version = "0.11.0"
 edition = "2024"
 description = "The Harbor wire contract: request shapes, NDJSON envelope, error codes"
 license = "MIT"

--- a/scripts/build-ui-extension.sh
+++ b/scripts/build-ui-extension.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 DUCKDB_LIB=${DUCKDB_LIB:-$HOME/.duckdb/cli/2.0.0}
 UI_DIR=${DUCKDB_UI_DIR:-$HOME/Data/Code/duckdb-ui}
 CACHE=${DUCKDB_SRC_CACHE:-$HOME/.cache/duckdb-src}
-OPENSSL=${OPENSSL:-$(brew --prefix openssl@3 2>/dev/null || echo /opt/homebrew/opt/openssl@3)}
+CXX=${CXX:-clang++}
 say() { printf '  %s\n' "$*"; }
 
 [ -x "$DUCKDB_LIB/duckdb" ] || { echo "build-ui: no duckdb CLI at $DUCKDB_LIB (run make fetch-duckdb)" >&2; exit 2; }
@@ -35,10 +35,14 @@ say "engine: $version ($source_id)"
 sha=$(gh api "repos/duckdb/duckdb/commits/$source_id" --jq .sha 2>/dev/null) \
   || { echo "build-ui: could not resolve $source_id to a full SHA" >&2; exit 3; }
 
+# Platform also picks the link model: macOS bundles leave DuckDB symbols
+# unresolved via -undefined dynamic_lookup; Linux shared objects allow
+# unresolved symbols by default. Both resolve from the host's libduckdb at load.
 case "$(uname -s)/$(uname -m)" in
-  Darwin/*)                  plat=osx_arm64  ;;
-  Linux/x86_64)              plat=linux_amd64 ;;
-  Linux/aarch64|Linux/arm64) plat=linux_arm64 ;;
+  Darwin/*)                  plat=osx_arm64;   ldflags=(-bundle -undefined dynamic_lookup)
+                             OPENSSL=${OPENSSL:-$(brew --prefix openssl@3 2>/dev/null || echo /opt/homebrew/opt/openssl@3)} ;;
+  Linux/x86_64)              plat=linux_amd64; ldflags=(-shared); OPENSSL=${OPENSSL:-} ;;
+  Linux/aarch64|Linux/arm64) plat=linux_arm64; ldflags=(-shared); OPENSSL=${OPENSSL:-} ;;
   *) echo "build-ui: unsupported platform" >&2; exit 2 ;;
 esac
 
@@ -72,8 +76,10 @@ incs=(
   -I"$tp/pdqsort" -I"$tp/tdigest" -I"$tp/mbedtls/include" -I"$tp/httplib"
   -I"$tp/jaro_winkler" -I"$tp/vergesort" -I"$tp/yyjson/include" -I"$tp/zstd/include"
   -I"$UI_DIR/src/include" -I"$UI_DIR/third_party/httplib"
-  -isystem "$OPENSSL/include"
 )
+# OpenSSL powers the UI's HTTPS *client* (it proxies the front-end from
+# ui.duckdb.org). macOS points at brew's; Linux finds the system one.
+[ -n "$OPENSSL" ] && incs+=(-isystem "$OPENSSL/include") && sslflags=(-L"$OPENSSL/lib") || sslflags=()
 
 # 4. version stamps the source expects (cosmetic — reported by ui_version())
 IFS=. read -r maj min pat <<<"${version#v}"; pat=${pat%%-*}
@@ -91,14 +97,15 @@ say "compiling ${#srcs[@]} sources"
 pids=(); objs=()
 for src in "${srcs[@]}"; do
   obj="$work/$(basename "$src").o"; objs+=("$obj")
-  clang++ -std=c++17 -O2 -fPIC -fvisibility=hidden "${defs[@]}" "${incs[@]}" -c "$src" -o "$obj" &
+  "$CXX" -std=c++17 -O2 -fPIC -fvisibility=hidden "${defs[@]}" "${incs[@]}" -c "$src" -o "$obj" &
   pids+=($!)
 done
 fail=0; for p in "${pids[@]}"; do wait "$p" || fail=1; done
 [ "$fail" = 0 ] || { echo "build-ui: a source failed to compile against $version" >&2; exit 4; }
 
 raw="$work/ui.raw"
-clang++ -bundle -undefined dynamic_lookup -o "$raw" "${objs[@]}" -L"$OPENSSL/lib" -lssl -lcrypto
+# bash 3.2 + set -u: an empty sslflags array can't expand bare, hence the idiom.
+"$CXX" "${ldflags[@]}" -o "$raw" "${objs[@]}" ${sslflags[@]+"${sslflags[@]}"} -lssl -lcrypto
 say "linked ($(du -h "$raw" | cut -f1)) — links no engine"
 
 # 6. stamp DuckDB extension metadata, matched to the running engine

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# package-release.sh — assemble one platform's release tarball.
+#
+# A release archive is self-contained and version-locked by construction:
+# harbor + pilot (built with a RELATIVE rpath: @loader_path/../lib on macOS,
+# $ORIGIN/../lib on Linux), the exact libduckdb they were built against, and
+# the ui extension compiled against that same engine. Extract anywhere and
+# bin/harbor runs in place; install.sh copies the pieces into their homes.
+#
+#   TAG=v0.11.0 PLAT=osx-arm64 UI_EXT=path/to/ui.duckdb_extension \
+#     scripts/package-release.sh
+#
+# Produces $OUT/harbor-$TAG-$PLAT.tar.gz (OUT defaults to dist/).
+
+set -euo pipefail
+
+TAG=${TAG:?package-release: set TAG (e.g. v0.11.0)}
+PLAT=${PLAT:?package-release: set PLAT (osx-arm64 | linux-amd64 | linux-arm64)}
+UI_EXT=${UI_EXT:?package-release: set UI_EXT (path to built ui.duckdb_extension)}
+DUCKDB_LIB=${DUCKDB_LIB:-$HOME/.duckdb/cli/2.0.0}
+OUT=${OUT:-dist}
+say() { printf '  %s\n' "$*"; }
+
+[ -f "$UI_EXT" ] || { echo "package-release: no ui extension at $UI_EXT" >&2; exit 2; }
+[ -f target/release/harbor ] && [ -f target/release/pilot ] \
+  || { echo "package-release: build harbor + pilot first" >&2; exit 2; }
+
+# The engine's identity, recorded in the archive so install.sh knows which
+# extensions/<version>/<platform>/ directory the ui extension belongs in.
+version=$("$DUCKDB_LIB/duckdb" -no-init -csv -noheader -c "PRAGMA version" | cut -d, -f1)
+ext_plat=$("$DUCKDB_LIB/duckdb" -no-init -csv -noheader -c "PRAGMA platform")
+
+name="harbor-$TAG-$PLAT"
+root="$OUT/$name"
+rm -rf "$root"; mkdir -p "$root/bin" "$root/lib" "$root/extensions"
+
+install -m 0755 target/release/harbor "$root/bin/harbor"
+install -m 0755 target/release/pilot  "$root/bin/pilot"
+for lib in libduckdb.dylib libduckdb.so; do
+  [ -f "$DUCKDB_LIB/$lib" ] && install -m 0755 "$DUCKDB_LIB/$lib" "$root/lib/$lib"
+done
+install -m 0644 "$UI_EXT" "$root/extensions/ui.duckdb_extension"
+printf '%s %s\n' "$version" "$ext_plat" > "$root/ENGINE"
+install -m 0755 scripts/release-install.sh "$root/install.sh"
+
+tar -C "$OUT" -czf "$OUT/$name.tar.gz" "$name"
+say "engine $version ($ext_plat)"
+say "-> $OUT/$name.tar.gz ($(du -h "$OUT/$name.tar.gz" | cut -f1))"

--- a/scripts/release-install.sh
+++ b/scripts/release-install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# install.sh — install this harbor release from the extracted archive.
+#
+#   bin/harbor, bin/pilot -> /usr/local/bin   (override: BIN=...)
+#   lib/libduckdb.*       -> /usr/local/lib   (override: LIB=...)
+#   ui.duckdb_extension   -> ~/.duckdb/extensions/<version>/<platform>/
+#
+# The binaries carry a relative rpath (../lib), so bin + lib travel as a pair —
+# they also run straight out of this directory without installing. The ui
+# extension goes where `LOAD ui` resolves it by name; ENGINE (written at
+# package time) names the exact <version>/<platform> it was built for.
+# sudo is used only if the system dirs are root-owned.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+BIN=${BIN:-/usr/local/bin}
+LIB=${LIB:-/usr/local/lib}
+read -r version ext_plat < ENGINE
+
+as_owner() { if [ -w "$(dirname "$1")" ] || [ -w "$1" ]; then "${@:2}"; else sudo "${@:2}"; fi; }
+as_owner "$BIN" install -d -m 0755 "$BIN"
+as_owner "$LIB" install -d -m 0755 "$LIB"
+as_owner "$BIN" install -m 0755 bin/harbor bin/pilot "$BIN"
+as_owner "$LIB" install -m 0755 lib/libduckdb.* "$LIB"
+
+ext_dir="$HOME/.duckdb/extensions/$version/$ext_plat"
+mkdir -p "$ext_dir"
+install -m 0644 extensions/ui.duckdb_extension "$ext_dir/ui.duckdb_extension"
+
+echo "installed: harbor + pilot -> $BIN, libduckdb -> $LIB"
+echo "           ui extension   -> $ext_dir  (engine $version)"
+echo "try: harbor add mydata.duckdb --unsigned --init 'LOAD ui; FROM start_ui_server();'"


### PR DESCRIPTION
Push a `v*` tag and three archives appear on the GitHub Release — **osx-arm64, linux-amd64, linux-arm64** — each self-contained and version-locked to one DuckDB v2 nightly:

```
harbor-v0.11.0-<plat>.tar.gz
├── bin/harbor, bin/pilot     relative rpath: runs in place
├── lib/libduckdb.*           the exact engine they were built against
├── extensions/ui.duckdb_extension
├── ENGINE                    "v2.0.0-alphaNNNNN <plat>"
└── install.sh                -> /usr/local/{bin,lib} + ~/.duckdb/extensions/
```

- **Release rpath is relative** (`@loader_path`/`$ORIGIN` + `../lib`) where the dev build bakes an absolute path — a release built on a runner would otherwise search the runner's `$HOME`. Verified locally: packaged archive extracts, harbor resolves `lib/`, LOADs the ui extension, pilot round-trips.
- **Each CI job smoke-tests the packaged layout** before uploading — rpath, wire round-trip, and ui load.
- **build-ui-extension.sh learns Linux**: `-shared` in place of macOS's `-bundle -undefined dynamic_lookup`, system OpenSSL in place of brew's.
- **`make install` → `/usr/local/bin`** (sudo only when root-owned), replacing the per-`cli/<ver>/` seeding.
- **Crates unify at v0.11.0** for the tag.

Windows is deliberately out of scope for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)