### PR TITLE
Give the release smoke test the ~/.duckdb a real machine has

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           tar -C /tmp -xzf dist/harbor-"$GITHUB_REF_NAME"-${{ matrix.plat }}.tar.gz
           root=/tmp/harbor-"$GITHUB_REF_NAME"-${{ matrix.plat }}
+          # The ui extension's init creates ~/.duckdb/extension_data
+          # non-recursively; a virgin runner $HOME has no ~/.duckdb yet
+          # (install.sh creates it for real users).
+          mkdir -p "$HOME/.duckdb"
           "$root/bin/harbor" add /tmp/smoke.duckdb --name smoke --unsigned \
             --init "LOAD '$root/extensions/ui.duckdb_extension';"
           "$root/bin/pilot" smoke -c "SELECT 42 AS ok" --mode csv | grep -q 42


### PR DESCRIPTION
The ui extension's init creates ~/.duckdb/extension_data with a
non-recursive mkdir, so on a virgin runner HOME the LOAD fails before
the berth can start — which sank all three platforms at once. Real
machines have the directory (fetch-duckdb and install.sh both create
it); the smoke test now starts from the same floor. Verified against a
fresh HOME locally: berth starts, ui loads, pilot round-trips.
