### PR TITLE
duckboxy: the box without the type row

### DIFF
--- a/crates/pilot/src/main.rs
+++ b/crates/pilot/src/main.rs
@@ -167,7 +167,7 @@ target:
 
 options:
   --token <t>                  bearer token (else HARBOR_TOKEN, else <name>.token)
-  --mode <m>                   duckbox, markdown, csv, json, jsonlines, line, list, trash
+  --mode <m>                   duckbox, duckboxy, markdown, csv, json, jsonlines, line, list, trash
   --json                       shorthand for --mode jsonlines
 
 config: $HARBOR_HOME/config.toml ([defaults] mode/timer/maxrows/nullvalue,

--- a/crates/pilot/src/render.rs
+++ b/crates/pilot/src/render.rs
@@ -14,6 +14,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
     Duckbox,
+    Duckboxy, // duckbox minus the type row
     Markdown,
     Csv,
     Json,
@@ -27,6 +28,7 @@ impl Mode {
     pub fn parse(s: &str) -> Option<Mode> {
         Some(match s {
             "duckbox" | "box" => Mode::Duckbox,
+            "duckboxy" | "boxy" => Mode::Duckboxy,
             "markdown" | "md" => Mode::Markdown,
             "csv" => Mode::Csv,
             "json" => Mode::Json,
@@ -40,6 +42,7 @@ impl Mode {
     pub fn name(&self) -> &'static str {
         match self {
             Mode::Duckbox => "duckbox",
+            Mode::Duckboxy => "duckboxy",
             Mode::Markdown => "markdown",
             Mode::Csv => "csv",
             Mode::Json => "json",
@@ -50,7 +53,7 @@ impl Mode {
         }
     }
     pub fn is_streaming(&self) -> bool {
-        !matches!(self, Mode::Duckbox | Mode::Markdown)
+        !matches!(self, Mode::Duckbox | Mode::Duckboxy | Mode::Markdown)
     }
 }
 
@@ -193,7 +196,7 @@ impl<'a> Renderer<'a> {
                 let line = values.iter().map(|v| self.render(v)).collect::<Vec<_>>().join("|");
                 self.emit(format_args!("{line}\n"));
             }
-            Mode::Duckbox | Mode::Markdown => {
+            Mode::Duckbox | Mode::Duckboxy | Mode::Markdown => {
                 // boxed_safe: a value with an embedded newline/tab must not
                 // shatter the frame; escape it for display only.
                 let cells: Vec<String> = values.iter().map(|v| boxed_safe(&self.render(v))).collect();
@@ -213,6 +216,7 @@ impl<'a> Renderer<'a> {
         match self.opts.mode {
             Mode::Json => self.emit(format_args!("\n]\n")),
             Mode::Duckbox => self.boxed(row_count, glyphs_duckbox()),
+            Mode::Duckboxy => self.boxed(row_count, Glyphs { type_row: false, ..glyphs_duckbox() }),
             Mode::Markdown => self.boxed(row_count, glyphs_markdown()),
             _ => {}
         }

--- a/crates/pilot/src/repl.rs
+++ b/crates/pilot/src/repl.rs
@@ -125,7 +125,7 @@ fn has_code(s: &str) -> bool {
 /// The one list of dot-commands: dispatch validates against it, `.help`
 /// prints it, and the completer's lane A suggests from it.
 pub const DOT_COMMANDS: &[(&str, &str, &str)] = &[
-    ("mode", "[m]", "duckbox | markdown | csv | json | jsonlines | line | list | trash"),
+    ("mode", "[m]", "duckbox | duckboxy | markdown | csv | json | jsonlines | line | list | trash"),
     ("maxrows", "[n]", "boxed-mode display cap (head … tail elision past it)"),
     ("nullvalue", "[s]", "how NULL renders"),
     ("timer", "on|off", "server + wall time per statement"),
@@ -319,7 +319,7 @@ fn dot_command(cmd: &str, conn: &Conn, opts: &mut RenderOpts) -> DotResult {
             let _ = crate::list_fleet();
         }
         "mode" => match parts.next() {
-            None => println!("mode: {} (duckbox markdown csv json jsonlines line list trash)", opts.mode.name()),
+            None => println!("mode: {} (duckbox duckboxy markdown csv json jsonlines line list trash)", opts.mode.name()),
             Some(m) => match Mode::parse(m) {
                 Some(m) => opts.mode = m,
                 None => eprintln!("pilot: unknown mode {m:?}"),


### PR DESCRIPTION
Same frame, same colors, same paging — minus the type line under each
header, and with it the width that line imposed on narrow columns.
The Glyphs bool was already there; duckboxy is duckbox with it off.
Also answers to "boxy".
