### PR TITLE
TODO: record the diagnosed reedline stray-word completion bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,3 +52,43 @@ re-apply Patch 2 or accept losing the stalled-reader protection.
 
 Until then the vendored copy is correct and harbor is safe; this is cleanup,
 not a fix.
+
+## Fix: pilot autocomplete inserts a stray word on Enter (diagnosed, unfixed)
+
+The bug: sometimes accepting/ignoring completion leaves an extra word (e.g.
+`table`) appended at the end of the line. Fully diagnosed 2026-08-18 — it is
+NOT in pilot's completer (`crates/pilot/src/complete.rs` is span-correct); it
+is a reedline 0.50.0 design flaw pilot inherits through the standard menu
+wiring in `crates/pilot/src/repl.rs::make_editor`:
+
+1. Tab opens the completion menu — and reedline keeps it ACTIVE for the whole
+   rest of the line. It refilters on every keystroke but only closes on Esc,
+   Enter, or an empty buffer (`engine.rs` Edit arm, ~line 1692: no
+   deactivate-on-empty, no deactivate-on-word-boundary).
+2. Any Enter while any menu is active is CONSUMED to insert the highlighted
+   suggestion at the cursor instead of submitting (`engine.rs` ~line 1575,
+   the `Enter | Submit | SubmitOrNewline if menu.is_active()` arm). Cursor is
+   at end of line → stray word appended.
+3. Sub-case: menu refiltered to zero matches still eats the Enter and inserts
+   nothing — the "had to press Enter twice" ghost.
+
+The complete fix cannot be made from pilot's side (acceptance is hardwired to
+Enter; menus expose no deactivate hook to the completer). Options weighed:
+
+- **(1) Vendor reedline + two-line patch** (the tiny_http precedent).
+  Patch A: an active menu with ZERO suggestions must not eat Enter — fall
+  through to submit. Patch B: typing a word boundary (whitespace, `;`)
+  deactivates the menu, fish/zsh-style. Together the menu can only intercept
+  Enter while visibly showing matches for the word under the cursor —
+  standard shell behavior. Cost: ~15k-line crate vendored for two lines.
+- **(2) Pilot-side mitigation only**: return no server-lane suggestions when
+  the cursor is not on a word (cache lane already does). Shrinks the window,
+  cannot close it — a statement ending in a matching word still gets
+  intercepted, and the double-Enter ghost remains.
+- **(3) Both + upstream PR** — RECOMMENDED. Do (1) now, file Patch A+B as a
+  reedline PR, un-vendor when it lands (add a Watch section here like
+  tiny_http's, with the `gh pr view` check).
+
+Repro for verification, before and after: type `create or replace ta`, Tab
+(menu opens), keep typing the rest of the statement, Enter — a keyword is
+appended at end of line instead of the statement running.


### PR DESCRIPTION
Full mechanism (menu stays active for the rest of the line; any Enter
while a menu is active inserts the highlighted suggestion instead of
submitting), the three fix options weighed, the recommendation to
vendor-patch reedline and file upstream, and the repro to verify by.
Diagnosis so far — the fix is future work.
