### PR TITLE
0.13.1 — the completion menu closes on statement punctuation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "duckdb",
  "justhttp",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -962,7 +962,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pilot"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "crossterm 0.29.0",
  "libc",
@@ -1825,7 +1825,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/harbor/Cargo.toml
+++ b/crates/harbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "harbor — DuckDB wearing a server: fleet manager + HTTP/UDS engine"
 license = "MIT"

--- a/crates/justhttp/Cargo.toml
+++ b/crates/justhttp/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "justhttp"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Steve Shreeve <steve.shreeve@gmail.com>"]

--- a/crates/pilot/Cargo.toml
+++ b/crates/pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilot"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "pilot — the Harbor client: fleet-aware SQL over UDS and HTTP"
 license = "MIT"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wire"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "The Harbor wire contract: request shapes, NDJSON envelope, error codes"
 license = "MIT"


### PR DESCRIPTION
Carries the vendored-reedline word-boundary fix: ';' and friends now
close the menu, so a Tab earlier in the line can no longer hand Enter
to a menu still offering next-statement keywords.
