### PR TITLE
Unlink before installing binaries — macOS caches signatures by inode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,13 @@ check_quick: binary pilot
 # rpath to $(DUCKDB_LIB), so it finds libduckdb from anywhere — no @loader_path,
 # no sibling dylib. pilot links no engine and runs on any machine. sudo is used
 # only when $(BIN) is root-owned (the /usr/local/bin default on macOS).
+# The rm first is load-bearing on macOS: overwriting a binary in place leaves
+# the kernel's per-inode signature cache stale, and every exec dies by SIGKILL
+# ("valid on disk", still killed). A fresh inode gets a fresh verdict.
 install: binary pilot
 	@sudo= ; [ -w "$(BIN)" ] || { sudo=sudo; echo "  $(BIN) is root-owned — using sudo"; }; \
 	  $$sudo install -d -m 0755 "$(BIN)"; \
+	  $$sudo rm -f "$(BIN)/harbor" "$(BIN)/pilot"; \
 	  $$sudo install -m 0755 target/release/harbor "$(BIN)/harbor"; \
 	  $$sudo install -m 0755 target/release/pilot  "$(BIN)/pilot"; \
 	  echo "installed harbor + pilot -> $(BIN)  (on your PATH)"

--- a/scripts/release-install.sh
+++ b/scripts/release-install.sh
@@ -22,6 +22,11 @@ read -r version ext_plat < ENGINE
 as_owner() { if [ -w "$(dirname "$1")" ] || [ -w "$1" ]; then "${@:2}"; else sudo "${@:2}"; fi; }
 as_owner "$BIN" install -d -m 0755 "$BIN"
 as_owner "$LIB" install -d -m 0755 "$LIB"
+# rm first, install second: macOS caches a binary's code signature per inode,
+# and overwriting in place leaves every later exec SIGKILL'd against the stale
+# cache. A fresh inode gets a fresh verdict; upgrades stay safe.
+as_owner "$BIN" rm -f "$BIN/harbor" "$BIN/pilot"
+as_owner "$LIB" rm -f "$LIB"/libduckdb.dylib "$LIB"/libduckdb.so
 as_owner "$BIN" install -m 0755 bin/harbor bin/pilot "$BIN"
 as_owner "$LIB" install -m 0755 lib/libduckdb.* "$LIB"
 


### PR DESCRIPTION
Overwriting a Mach-O in place leaves the kernel's per-inode signature
cache pointing at the old bytes: codesign calls the file valid on
disk while every exec dies by SIGKILL. Bitten for real by a repeat
make install. Both installers (make install and the release archive's
install.sh) now rm before install, so upgrades land on a fresh inode
and a fresh verdict.
