### PR TITLE
duckbox: lowercase the type row

### DIFF
--- a/crates/pilot/src/render.rs
+++ b/crates/pilot/src/render.rs
@@ -143,7 +143,9 @@ impl<'a> Renderer<'a> {
             .enumerate()
             .map(|(i, c)| c.name.clone().unwrap_or_else(|| format!("col{i}")))
             .collect();
-        self.types = cols.iter().map(|c| c.duckdb_type.clone()).collect();
+        // Lowercased for the type row, duckbox-style: quieter under the
+        // headers, and how DuckDB's own CLI prints them.
+        self.types = cols.iter().map(|c| c.duckdb_type.to_lowercase()).collect();
         match self.opts.mode {
             Mode::Csv => {
                 let hdr = self.columns.iter().map(|c| csv_cell(c)).collect::<Vec<_>>().join(",");


### PR DESCRIPTION
VARCHAR shouted under every header; DuckDB's own duckbox prints types
lowercase, quieter beneath the column names. One change at ingestion,
so widths and cells always agree.
