### PR TITLE
common: one crate for what harbor, pilot and ducktable each guessed at alone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,13 +603,25 @@ name = "harbor"
 version = "0.15.0"
 dependencies = [
  "duckdb",
+ "harbor-common",
  "justhttp",
  "libc",
  "rand",
  "serde",
  "serde_json",
  "signal-hook 0.3.18",
+ "toml",
  "wire",
+]
+
+[[package]]
+name = "harbor-common"
+version = "0.15.0"
+dependencies = [
+ "libc",
+ "serde",
+ "toml",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ name = "pilot"
 version = "0.15.0"
 dependencies = [
  "crossterm 0.29.0",
+ "harbor-common",
  "libc",
  "nu-ansi-term",
  "reedline",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "harbor-common"
+version = "0.15.0"
+edition = "2024"
+description = "harbor-common — what harbor, pilot and ducktable all need: paths, names, permissions, config, lifetimes, states"
+license = "MIT"
+
+# No DuckDB, no HTTP, no process spawning, and nothing that shells out. Both
+# binaries depend on this crate, so anything that lands here lands in the
+# server too — including in the process holding an exclusive write lock on a
+# database. Keep it to files, strings, and formatting.
+[features]
+# The terminal renderer. On by default, for harbor and pilot. A GUI takes
+# `default-features = false` and skips it along with unicode-width — it wants
+# the semantics (see `state::Level`), not the ANSI.
+default = ["term"]
+term = ["dep:unicode-width"]
+
+[dependencies]
+serde = { version = "1.0.229", features = ["derive"] }
+toml = "1.1.4"
+# terminal-cell widths: a path with CJK or an emoji in it must not shear a
+# table, and counting bytes (or even chars) is exactly how that happens.
+unicode-width = { version = "0.2", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[lib]
+name = "harbor_common"
+path = "src/lib.rs"

--- a/crates/common/examples/demo.rs
+++ b/crates/common/examples/demo.rs
@@ -1,0 +1,43 @@
+//! `cargo run -p harbor-common --example demo` — the look, without the plumbing.
+fn main() {
+    use harbor_common::state::State;
+    use harbor_common::ui::*;
+    let st = Style { color: std::env::args().any(|a| a == "--color"), boxed: true };
+
+    let mut t = Table::new(["NAME", "STATE", "PID", "UPTIME", "DATABASE"]);
+    let rows: &[(&str, State, &str, &str, &str, Option<&str>)] = &[
+        ("labs", State::Running, "83582", "4m", "~/Data/Code/invoices/data/labs.duckdb", None),
+        ("medlabs", State::Drifted, "12699", "1h12m", "~/Data/Code/medlabs/api/db/medlabs.duckdb",
+         Some("config now says medlabs-v2.duckdb — harbor restart medlabs")),
+        ("sales", State::Stopped, "—", "—", "~/Data/sales.duckdb", None),
+        ("scratch", State::Unmanaged, "90551", "2m", "~/Data/scratch.duckdb",
+         Some("not in config — summoned by pilot; retires 90s after the last use")),
+        ("probe2", State::Stale, "—", "—", "—",
+         Some("runtime/probe2.lock, held by nobody — harbor prune")),
+    ];
+    for (name, state, pid, up, db, note) in rows {
+        t.row([
+            Cell::new(name),
+            Cell::new(state.label()).tone(Tone::from(state.level())),
+            Cell::new(pid).right(),
+            Cell::new(up).right(),
+            Cell::new(db),
+        ]);
+        if let Some(n) = note {
+            t.note(Tone::Dim, n);
+        }
+    }
+    print!("{}", t.render(&st));
+    println!("\n  2 running, 1 stopped, 1 unmanaged, 1 stale\n");
+
+    let p = Panel::new("medlabs")
+        .badge(format!("{} · 1h12m", State::Running.label()), Tone::from(State::Running.level()))
+        .footer("pid 12699")
+        .field("database", "~/Data/Code/medlabs/api/db/medlabs.duckdb  (412 MB)")
+        .field("address", "unix ~/.local/state/harbor/runtime/medlabs.sock")
+        .field("engine", "duckdb v2.0.0-alpha38195 · harbor 0.15.0")
+        .field("limits", "6 workers · 2 GB · no statement timeout")
+        .field("idle-exit", "never  (persistent)")
+        .field("config", "~/.config/harbor/config.toml  [connection.medlabs]");
+    print!("{}", p.render(&st));
+}

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,0 +1,314 @@
+//! `~/.config/harbor/config.toml` — one file, read by both binaries.
+//!
+//! One namespace, so "where do I configure medlabs?" has one answer. What
+//! kind of thing an entry is follows from which key it sets:
+//!
+//! ```toml
+//! [defaults]
+//! mode      = "duckbox"     # pilot's taste
+//! idle-exit = "90s"         # harbor's spawn policy
+//!
+//! [connection.medlabs]      # has `path` -> a local berth, harbor can start it
+//! path = "~/Data/Code/medlabs/api/db/medlabs.duckdb"
+//!
+//! [connection.prod]         # has `url` -> a remote, harbor never touches it
+//! url       = "https://db.example.com"
+//! token-cmd = "op read op://vault/prod/token"
+//! ```
+//!
+//! Harbor reads this file too, which is what makes `harbor start medlabs`
+//! mean anything. It is safe for it to: the deserializer below has no
+//! `token-cmd` field on the server's side of the fence, so the server cannot
+//! be made to shell out for a credential no matter what the file says.
+//!
+//! Every berth key is the matching `harbor serve` flag with the dashes
+//! stripped, so `harbor serve --help` is the reference and there is no second
+//! dialect to learn. A key that is only ever passed as a flag would make the
+//! config decorative, so there aren't any.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct FileConfig {
+    #[serde(default)]
+    pub defaults: Defaults,
+    #[serde(default)]
+    pub connection: HashMap<String, Connection>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Defaults {
+    // --- pilot: how output looks -------------------------------------------
+    pub mode: Option<String>,
+    pub timer: Option<bool>,
+    pub maxrows: Option<usize>,
+    pub nullvalue: Option<String>,
+    /// duck | mono | vivid
+    pub theme: Option<String>,
+    /// auto | light | dark — `auto` asks the terminal for its background.
+    pub appearance: Option<String>,
+    /// auto | always | never. `NO_COLOR` in the environment beats all three.
+    pub color: Option<String>,
+    /// What bare `pilot` opens. Unset, bare `pilot` lists what is openable
+    /// instead — deliberately, rather than connecting to the only berth when
+    /// there happens to be one, which would make adding a second database
+    /// silently change what the command does.
+    pub connection: Option<String>,
+
+    // --- harbor: how a berth is started ------------------------------------
+    /// Ten lines above the entry it explains, which is the whole reason a
+    /// shared default is tolerable here and would not be across two files.
+    pub idle_exit: Option<String>,
+    pub memory_limit: Option<String>,
+    pub workers: Option<usize>,
+    pub threads: Option<usize>,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Connection {
+    // --- a remote: pilot only ----------------------------------------------
+    pub url: Option<String>,
+    pub token: Option<String>,
+    pub token_file: Option<String>,
+    pub token_cmd: Option<String>,
+
+    // --- a local berth: harbor starts it, pilot may summon it --------------
+    pub path: Option<String>,
+    pub idle_exit: Option<String>,
+    pub memory_limit: Option<String>,
+    pub threads: Option<usize>,
+    pub workers: Option<usize>,
+    pub statement_timeout: Option<String>,
+    pub max_temp_size: Option<String>,
+    pub sealed: Option<bool>,
+    pub unsigned: Option<bool>,
+    pub create: Option<bool>,
+    pub log: Option<bool>,
+    pub init: Option<Vec<String>>,
+    pub port: Option<u16>,
+    pub bind: Option<String>,
+    /// Start this berth at login. The flag lives here, in the file you edit,
+    /// and never in runtime state — launchd moved exactly one field of
+    /// desired state (`Disabled`) out into an opaque database and spent a
+    /// decade explaining why editing the plist did nothing.
+    pub autostart: Option<bool>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Kind {
+    /// `path` — a database file on this machine.
+    Berth,
+    /// `url` — somebody else's server.
+    Remote,
+    /// Neither, or both.
+    Malformed,
+}
+
+impl Connection {
+    pub fn kind(&self) -> Kind {
+        match (self.path.is_some(), self.url.is_some()) {
+            (true, false) => Kind::Berth,
+            (false, true) => Kind::Remote,
+            _ => Kind::Malformed,
+        }
+    }
+
+    pub fn is_berth(&self) -> bool {
+        self.kind() == Kind::Berth
+    }
+
+    /// The database file, expanded. `None` unless this is a berth.
+    pub fn database(&self) -> Option<PathBuf> {
+        self.path.as_deref().map(crate::paths::expand)
+    }
+}
+
+impl FileConfig {
+    /// Configured local berths, sorted. The name is the section key — never
+    /// the database file's stem, which is how `[connection.warehouse]`
+    /// pointing at `inventory.duckdb` used to produce a berth called
+    /// `inventory` and an alias nobody could use.
+    pub fn berths(&self) -> Vec<(&str, &Connection)> {
+        let mut v: Vec<_> = self
+            .connection
+            .iter()
+            .filter(|(_, c)| c.is_berth())
+            .map(|(k, c)| (k.as_str(), c))
+            .collect();
+        v.sort_by_key(|(k, _)| *k);
+        v
+    }
+
+    pub fn remotes(&self) -> Vec<(&str, &Connection)> {
+        let mut v: Vec<_> = self
+            .connection
+            .iter()
+            .filter(|(_, c)| c.kind() == Kind::Remote)
+            .map(|(k, c)| (k.as_str(), c))
+            .collect();
+        v.sort_by_key(|(k, _)| *k);
+        v
+    }
+
+    pub fn get(&self, name: &str) -> Option<&Connection> {
+        self.connection.get(name)
+    }
+
+    /// Berths marked `autostart`, sorted. One platform unit runs `harbor
+    /// boot`, which starts these — rather than one unit per berth, so this
+    /// file stays the only place that says what starts at login.
+    pub fn autostarted(&self) -> Vec<(&str, &Connection)> {
+        self.berths().into_iter().filter(|(_, c)| c.autostart == Some(true)).collect()
+    }
+
+    /// Entries that set neither `path` nor `url`, or both. Reported rather
+    /// than guessed at: an entry with both is a question only its author can
+    /// answer, and picking one silently is how you query the wrong database.
+    pub fn malformed(&self) -> Vec<&str> {
+        let mut v: Vec<_> = self
+            .connection
+            .iter()
+            .filter(|(_, c)| c.kind() == Kind::Malformed)
+            .map(|(k, _)| k.as_str())
+            .collect();
+        v.sort_unstable();
+        v
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// No config file. Normal: zero-config local always works.
+    Missing(PathBuf),
+    /// The file, or the directory holding it, is writable by someone else.
+    Refused { file: PathBuf, offender: PathBuf },
+    Invalid { file: PathBuf, why: String },
+    NoHome(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Missing(p) => write!(f, "no config file at {}", p.display()),
+            Error::Refused { file, offender } => write!(
+                f,
+                "ignoring {} — {} is writable by others or not yours (chmod go-w it)",
+                file.display(),
+                offender.display()
+            ),
+            Error::Invalid { file, why } => write!(f, "{} is not valid: {why}", file.display()),
+            Error::NoHome(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// Read and parse the config, or say precisely why not.
+pub fn load() -> Result<FileConfig, Error> {
+    let root = crate::paths::config_root().map_err(Error::NoHome)?;
+    let file = root.join("config.toml");
+    let Ok(text) = std::fs::read_to_string(&file) else {
+        return Err(Error::Missing(file));
+    };
+    // Anyone who can rewrite this file is not editing settings, they are
+    // writing a program: `token-cmd` runs through `sh -c`, `init` runs SQL
+    // that can load native code, and `url` decides who receives the bearer
+    // token. Refuse it whole, the way ssh refuses a loose identity file,
+    // rather than trust it in part.
+    for p in [&file, &root] {
+        if crate::perms::exposed(p) {
+            return Err(Error::Refused { file: file.clone(), offender: p.clone() });
+        }
+    }
+    toml::from_str(&text).map_err(|e| Error::Invalid { file, why: e.to_string() })
+}
+
+/// Load, or carry on with nothing. A missing file is silent — that is the
+/// zero-config path, not a problem. Anything else is worth a line on stderr,
+/// because it means settings the user wrote are not in effect.
+pub fn load_or_empty(who: &str) -> FileConfig {
+    match load() {
+        Ok(c) => c,
+        Err(Error::Missing(_)) => FileConfig::default(),
+        Err(e) => {
+            eprintln!("{who}: {e}");
+            FileConfig::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        [defaults]
+        mode = "duckbox"
+        idle-exit = "90s"
+
+        [connection.medlabs]
+        path = "~/Data/Code/medlabs/api/db/medlabs.duckdb"
+
+        [connection.warehouse]
+        path = "/srv/data/inventory.duckdb"
+        memory-limit = "8GB"
+        init = ["LOAD ui"]
+
+        [connection.prod]
+        url = "https://db.example.com"
+        token-cmd = "op read op://vault/prod/token"
+    "#;
+
+    #[test]
+    fn one_namespace_two_kinds() {
+        let c: FileConfig = toml::from_str(SAMPLE).unwrap();
+        assert_eq!(c.defaults.mode.as_deref(), Some("duckbox"));
+        assert_eq!(c.defaults.idle_exit.as_deref(), Some("90s"));
+
+        let berths: Vec<_> = c.berths().iter().map(|(n, _)| *n).collect();
+        assert_eq!(berths, ["medlabs", "warehouse"]);
+        let remotes: Vec<_> = c.remotes().iter().map(|(n, _)| *n).collect();
+        assert_eq!(remotes, ["prod"]);
+
+        let w = c.get("warehouse").unwrap();
+        assert_eq!(w.memory_limit.as_deref(), Some("8GB"));
+        assert_eq!(w.init.as_deref(), Some(&["LOAD ui".to_string()][..]));
+    }
+
+    #[test]
+    fn the_name_is_the_key_not_the_file_stem() {
+        // The bug this schema exists to make impossible: `warehouse` must
+        // never become a berth called `inventory`.
+        let c: FileConfig = toml::from_str(SAMPLE).unwrap();
+        let (name, conn) = c.berths()[1];
+        assert_eq!(name, "warehouse");
+        assert!(conn.database().unwrap().ends_with("inventory.duckdb"));
+    }
+
+    #[test]
+    fn both_or_neither_is_reported_not_guessed() {
+        let c: FileConfig = toml::from_str(
+            r#"
+            [connection.confused]
+            path = "/a.duckdb"
+            url = "https://b"
+            [connection.empty]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(c.malformed(), ["confused", "empty"]);
+        assert!(c.berths().is_empty());
+    }
+
+    #[test]
+    fn unknown_keys_are_an_error_not_a_silent_typo() {
+        // `default-address-pool` vs `default-address-pools` cost Docker users
+        // years. A misspelled key here is a hard error naming the key.
+        let e = toml::from_str::<FileConfig>("[connection.x]\npth = \"/a.duckdb\"\n");
+        assert!(e.is_err());
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,0 +1,34 @@
+//! What harbor, pilot and ducktable all need.
+//!
+//! Before this crate each binary had its own copy of "where does config
+//! live", "what is a legal berth name", and "may I trust this file" — and the
+//! copies disagreed: harbor refused to start without `$HOME` while pilot
+//! quietly resolved to `./.config/harbor` and looked for sockets in a
+//! relative directory. One definition, imported everywhere, is the point.
+//!
+//! # Front ends
+//!
+//! Everything here is presentation-free except [`ui`], which is the terminal
+//! renderer and is behind the default `term` feature. A GUI takes
+//! `default-features = false` and gets the semantics without the ANSI:
+//! [`state::State`] answers *what is this berth doing* and
+//! [`state::Level`] answers *how alarming is that*, leaving each front end to
+//! map a level onto its own palette — a `Tone` in a terminal, a token in a
+//! stylesheet. Nothing in this crate decides that a running berth is
+//! `#22c55e`.
+
+pub mod config;
+pub mod lifetime;
+pub mod paths;
+pub mod perms;
+pub mod state;
+#[cfg(feature = "term")]
+pub mod ui;
+
+pub use paths::{
+    config_file, config_root, expand, history_file, log_dir, looks_like_path, normalize,
+    runtime_dir, state_root,
+};
+pub use lifetime::{Lifetime, Summoner};
+pub use state::{Level, State};
+pub use perms::{chmod, create_dir_private, exposed, write_private};

--- a/crates/common/src/lifetime.rs
+++ b/crates/common/src/lifetime.rs
@@ -1,0 +1,248 @@
+//! How long a berth lives, and who decides.
+//!
+//! There are only two lifetimes, and one key expresses both:
+//!
+//! * **persistent** — runs until someone stops it. `idle-exit = "never"`.
+//! * **ephemeral** — retires once nothing has used it for a while.
+//!   `idle-exit = "90s"`.
+//!
+//! Everything the CLI can express is one of those two. "Start it and leave
+//! it", "open it and let it go when I quit", "keep it up after ducktable
+//! closes" are not three mechanisms — they are the same knob, set from three
+//! places. Most specific wins:
+//!
+//! ```text
+//! 1. a flag            --keep, --idle-exit 5m
+//! 2. the entry         [connection.medlabs] idle-exit = "90s"
+//! 3. the defaults      [defaults] idle-exit = "90s"
+//! 4. who asked         harbor start -> persistent;  pilot -> ephemeral
+//! ```
+//!
+//! Step 4 is the DWIM: a human who typed `harbor start` asked for a server
+//! and gets one; a human who typed `pilot` asked for a prompt and gets a
+//! process that cleans up after itself. Neither has to say so.
+//!
+//! # The joiner never changes the lifetime
+//!
+//! This is the invariant that makes the whole thing safe, and it is worth
+//! stating out loud because getting it wrong is silently destructive: a
+//! client that **joins** a berth already running inherits nothing and decides
+//! nothing. Only the client that **summons** a berth sets its lifetime.
+//!
+//! Without that rule, opening ducktable against a long-running `medlabs` and
+//! then closing the window would take the server — and everyone else on it —
+//! down with you. With it, a berth's lifetime is fixed at birth by whoever
+//! actually started it, and every later arrival is just a guest.
+
+use std::time::Duration;
+
+/// The default grace period for a berth a client summoned on its way to a
+/// prompt: long enough to survive a reconnect, short enough that a forgotten
+/// window does not leave a server behind.
+pub const DEFAULT_GRACE: Duration = Duration::from_secs(90);
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Lifetime {
+    /// Runs until stopped.
+    Persistent,
+    /// Retires once nothing has used it for this long.
+    Idle(Duration),
+}
+
+/// Who asked for this berth to exist.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Summoner {
+    /// `harbor start` — a human asked for a server.
+    Operator,
+    /// `pilot`, `ducktable` — a client opened it on the way to a prompt.
+    Client,
+}
+
+impl Lifetime {
+    pub fn is_persistent(self) -> bool {
+        self == Lifetime::Persistent
+    }
+
+    /// The `harbor serve` argv this lifetime means. Config is translated into
+    /// flags rather than read twice, so `serve` stays flag-complete and a
+    /// systemd unit or a container never needs a config file at all.
+    pub fn to_args(self) -> Vec<String> {
+        match self {
+            Lifetime::Persistent => vec![],
+            Lifetime::Idle(d) => vec!["--idle-exit".into(), format!("{}s", d.as_secs())],
+        }
+    }
+
+    /// How to say it in a status line.
+    pub fn describe(self) -> String {
+        match self {
+            Lifetime::Persistent => "never".to_string(),
+            Lifetime::Idle(d) => humanize(d),
+        }
+    }
+}
+
+/// What the user wrote on the command line, if anything.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Override {
+    /// `--keep`: leave it running after I disconnect.
+    pub keep: bool,
+    /// `--idle-exit <d>`: retire it this long after the last use.
+    pub idle_exit: Option<Duration>,
+}
+
+/// Settle the lifetime of a berth about to be **summoned**.
+///
+/// Never call this for a berth that is already running — see the module note
+/// on joiners.
+pub fn resolve(
+    flags: Override,
+    entry: Option<&str>,
+    defaults: Option<&str>,
+    who: Summoner,
+) -> Result<Lifetime, String> {
+    if let Some(d) = flags.idle_exit {
+        return Ok(Lifetime::Idle(d));
+    }
+    if flags.keep {
+        return Ok(Lifetime::Persistent);
+    }
+    for spec in [entry, defaults].into_iter().flatten() {
+        return parse(spec);
+    }
+    Ok(match who {
+        Summoner::Operator => Lifetime::Persistent,
+        Summoner::Client => Lifetime::Idle(DEFAULT_GRACE),
+    })
+}
+
+/// `"never"` (or `"off"`), else a duration.
+pub fn parse(spec: &str) -> Result<Lifetime, String> {
+    match spec.trim() {
+        "never" | "off" | "none" => Ok(Lifetime::Persistent),
+        s => parse_duration(s).map(Lifetime::Idle),
+    }
+}
+
+/// `"90s"`, `"10m"`, `"2h"`, or bare seconds.
+pub fn parse_duration(s: &str) -> Result<Duration, String> {
+    // Split off a trailing alphabetic unit. `trim_end_matches` works in whole
+    // chars, so a multibyte unit (`5µs`, `5é`) can't land `split_at` inside a
+    // UTF-8 char and panic — it just fails the unit match below.
+    let num = s.trim_end_matches(char::is_alphabetic);
+    let unit = &s[num.len()..];
+    let n: u64 = num.parse().map_err(|_| format!("bad duration {s:?}"))?;
+    // checked, because `n * 3600` wraps in release: `--idle-exit 9999999999999999h`
+    // parsed fine and then meant something arbitrary and small.
+    let secs = match unit {
+        "" | "s" => Some(n),
+        "m" => n.checked_mul(60),
+        "h" => n.checked_mul(3600),
+        _ => return Err(format!("bad duration unit in {s:?} (use s, m, h)")),
+    };
+    let secs = secs.ok_or_else(|| format!("duration {s:?} is too large"))?;
+    Ok(Duration::from_secs(secs))
+}
+
+/// Coarse and readable: `4m`, `1h12m`, `3d`. Precision here is noise.
+pub fn humanize(d: Duration) -> String {
+    let s = d.as_secs();
+    match s {
+        0..=59 => format!("{s}s"),
+        60..=3599 => format!("{}m", s / 60),
+        3600..=86399 => match (s / 3600, (s % 3600) / 60) {
+            (h, 0) => format!("{h}h"),
+            (h, m) => format!("{h}h{m}m"),
+        },
+        _ => format!("{}d", s / 86400),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NONE: Option<&str> = None;
+
+    #[test]
+    fn who_asked_decides_when_nothing_else_does() {
+        let f = Override::default();
+        assert_eq!(resolve(f, NONE, NONE, Summoner::Operator).unwrap(), Lifetime::Persistent);
+        assert_eq!(
+            resolve(f, NONE, NONE, Summoner::Client).unwrap(),
+            Lifetime::Idle(DEFAULT_GRACE)
+        );
+    }
+
+    #[test]
+    fn the_entry_beats_the_defaults_and_who_asked() {
+        let f = Override::default();
+        // A berth pinned persistent stays persistent even when a client
+        // summoned it — this is what `harbor start` then `pilot` then quit
+        // must not undo.
+        assert_eq!(
+            resolve(f, Some("never"), Some("90s"), Summoner::Client).unwrap(),
+            Lifetime::Persistent
+        );
+        assert_eq!(
+            resolve(f, Some("5m"), NONE, Summoner::Operator).unwrap(),
+            Lifetime::Idle(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn defaults_apply_to_anything_without_its_own() {
+        let f = Override::default();
+        assert_eq!(
+            resolve(f, NONE, Some("30s"), Summoner::Operator).unwrap(),
+            Lifetime::Idle(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn flags_win_over_everything() {
+        let keep = Override { keep: true, ..Default::default() };
+        assert_eq!(
+            resolve(keep, Some("90s"), Some("90s"), Summoner::Client).unwrap(),
+            Lifetime::Persistent
+        );
+        let five = Override { idle_exit: Some(Duration::from_secs(300)), ..Default::default() };
+        assert_eq!(
+            resolve(five, Some("never"), NONE, Summoner::Operator).unwrap(),
+            Lifetime::Idle(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn persistent_passes_no_idle_flag_at_all() {
+        assert!(Lifetime::Persistent.to_args().is_empty());
+        assert_eq!(
+            Lifetime::Idle(Duration::from_secs(90)).to_args(),
+            ["--idle-exit", "90s"]
+        );
+    }
+
+    #[test]
+    fn never_is_spelled_several_reasonable_ways() {
+        for s in ["never", "off", "none", " never "] {
+            assert_eq!(parse(s).unwrap(), Lifetime::Persistent, "{s:?}");
+        }
+    }
+
+    #[test]
+    fn durations_do_not_wrap() {
+        assert!(parse_duration("9999999999999999h").is_err());
+        assert!(parse_duration("5µs").is_err());
+        assert_eq!(parse_duration("120").unwrap(), Duration::from_secs(120));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn humanized_uptime_is_coarse() {
+        assert_eq!(humanize(Duration::from_secs(14)), "14s");
+        assert_eq!(humanize(Duration::from_secs(240)), "4m");
+        assert_eq!(humanize(Duration::from_secs(4320)), "1h12m");
+        assert_eq!(humanize(Duration::from_secs(7200)), "2h");
+        assert_eq!(humanize(Duration::from_secs(300000)), "3d");
+    }
+}

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -1,0 +1,197 @@
+//! Where everything lives.
+//!
+//! Two roots, split by what the files *are* rather than by who writes them:
+//!
+//! ```text
+//! ~/.config/harbor/config.toml    desired state — you edit this
+//! ~/.local/state/harbor/          actual state — harbor writes this
+//!     runtime/   <name>.{json,sock,token,lock}
+//!     log/       <name>.log
+//!     history    pilot's REPL history
+//! ```
+//!
+//! Runtime state used to live under `~/.config/harbor/`, which is how a
+//! config directory came to hold sockets, tombstoned lock files and a shell
+//! history — unreadable enough that deleting it looked like the reasonable
+//! move. `~/.local/state` is the XDG home for exactly this: files that
+//! accumulate, that you would not back up, and that you are meant to be able
+//! to throw away. It is also not `/tmp`, which is swept after three days on
+//! macOS and ten by systemd-tmpfiles, and would take a long-running berth's
+//! socket with it.
+//!
+//! `$HARBOR_HOME`, if absolute, collapses both roots into that one directory.
+//! That is the self-contained form tests, containers and unit files want, and
+//! it is the single escape hatch — there is no per-directory override.
+
+use std::path::{Path, PathBuf};
+
+const APP: &str = "harbor";
+
+fn home() -> Result<PathBuf, String> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(PathBuf::from)
+        .map_err(|_| "neither $HOME nor %USERPROFILE% is set".to_string())
+}
+
+/// An environment variable read as an absolute path, or nothing.
+///
+/// Relative values are ignored rather than resolved. XDG calls them invalid,
+/// and the failure they produce is the worst kind: a state root that moves
+/// with the working directory, so the same command finds a different fleet
+/// depending on where it was run from.
+fn abs_env(var: &str) -> Option<PathBuf> {
+    let v = std::env::var(var).ok()?;
+    let p = PathBuf::from(v);
+    p.is_absolute().then_some(p)
+}
+
+/// The one override: everything under a single directory.
+pub fn harbor_home() -> Option<PathBuf> {
+    abs_env("HARBOR_HOME")
+}
+
+/// Holds `config.toml`, and nothing else.
+pub fn config_root() -> Result<PathBuf, String> {
+    if let Some(h) = harbor_home() {
+        return Ok(h);
+    }
+    if let Some(x) = abs_env("XDG_CONFIG_HOME") {
+        return Ok(x.join(APP));
+    }
+    Ok(home()?.join(".config").join(APP))
+}
+
+pub fn config_file() -> Result<PathBuf, String> {
+    Ok(config_root()?.join("config.toml"))
+}
+
+/// Holds `runtime/`, `log/` and `history` — everything harbor writes.
+pub fn state_root() -> Result<PathBuf, String> {
+    if let Some(h) = harbor_home() {
+        return Ok(h);
+    }
+    if let Some(x) = abs_env("XDG_STATE_HOME") {
+        return Ok(x.join(APP));
+    }
+    #[cfg(windows)]
+    {
+        // Windows has no XDG, and `Local` is the right half of AppData for
+        // this: state that belongs to this machine and must not roam.
+        if let Some(x) = abs_env("LOCALAPPDATA") {
+            return Ok(x.join(APP));
+        }
+    }
+    Ok(home()?.join(".local").join("state").join(APP))
+}
+
+/// Sockets, sidecars, tokens, locks.
+pub fn runtime_dir() -> Result<PathBuf, String> {
+    Ok(state_root()?.join("runtime"))
+}
+
+pub fn log_dir() -> Result<PathBuf, String> {
+    Ok(state_root()?.join("log"))
+}
+
+/// pilot's REPL history. State, not config, and not the fleet's business —
+/// it lived in `runtime/` for a while, where every sweep had to special-case
+/// it forever.
+pub fn history_file() -> Result<PathBuf, String> {
+    Ok(state_root()?.join("history"))
+}
+
+/// Berth names are registry filenames: `[a-z0-9_-]`, 1..=64.
+pub fn normalize(name: &str) -> Result<String, String> {
+    let n: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
+        .collect();
+    if n.is_empty() || n.len() > 64 {
+        return Err(format!("bad berth name {name:?}"));
+    }
+    Ok(n)
+}
+
+/// Is this argument a path, or a configured name?
+///
+/// **A bare word is never a path.** `harbor add medlabs`, run from the wrong
+/// directory, once named the file `./medlabs`, created it empty, and served
+/// it under the name clients trusted — an empty impostor in front of real
+/// data. Reading a bare word as a name closes that whole class: the argument
+/// either matches something configured or it is an error, and it can never
+/// silently become a file that isn't there.
+pub fn looks_like_path(arg: &str) -> bool {
+    arg.contains('/')
+        || arg.contains('\\')
+        || arg.starts_with('~')
+        || arg == "."
+        || arg == ".."
+        || Path::new(arg)
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("duckdb") || e.eq_ignore_ascii_case("db"))
+}
+
+/// `~/` expansion, nothing fancier.
+pub fn expand(p: &str) -> PathBuf {
+    if let Some(rest) = p.strip_prefix("~/") {
+        if let Ok(h) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            return Path::new(&h).join(rest);
+        }
+    }
+    PathBuf::from(p)
+}
+
+/// Render a path with `$HOME` shortened back to `~`, for display only.
+pub fn shorten(p: &Path) -> String {
+    let s = p.display().to_string();
+    let Ok(h) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) else {
+        return s;
+    };
+    if h.is_empty() {
+        return s;
+    }
+    match s.strip_prefix(&h) {
+        Some(rest) if rest.is_empty() => "~".to_string(),
+        Some(rest) if rest.starts_with('/') || rest.starts_with('\\') => format!("~{rest}"),
+        _ => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_become_registry_filenames() {
+        assert_eq!(normalize("MedLabs").unwrap(), "medlabs");
+        assert_eq!(normalize("my.db").unwrap(), "my-db");
+        assert_eq!(normalize("a b").unwrap(), "a-b");
+        assert!(normalize("").is_err());
+        assert!(normalize(&"x".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn a_bare_word_is_never_a_path() {
+        // The whole point: these must resolve as configured names.
+        assert!(!looks_like_path("medlabs"));
+        assert!(!looks_like_path("labs"));
+        assert!(!looks_like_path("warehouse2"));
+        // And these must stay paths.
+        assert!(looks_like_path("./medlabs.duckdb"));
+        assert!(looks_like_path("medlabs.duckdb"));
+        assert!(looks_like_path("data.db"));
+        assert!(looks_like_path("~/Data/x.duckdb"));
+        assert!(looks_like_path("/srv/db/inventory.duckdb"));
+        assert!(looks_like_path("sub/dir"));
+        assert!(looks_like_path("."));
+    }
+
+    #[test]
+    fn a_relative_env_root_is_ignored_not_resolved() {
+        // Guards the rule, not the env: a relative $HARBOR_HOME must never
+        // become a state root, or the fleet moves with the working directory.
+        assert!(PathBuf::from("relative/harbor").is_absolute().then_some(()).is_none());
+    }
+}

--- a/crates/common/src/perms.rs
+++ b/crates/common/src/perms.rs
@@ -1,0 +1,93 @@
+//! File modes, and the one question worth asking about a config file: could
+//! anyone but me have written this?
+
+use std::io::Write;
+use std::path::Path;
+
+/// True if someone other than us could swap this path's contents out from
+/// under us: group- or world-writable, or owned by another user. A sticky
+/// directory (`/tmp`) is writable by all but hijackable by none, so it passes.
+///
+/// Both binaries need this, and harbor needs it more than it looks. A berth
+/// definition carries `init` SQL, and `init` can `LOAD` a native extension —
+/// so a config file anyone can rewrite is not a settings leak, it is code
+/// execution as its owner the next time a berth starts. Same argument pilot
+/// already makes about `token-cmd`, same answer: refuse the file whole.
+#[cfg(unix)]
+pub fn exposed(path: &Path) -> bool {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let Ok(md) = std::fs::metadata(path) else {
+        return false;
+    };
+    let mode = md.permissions().mode();
+    let sticky = md.is_dir() && mode & 0o1000 != 0;
+    let uid = unsafe { libc::getuid() };
+    (mode & 0o022 != 0 && !sticky) || (md.uid() != uid && md.uid() != 0)
+}
+
+#[cfg(not(unix))]
+pub fn exposed(_path: &Path) -> bool {
+    false
+}
+
+/// Create a file that is 0600 from its first byte, and write `contents`.
+///
+/// The point is the absence of a window: `fs::write` followed by `chmod` is
+/// correct at rest and wrong in between, and "in between" is where a secret
+/// leaks.
+pub fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(contents.as_bytes())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)
+    }
+}
+
+/// Create a directory that is 0700 from the moment it exists. Same reasoning
+/// as `write_private`, for the directory the tokens live in: `create_dir_all`
+/// applies the umask, so the plain form is 0755 for the instant before a
+/// chmod — and in that window another local user can plant a `<name>.token`
+/// this process would then adopt as its own credential.
+pub fn create_dir_private(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new().recursive(true).mode(0o700).create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+pub fn chmod(path: &Path, mode: u32) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, mode);
+        Ok(())
+    }
+}
+
+/// Ensure a directory exists, is ours alone, and stays that way.
+pub fn ensure_private_dir(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        create_dir_private(path).map_err(|e| format!("cannot create {}: {e}", path.display()))?;
+    }
+    let _ = chmod(path, 0o700);
+    Ok(())
+}

--- a/crates/common/src/state.rs
+++ b/crates/common/src/state.rs
@@ -1,0 +1,147 @@
+//! What a berth is doing, in one word — and what that word looks like.
+//!
+//! The set exists because desired and actual can disagree, and every way
+//! they can disagree needs a name the reader can act on. Both binaries
+//! import this so a berth is never described two different ways.
+//!
+//! Severity is a ladder, and it is stated as meaning rather than as color:
+//!
+//! * [`Level::Idle`] — nothing is wrong. Configured and down, or leftovers.
+//! * [`Level::Good`] — running and matching its config.
+//! * [`Level::Warn`] — running, but not the way the file says. Worth a look.
+//! * [`Level::Bad`] — the registry claims a process that is not there.
+//!
+//! What a level *looks* like is the front end's business: dim/green/yellow/red
+//! in a terminal, a palette token in a GUI. The glyph carries the same
+//! meaning independently, so the table still reads with color off, in a pipe,
+//! or for someone who cannot separate the hues.
+
+/// How alarming a state is, with no opinion about color.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Level {
+    /// Nothing is wrong, nothing is happening.
+    Idle,
+    /// Healthy.
+    Good,
+    /// Works, but something disagrees with something else.
+    Warn,
+    /// Broken.
+    Bad,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum State {
+    /// Configured, running, and serving what the config says.
+    Running,
+    /// Configured, not running. Opens on demand.
+    Stopped,
+    /// Running, but the database or the options differ from the config now.
+    Drifted,
+    /// Running, with nothing in the config about it — summoned by a client,
+    /// or started by hand. Not an error; `pilot ./x.duckdb` is meant to work.
+    Unmanaged,
+    /// A sidecar claims a live process and the lock says otherwise.
+    Dead,
+    /// Files left behind by a berth that is gone. Harmless, just untidy.
+    Stale,
+}
+
+impl State {
+    pub fn word(self) -> &'static str {
+        match self {
+            State::Running => "running",
+            State::Stopped => "stopped",
+            State::Drifted => "drifted",
+            State::Unmanaged => "unmanaged",
+            State::Dead => "dead",
+            State::Stale => "stale",
+        }
+    }
+
+    pub fn glyph(self) -> &'static str {
+        match self {
+            State::Running => "●",
+            State::Stopped => "○",
+            State::Drifted => "◆",
+            State::Unmanaged => "◍",
+            State::Dead => "✕",
+            State::Stale => "◌",
+        }
+    }
+
+    pub fn level(self) -> Level {
+        match self {
+            State::Running => Level::Good,
+            State::Stopped | State::Stale => Level::Idle,
+            State::Drifted | State::Unmanaged => Level::Warn,
+            State::Dead => Level::Bad,
+        }
+    }
+
+    /// `● running`, ready for a cell.
+    pub fn label(self) -> String {
+        format!("{} {}", self.glyph(), self.word())
+    }
+
+    /// Is this a berth you can talk to right now?
+    pub fn is_live(self) -> bool {
+        matches!(self, State::Running | State::Drifted | State::Unmanaged)
+    }
+
+    /// systemctl's, so a script written for one works on the other:
+    /// 0 running, 3 known but not running, 4 nothing by that name.
+    pub fn exit_code(self) -> u8 {
+        match self {
+            s if s.is_live() => 0,
+            _ => 3,
+        }
+    }
+
+    /// Sort order for the fleet view: what you have, then what is running
+    /// without being configured, then the mess to sweep. Stale goes last
+    /// because it is acted on in bulk, not one at a time.
+    pub fn rank(self) -> u8 {
+        match self {
+            State::Running | State::Drifted | State::Stopped => 0,
+            State::Unmanaged => 1,
+            State::Dead => 2,
+            State::Stale => 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_climbs_with_the_problem() {
+        assert!(State::Stopped.level() < State::Running.level());
+        assert!(State::Running.level() < State::Drifted.level());
+        assert!(State::Drifted.level() < State::Dead.level());
+    }
+
+    #[test]
+    fn the_word_survives_without_color() {
+        // A reader with color off, or in a pipe, still gets the state.
+        for s in [State::Running, State::Stopped, State::Drifted, State::Dead, State::Stale] {
+            assert!(!s.word().is_empty() && !s.glyph().is_empty());
+            assert!(s.label().contains(s.word()));
+        }
+    }
+
+    #[test]
+    fn exit_codes_match_systemctl() {
+        assert_eq!(State::Running.exit_code(), 0);
+        assert_eq!(State::Unmanaged.exit_code(), 0);
+        assert_eq!(State::Stopped.exit_code(), 3);
+        assert_eq!(State::Stale.exit_code(), 3);
+    }
+
+    #[test]
+    fn the_mess_sorts_last() {
+        let mut v = [State::Stale, State::Running, State::Unmanaged, State::Stopped];
+        v.sort_by_key(|s| s.rank());
+        assert_eq!(v, [State::Running, State::Stopped, State::Unmanaged, State::Stale]);
+    }
+}

--- a/crates/common/src/ui.rs
+++ b/crates/common/src/ui.rs
@@ -1,0 +1,532 @@
+//! How harbor and pilot look.
+//!
+//! Three rules hold the whole module together:
+//!
+//! 1. **A pipe gets data, a terminal gets a picture.** Box-drawing and color
+//!    appear only when stdout is a tty. Piped output is tab-separated and
+//!    byte-stable, so `harbor ls | awk` keeps working forever.
+//! 2. **`NO_COLOR` wins.** It is the de facto standard and it costs one line.
+//! 3. **Nothing from disk is ever printed raw.** A database path containing
+//!    an escape sequence must not be able to repaint the terminal or forge a
+//!    table row, so every untrusted string goes through [`sanitize`] before
+//!    it is measured or padded.
+
+use std::io::IsTerminal;
+use unicode_width::UnicodeWidthStr;
+
+// ---------------------------------------------------------------------------
+// color
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Tone {
+    #[default]
+    Plain,
+    Dim,
+    Bold,
+    Green,
+    Yellow,
+    Red,
+    Cyan,
+}
+
+impl Tone {
+    fn code(self) -> &'static str {
+        match self {
+            Tone::Plain => "",
+            Tone::Dim => "\x1b[2m",
+            Tone::Bold => "\x1b[1m",
+            Tone::Green => "\x1b[32m",
+            Tone::Yellow => "\x1b[33m",
+            Tone::Red => "\x1b[31m",
+            Tone::Cyan => "\x1b[36m",
+        }
+    }
+}
+
+/// The terminal's reading of a severity level. A GUI writes its own.
+impl From<crate::state::Level> for Tone {
+    fn from(l: crate::state::Level) -> Tone {
+        use crate::state::Level;
+        match l {
+            Level::Idle => Tone::Dim,
+            Level::Good => Tone::Green,
+            Level::Warn => Tone::Yellow,
+            Level::Bad => Tone::Red,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Style {
+    pub color: bool,
+    pub boxed: bool,
+}
+
+impl Style {
+    /// What stdout deserves right now.
+    ///
+    /// `NO_COLOR` (present and non-empty) turns color off whatever else says;
+    /// `CLICOLOR_FORCE` turns it on even through a pipe, which is what CI
+    /// systems that render ANSI in their log viewer need.
+    pub fn stdout() -> Self {
+        let tty = std::io::stdout().is_terminal();
+        Style { color: color_allowed(tty), boxed: tty }
+    }
+
+    /// Bytes, for a pipe or a file. Never colored, never boxed.
+    pub fn plain() -> Self {
+        Style { color: false, boxed: false }
+    }
+
+    /// `--color auto|always|never`, or `[defaults] color`.
+    pub fn with_choice(self, choice: Option<&str>) -> Self {
+        match choice {
+            Some("always") => Style { color: true, ..self },
+            Some("never") => Style { color: false, ..self },
+            _ => self,
+        }
+    }
+
+    pub fn paint(&self, tone: Tone, s: &str) -> String {
+        if !self.color || tone == Tone::Plain {
+            return s.to_string();
+        }
+        format!("{}{s}\x1b[0m", tone.code())
+    }
+}
+
+fn color_allowed(tty: bool) -> bool {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if std::env::var_os("CLICOLOR_FORCE").is_some_and(|v| !v.is_empty() && v != "0") {
+        return true;
+    }
+    // TERM=dumb means a terminal that cannot, not one that would rather not.
+    if std::env::var("TERM").is_ok_and(|t| t == "dumb") {
+        return false;
+    }
+    tty
+}
+
+// ---------------------------------------------------------------------------
+// safety and width
+// ---------------------------------------------------------------------------
+
+/// Strip anything that could move the cursor, change the color, or forge a
+/// border. Replaces rather than deletes, so a hostile name still occupies
+/// space and stays visible instead of quietly vanishing.
+pub fn sanitize(s: &str) -> String {
+    s.chars().map(|c| if c == '\u{1b}' || c.is_control() { '\u{fffd}' } else { c }).collect()
+}
+
+/// Terminal cells, not bytes and not chars.
+fn cells(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+fn pad(s: &str, to: usize, right: bool) -> String {
+    let w = cells(s);
+    let gap = to.saturating_sub(w);
+    match right {
+        true => format!("{}{s}", " ".repeat(gap)),
+        false => format!("{s}{}", " ".repeat(gap)),
+    }
+}
+
+/// Shorten to fit, with an ellipsis, measured in cells.
+pub fn elide(s: &str, max: usize) -> String {
+    if cells(s) <= max || max == 0 {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    let mut w = 0;
+    for c in s.chars() {
+        let cw = UnicodeWidthStr::width(c.to_string().as_str());
+        if w + cw > max.saturating_sub(1) {
+            break;
+        }
+        out.push(c);
+        w += cw;
+    }
+    out.push('…');
+    out
+}
+
+// ---------------------------------------------------------------------------
+// box drawing
+// ---------------------------------------------------------------------------
+
+pub struct Charset {
+    pub tl: &'static str,
+    pub tm: &'static str,
+    pub tr: &'static str,
+    pub ml: &'static str,
+    pub mm: &'static str,
+    pub mr: &'static str,
+    pub bl: &'static str,
+    pub bm: &'static str,
+    pub br: &'static str,
+    pub h: &'static str,
+    pub v: &'static str,
+}
+
+/// Rounded corners. The straight-cornered set stays in pilot's `render.rs`
+/// for duckbox, which deliberately mirrors the DuckDB shell.
+pub const ROUNDED: Charset = Charset {
+    tl: "╭",
+    tm: "┬",
+    tr: "╮",
+    ml: "├",
+    mm: "┼",
+    mr: "┤",
+    bl: "╰",
+    bm: "┴",
+    br: "╯",
+    h: "─",
+    v: "│",
+};
+
+// ---------------------------------------------------------------------------
+// table
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct Cell {
+    pub text: String,
+    pub tone: Tone,
+    pub right: bool,
+}
+
+impl Cell {
+    pub fn new(text: impl AsRef<str>) -> Self {
+        Cell { text: sanitize(text.as_ref()), tone: Tone::Plain, right: false }
+    }
+    pub fn tone(mut self, tone: Tone) -> Self {
+        self.tone = tone;
+        self
+    }
+    pub fn right(mut self) -> Self {
+        self.right = true;
+        self
+    }
+}
+
+/// A table, plus advisory lines that hang off a row.
+///
+/// The notes are the point: a `stale` row that cannot say *why* it is stale,
+/// or what to run about it, sends the reader to the docs — and the moment
+/// they need the answer is the only moment they will read anything.
+#[derive(Default)]
+pub struct Table {
+    head: Vec<String>,
+    rows: Vec<Vec<Cell>>,
+    notes: Vec<(usize, Tone, String)>,
+}
+
+impl Table {
+    pub fn new<S: AsRef<str>>(head: impl IntoIterator<Item = S>) -> Self {
+        Table {
+            head: head.into_iter().map(|h| sanitize(h.as_ref())).collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn row(&mut self, cells: impl IntoIterator<Item = Cell>) -> &mut Self {
+        self.rows.push(cells.into_iter().collect());
+        self
+    }
+
+    /// Attach an advisory to the row most recently added.
+    pub fn note(&mut self, tone: Tone, text: impl AsRef<str>) -> &mut Self {
+        let at = self.rows.len().saturating_sub(1);
+        self.notes.push((at, tone, sanitize(text.as_ref())));
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn render(&self, st: &Style) -> String {
+        match st.boxed {
+            true => self.render_boxed(st),
+            false => self.render_plain(),
+        }
+    }
+
+    /// Tab-separated, no notes, no color. What a pipe wants.
+    fn render_plain(&self) -> String {
+        let mut out = String::new();
+        if !self.head.is_empty() {
+            out.push_str(&self.head.join("\t"));
+            out.push('\n');
+        }
+        for r in &self.rows {
+            let line: Vec<&str> = r.iter().map(|c| c.text.as_str()).collect();
+            out.push_str(&line.join("\t"));
+            out.push('\n');
+        }
+        out
+    }
+
+    fn widths(&self) -> Vec<usize> {
+        let n = self.head.len().max(self.rows.iter().map(|r| r.len()).max().unwrap_or(0));
+        let mut w = vec![0usize; n];
+        for (i, h) in self.head.iter().enumerate() {
+            w[i] = w[i].max(cells(h));
+        }
+        for r in &self.rows {
+            for (i, c) in r.iter().enumerate() {
+                w[i] = w[i].max(cells(&c.text));
+            }
+        }
+        w
+    }
+
+    fn render_boxed(&self, st: &Style) -> String {
+        let c = &ROUNDED;
+        let w = self.widths();
+        if w.is_empty() {
+            return String::new();
+        }
+        let seg = |i: usize| c.h.repeat(w[i] + 2);
+        let rule = |l: &str, m: &str, r: &str| {
+            let mid: Vec<String> = (0..w.len()).map(seg).collect();
+            format!("{l}{}{r}", mid.join(m))
+        };
+        // Everything between the outer bars, for a note that spans the table.
+        let inner: usize = w.iter().map(|x| x + 2).sum::<usize>() + w.len().saturating_sub(1);
+
+        let mut out = String::new();
+        out.push_str(&rule(c.tl, c.tm, c.tr));
+        out.push('\n');
+
+        if !self.head.is_empty() {
+            let hs: Vec<String> = (0..w.len())
+                .map(|i| {
+                    let h = self.head.get(i).map(String::as_str).unwrap_or("");
+                    format!(" {} ", pad(h, w[i], false))
+                })
+                .map(|s| st.paint(Tone::Bold, &s))
+                .collect();
+            out.push_str(&format!("{}{}{}\n", c.v, hs.join(c.v), c.v));
+            out.push_str(&rule(c.ml, c.mm, c.mr));
+            out.push('\n');
+        }
+
+        for (ri, r) in self.rows.iter().enumerate() {
+            let cs: Vec<String> = (0..w.len())
+                .map(|i| match r.get(i) {
+                    Some(cell) => {
+                        let body = pad(&cell.text, w[i], cell.right);
+                        format!(" {} ", st.paint(cell.tone, &body))
+                    }
+                    None => " ".repeat(w[i] + 2),
+                })
+                .collect();
+            out.push_str(&format!("{}{}{}\n", c.v, cs.join(c.v), c.v));
+
+            for (_, tone, text) in self.notes.iter().filter(|(a, _, _)| *a == ri) {
+                let body = elide(&format!("  ! {text}"), inner);
+                out.push_str(&format!(
+                    "{}{}{}\n",
+                    c.v,
+                    st.paint(*tone, &pad(&body, inner, false)),
+                    c.v
+                ));
+            }
+        }
+
+        out.push_str(&rule(c.bl, c.bm, c.br));
+        out.push('\n');
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// panel
+// ---------------------------------------------------------------------------
+
+/// A detail view for one thing: `harbor status <name>`.
+#[derive(Default)]
+pub struct Panel {
+    title: String,
+    badge: (String, Tone),
+    footer: String,
+    fields: Vec<(String, String, Tone)>,
+}
+
+impl Panel {
+    pub fn new(title: impl AsRef<str>) -> Self {
+        Panel { title: sanitize(title.as_ref()), ..Default::default() }
+    }
+
+    pub fn badge(mut self, text: impl AsRef<str>, tone: Tone) -> Self {
+        self.badge = (sanitize(text.as_ref()), tone);
+        self
+    }
+
+    pub fn footer(mut self, text: impl AsRef<str>) -> Self {
+        self.footer = sanitize(text.as_ref());
+        self
+    }
+
+    pub fn field(mut self, label: impl AsRef<str>, value: impl AsRef<str>) -> Self {
+        self.fields.push((sanitize(label.as_ref()), sanitize(value.as_ref()), Tone::Plain));
+        self
+    }
+
+    pub fn field_toned(mut self, label: impl AsRef<str>, value: impl AsRef<str>, t: Tone) -> Self {
+        self.fields.push((sanitize(label.as_ref()), sanitize(value.as_ref()), t));
+        self
+    }
+
+    pub fn render(&self, st: &Style) -> String {
+        if !st.boxed {
+            let mut out = String::new();
+            for (l, v, _) in &self.fields {
+                out.push_str(&format!("{l}\t{v}\n"));
+            }
+            return out;
+        }
+        let c = &ROUNDED;
+        let lw = self.fields.iter().map(|(l, _, _)| cells(l)).max().unwrap_or(0);
+        let lines: Vec<String> =
+            self.fields.iter().map(|(l, v, _)| format!("  {}  {v}", pad(l, lw, false))).collect();
+        let tones: Vec<Tone> = self.fields.iter().map(|(_, _, t)| *t).collect();
+
+        // Caps first: the border has to fit its own text before anything else.
+        let left_cap = format!("{} {} ", c.h, self.title);
+        let right_cap = match self.badge.0.is_empty() {
+            true => String::new(),
+            false => format!(" {} {}", self.badge.0, c.h),
+        };
+        let foot_cap = match self.footer.is_empty() {
+            true => String::new(),
+            false => format!(" {} {}", self.footer, c.h),
+        };
+        let inner = lines
+            .iter()
+            .map(|l| cells(l))
+            .chain([cells(&left_cap) + cells(&right_cap) + 2])
+            .chain([cells(&foot_cap) + 2])
+            .max()
+            .unwrap_or(0)
+            + 2;
+
+        let mut out = String::new();
+        let fill = inner.saturating_sub(cells(&left_cap) + cells(&right_cap));
+        out.push_str(&format!(
+            "{}{}{}{}{}\n",
+            c.tl,
+            st.paint(Tone::Bold, &left_cap),
+            c.h.repeat(fill),
+            st.paint(self.badge.1, &right_cap),
+            c.tr
+        ));
+        out.push_str(&format!("{}{}{}\n", c.v, " ".repeat(inner), c.v));
+        for (l, t) in lines.iter().zip(tones) {
+            out.push_str(&format!("{}{}{}\n", c.v, st.paint(t, &pad(l, inner, false)), c.v));
+        }
+        out.push_str(&format!("{}{}{}\n", c.v, " ".repeat(inner), c.v));
+        let ffill = inner.saturating_sub(cells(&foot_cap));
+        out.push_str(&format!(
+            "{}{}{}{}\n",
+            c.bl,
+            c.h.repeat(ffill),
+            st.paint(Tone::Dim, &foot_cap),
+            c.br
+        ));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn boxed() -> Style {
+        Style { color: false, boxed: true }
+    }
+
+    #[test]
+    fn a_pipe_gets_tsv_with_no_escapes() {
+        let mut t = Table::new(["NAME", "STATE"]);
+        t.row([Cell::new("medlabs"), Cell::new("running").tone(Tone::Green)]);
+        t.note(Tone::Yellow, "config changed — harbor restart medlabs");
+        let out = t.render(&Style::plain());
+        assert_eq!(out, "NAME\tSTATE\nmedlabs\trunning\n");
+        assert!(!out.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn rounded_corners_and_square_joints() {
+        let mut t = Table::new(["A", "B"]);
+        t.row([Cell::new("1"), Cell::new("2")]);
+        let out = t.render(&boxed());
+        assert!(out.starts_with("╭─"), "{out}");
+        assert!(out.contains('┬') && out.contains('┼') && out.contains('┴'));
+        assert!(out.trim_end().ends_with('╯'), "{out}");
+    }
+
+    #[test]
+    fn every_line_of_a_table_is_the_same_width() {
+        let mut t = Table::new(["NAME", "DATABASE"]);
+        t.row([Cell::new("medlabs"), Cell::new("~/Data/medlabs.duckdb")]);
+        t.note(Tone::Yellow, "no setup file");
+        t.row([Cell::new("x"), Cell::new("~/y.duckdb")]);
+        let out = t.render(&boxed());
+        let widths: Vec<usize> = out.lines().map(cells).collect();
+        assert!(widths.windows(2).all(|w| w[0] == w[1]), "ragged: {widths:?}\n{out}");
+    }
+
+    #[test]
+    fn wide_characters_do_not_shear_the_columns() {
+        // Counting bytes or chars here is exactly how a table goes ragged.
+        let mut t = Table::new(["NAME"]);
+        t.row([Cell::new("日本語")]);
+        t.row([Cell::new("abcdef")]);
+        let out = t.render(&boxed());
+        let widths: Vec<usize> = out.lines().map(cells).collect();
+        assert!(widths.windows(2).all(|w| w[0] == w[1]), "ragged: {widths:?}\n{out}");
+    }
+
+    #[test]
+    fn a_hostile_name_cannot_repaint_the_terminal() {
+        let mut t = Table::new(["NAME"]);
+        t.row([Cell::new("\u{1b}[31mred\u{1b}[0m│fake")]);
+        let out = t.render(&boxed());
+        assert!(!out.contains('\u{1b}'), "escape survived: {out:?}");
+        // The bars that remain are the table's own, one per side.
+        let bars = out.lines().nth(3).unwrap().matches('│').count();
+        assert_eq!(bars, 3, "a forged bar got through: {out}");
+    }
+
+    #[test]
+    fn no_color_beats_everything() {
+        let st = Style { color: false, boxed: true };
+        assert_eq!(st.paint(Tone::Red, "x"), "x");
+    }
+
+    #[test]
+    fn a_panel_is_square_and_carries_its_caps() {
+        let p = Panel::new("medlabs")
+            .badge("running · 1h12m", Tone::Green)
+            .footer("pid 12699")
+            .field("database", "~/Data/medlabs.duckdb")
+            .field("limits", "6 workers · 2 GB");
+        let out = p.render(&boxed());
+        let widths: Vec<usize> = out.lines().map(cells).collect();
+        assert!(widths.windows(2).all(|w| w[0] == w[1]), "ragged: {widths:?}\n{out}");
+        assert!(out.contains("medlabs") && out.contains("running") && out.contains("pid 12699"));
+        assert!(out.starts_with('╭') && out.trim_end().ends_with('╯'));
+    }
+
+    #[test]
+    fn elide_measures_cells() {
+        assert_eq!(elide("abcdef", 4), "abc…");
+        assert_eq!(elide("abc", 10), "abc");
+    }
+}

--- a/crates/harbor/Cargo.toml
+++ b/crates/harbor/Cargo.toml
@@ -6,6 +6,10 @@ description = "harbor — DuckDB wearing a server: fleet manager + HTTP/UDS engi
 license = "MIT"
 
 [dependencies]
+# Paths, names, the permission gate, the config schema, berth lifetimes and
+# states, and the renderer. Shared with pilot so the two cannot drift, and
+# with ducktable, which takes it without the `term` feature.
+harbor-common = { path = "../common" }
 duckdb = { version = "~1.10505.0", default-features = false, features = ["vtab"] }
 justhttp = { path = "../justhttp" }
 serde = "1"
@@ -17,6 +21,8 @@ libc = "0.2"
 # the tests check it against the crate that publishes it.
 [dev-dependencies]
 wire = { path = "../wire" }
+# Test-only: doctor's checks are driven from config literals.
+toml = "1.1.4"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }

--- a/crates/harbor/src/doctor.rs
+++ b/crates/harbor/src/doctor.rs
@@ -1,0 +1,395 @@
+//! `harbor doctor` — the checks nothing else has a moment to make.
+//!
+//! Lives in harbor rather than in `harbor-common` because harbor is the only
+//! thing that runs it. Pilot connects; it does not audit. If ducktable ever
+//! wants a problems panel, this moves back — but not before.
+//!
+//! The discipline that keeps this verb useful: **doctor reports only what no
+//! other command would naturally notice.** A database that has moved is
+//! doctor's business, because nothing looks until you try to start it. A
+//! misspelled key is not, because the parser already refuses the file and
+//! names the key. Every check that duplicates a good error message makes the
+//! output longer and the signal weaker, which is how a doctor command ends
+//! up as a wall of warnings nobody reads.
+//!
+//! Every finding names the fix. A finding with no fix is a complaint.
+
+use harbor_common::config::{Connection, FileConfig, Kind};
+use harbor_common::paths::shorten;
+use harbor_common::ui::Tone;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Severity {
+    /// Something is already broken, or will be the moment it is used.
+    Error,
+    /// Works today, will surprise someone.
+    Warn,
+    /// Worth knowing.
+    Note,
+}
+
+impl Severity {
+    pub fn tone(self) -> Tone {
+        match self {
+            Severity::Error => Tone::Red,
+            Severity::Warn => Tone::Yellow,
+            Severity::Note => Tone::Dim,
+        }
+    }
+    pub fn glyph(self) -> &'static str {
+        match self {
+            Severity::Error => "✕",
+            Severity::Warn => "▲",
+            Severity::Note => "·",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Finding {
+    pub severity: Severity,
+    /// One line: what is wrong.
+    pub title: String,
+    /// The evidence — paths, names, what disagrees with what.
+    pub detail: Vec<String>,
+    /// What to run or edit. Never empty.
+    pub fix: String,
+}
+
+/// Entries that set neither `path` nor `url`, or both.
+///
+/// Both is the interesting one: it is a question only the author can answer,
+/// and picking either silently is how you end up querying the wrong database
+/// while everything looks fine.
+pub fn check_entries(cfg: &FileConfig) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for name in cfg.malformed() {
+        let c = cfg.get(name).expect("named by malformed()");
+        let (title, fix) = match (c.path.is_some(), c.url.is_some()) {
+            (true, true) => (
+                format!("[connection.{name}] sets both path and url"),
+                format!("keep one: path makes {name} a local berth, url makes it a remote"),
+            ),
+            _ => (
+                format!("[connection.{name}] sets neither path nor url"),
+                format!("give {name} a path (a local database) or a url (a remote)"),
+            ),
+        };
+        out.push(Finding { severity: Severity::Error, title, detail: vec![], fix });
+    }
+    out
+}
+
+/// Two names for one database file.
+///
+/// DuckDB takes a single writer, so two berths on one file cannot both run —
+/// the second loses the lock and dies with a message about the *name*, which
+/// is not where the problem is. Nothing else looks across entries, so this is
+/// doctor's most useful check.
+pub fn check_duplicates(cfg: &FileConfig, canon: impl Fn(&Path) -> PathBuf) -> Vec<Finding> {
+    let mut seen: HashMap<PathBuf, Vec<&str>> = HashMap::new();
+    for (name, c) in cfg.berths() {
+        if let Some(p) = c.database() {
+            seen.entry(canon(&p)).or_default().push(name);
+        }
+    }
+    let mut out: Vec<Finding> = seen
+        .into_iter()
+        .filter(|(_, names)| names.len() > 1)
+        .map(|(path, mut names)| {
+            names.sort_unstable();
+            Finding {
+                severity: Severity::Error,
+                title: format!("{} names one database", names.join(" and ")),
+                detail: vec![shorten(&path)],
+                fix: format!(
+                    "DuckDB allows one writer — drop all but one of them (harbor forget {})",
+                    names[1..].join(", harbor forget ")
+                ),
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| a.title.cmp(&b.title));
+    out
+}
+
+/// Berths whose database is not where the config says.
+///
+/// Latent by nature: the entry is fine, the file moved, and you find out the
+/// next time you start it — which for an `autostart` berth is at login, in a
+/// context with nobody watching.
+pub fn check_databases(cfg: &FileConfig, exists: impl Fn(&Path) -> bool) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (name, c) in cfg.berths() {
+        let Some(p) = c.database() else { continue };
+        if exists(&p) {
+            continue;
+        }
+        let auto = c.autostart == Some(true);
+        out.push(Finding {
+            severity: if auto { Severity::Error } else { Severity::Warn },
+            title: format!("{name} points at a database that is not there"),
+            detail: {
+                let mut d = vec![shorten(&p)];
+                if auto {
+                    d.push("and it is marked autostart, so this fails at login".into());
+                }
+                d
+            },
+            fix: format!("fix the path in [connection.{name}], or harbor forget {name}"),
+        });
+    }
+    out
+}
+
+/// `token-file` pointing at nothing. The connection looks configured and
+/// fails with an auth error, which sends people looking in the wrong place.
+pub fn check_tokens(cfg: &FileConfig, exists: impl Fn(&Path) -> bool) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (name, c) in cfg.remotes() {
+        let Some(tf) = c.token_file.as_deref() else { continue };
+        let p = harbor_common::paths::expand(tf);
+        if exists(&p) {
+            continue;
+        }
+        out.push(Finding {
+            severity: Severity::Warn,
+            title: format!("{name} has a token-file that is not there"),
+            detail: vec![shorten(&p)],
+            fix: format!("fix token-file in [connection.{name}], or use token-cmd"),
+        });
+    }
+    out
+}
+
+/// A relative `$HARBOR_HOME` is ignored rather than resolved — deliberately,
+/// since a relative state root moves with the working directory. But it is
+/// ignored *silently*, so someone who set it deserves to be told.
+pub fn check_environment(var: Option<&str>) -> Vec<Finding> {
+    let Some(v) = var else { return vec![] };
+    if v.is_empty() || Path::new(v).is_absolute() {
+        return vec![];
+    }
+    vec![Finding {
+        severity: Severity::Warn,
+        title: "$HARBOR_HOME is relative and is being ignored".into(),
+        detail: vec![
+            format!("HARBOR_HOME={v}"),
+            "a relative root would move the fleet with the working directory".into(),
+        ],
+        fix: "set it to an absolute path, or unset it".into(),
+    }]
+}
+
+/// The checks that touch nothing.
+///
+/// `harbor show` runs these on every invocation and prints a one-line
+/// pointer, because a doctor nobody runs is a doctor that finds nothing. It
+/// must never run the rest: `exists()` and `canonicalize()` on a path whose
+/// mount is gone block for the mount timeout, and turning an instant command
+/// into an occasional hang is a poor trade for a check nobody asked for.
+///
+/// The duplicate check here compares expanded paths as written, which catches
+/// the realistic case — a copy-pasted entry — and misses symlink aliasing.
+/// `doctor` canonicalizes and catches both.
+pub fn quick(cfg: &FileConfig) -> Vec<Finding> {
+    let mut out = check_entries(cfg);
+    out.extend(check_duplicates(cfg, |p| p.to_path_buf()));
+    out.extend(check_environment(std::env::var("HARBOR_HOME").ok().as_deref()));
+    out.sort_by_key(|f| f.severity);
+    out
+}
+
+/// The footer `show` prints when `quick` found something — and nothing at
+/// all when it did not. A clean fleet gets a clean screen.
+///
+/// Deliberately a count and a verb, not the findings themselves: `show`
+/// answers "what do I have", and burying that under diagnostics every time
+/// is how a status view becomes a wall nobody reads.
+pub fn summary(findings: &[Finding]) -> Option<(Severity, String)> {
+    let worst = findings.iter().map(|f| f.severity).min()?;
+    let n = findings.len();
+    let noun = if n == 1 { "problem" } else { "problems" };
+    Some((worst, format!("{} {n} {noun} in your config — harbor doctor", worst.glyph())))
+}
+
+/// Everything, against the real filesystem.
+pub fn examine(cfg: &FileConfig) -> Vec<Finding> {
+    let exists = |p: &Path| p.exists();
+    let canon = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let mut out = check_entries(cfg);
+    out.extend(check_duplicates(cfg, canon));
+    out.extend(check_databases(cfg, exists));
+    out.extend(check_tokens(cfg, exists));
+    out.extend(check_environment(std::env::var("HARBOR_HOME").ok().as_deref()));
+    out.sort_by_key(|f| f.severity);
+    out
+}
+
+/// Non-zero when anything needs a human, so `harbor doctor` works in a
+/// health check. Notes alone are not a failure.
+pub fn exit_code(findings: &[Finding]) -> u8 {
+    match findings.iter().any(|f| f.severity <= Severity::Warn) {
+        true => 1,
+        false => 0,
+    }
+}
+
+/// Handy for callers that want the connection back out of a finding.
+pub fn berth_of<'a>(cfg: &'a FileConfig, name: &str) -> Option<&'a Connection> {
+    cfg.get(name).filter(|c| c.kind() == Kind::Berth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(s: &str) -> FileConfig {
+        toml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn two_names_for_one_database_is_an_error() {
+        let c = cfg(r#"
+            [connection.medlabs]
+            path = "/data/medlabs.duckdb"
+            [connection.backup]
+            path = "/data/medlabs.duckdb"
+            [connection.other]
+            path = "/data/other.duckdb"
+        "#);
+        let f = check_duplicates(&c, |p| p.to_path_buf());
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f[0].severity, Severity::Error);
+        assert!(f[0].title.contains("backup and medlabs"), "{}", f[0].title);
+        assert!(f[0].fix.contains("harbor forget"));
+    }
+
+    #[test]
+    fn distinct_paths_that_canonicalize_together_are_caught() {
+        // The whole reason to canonicalize: a symlink and its target are one
+        // database, and DuckDB will not let both berths run.
+        let c = cfg(r#"
+            [connection.a]
+            path = "/data/link.duckdb"
+            [connection.b]
+            path = "/real/db.duckdb"
+        "#);
+        let same = |_: &Path| PathBuf::from("/real/db.duckdb");
+        assert_eq!(check_duplicates(&c, same).len(), 1);
+    }
+
+    #[test]
+    fn a_missing_database_is_worse_when_it_autostarts() {
+        let c = cfg(r#"
+            [connection.quiet]
+            path = "/gone/a.duckdb"
+            [connection.loud]
+            path = "/gone/b.duckdb"
+            autostart = true
+        "#);
+        let f = check_databases(&c, |_| false);
+        let loud = f.iter().find(|f| f.title.starts_with("loud")).unwrap();
+        let quiet = f.iter().find(|f| f.title.starts_with("quiet")).unwrap();
+        assert_eq!(loud.severity, Severity::Error);
+        assert_eq!(quiet.severity, Severity::Warn);
+        assert!(loud.detail.iter().any(|d| d.contains("at login")));
+    }
+
+    #[test]
+    fn present_databases_say_nothing_at_all() {
+        let c = cfg("[connection.ok]\npath = \"/data/ok.duckdb\"\n");
+        assert!(check_databases(&c, |_| true).is_empty());
+        assert!(check_entries(&c).is_empty());
+        assert!(check_duplicates(&c, |p| p.to_path_buf()).is_empty());
+    }
+
+    #[test]
+    fn both_path_and_url_asks_the_author_rather_than_guessing() {
+        let c = cfg("[connection.x]\npath = \"/a.duckdb\"\nurl = \"https://b\"\n");
+        let f = check_entries(&c);
+        assert_eq!(f[0].severity, Severity::Error);
+        assert!(f[0].fix.contains("keep one"));
+    }
+
+    #[test]
+    fn a_relative_harbor_home_is_reported_because_it_is_ignored() {
+        assert!(check_environment(Some("/abs/ok")).is_empty());
+        assert!(check_environment(None).is_empty());
+        let f = check_environment(Some("relative/harbor"));
+        assert_eq!(f.len(), 1);
+        assert!(f[0].fix.contains("absolute"));
+    }
+
+    #[test]
+    fn every_finding_carries_a_fix() {
+        let c = cfg(r#"
+            [connection.dup1]
+            path = "/d.duckdb"
+            [connection.dup2]
+            path = "/d.duckdb"
+            [connection.bad]
+            [connection.remote]
+            url = "https://x"
+            token-file = "/gone/t"
+        "#);
+        let mut all = check_entries(&c);
+        all.extend(check_duplicates(&c, |p| p.to_path_buf()));
+        all.extend(check_databases(&c, |_| false));
+        all.extend(check_tokens(&c, |_| false));
+        assert!(!all.is_empty());
+        for f in &all {
+            assert!(!f.fix.trim().is_empty(), "no fix: {}", f.title);
+            assert!(!f.title.trim().is_empty());
+        }
+        assert_eq!(exit_code(&all), 1);
+    }
+
+    #[test]
+    fn a_clean_config_exits_zero() {
+        assert_eq!(exit_code(&[]), 0);
+    }
+
+    #[test]
+    fn quick_touches_no_filesystem_at_all() {
+        // The guard that keeps `harbor show` instant: a berth pointed at a
+        // path that would block on a dead mount must not be probed here.
+        let c = cfg(r#"
+            [connection.a]
+            path = "/net/dead-mount/a.duckdb"
+            [connection.b]
+            path = "/net/dead-mount/a.duckdb"
+        "#);
+        let f = quick(&c);
+        // Found the duplicate without asking the filesystem anything.
+        assert_eq!(f.len(), 1);
+        assert!(f[0].title.contains("a and b"));
+    }
+
+    #[test]
+    fn a_clean_fleet_gets_a_clean_screen() {
+        assert!(summary(&[]).is_none());
+        let c = cfg("[connection.ok]\npath = \"/data/ok.duckdb\"\n");
+        assert!(summary(&quick(&c)).is_none());
+    }
+
+    #[test]
+    fn the_footer_counts_and_points_and_takes_the_worst_tone() {
+        let c = cfg(r#"
+            [connection.dup1]
+            path = "/d.duckdb"
+            [connection.dup2]
+            path = "/d.duckdb"
+            [connection.bad]
+        "#);
+        let (sev, line) = summary(&quick(&c)).unwrap();
+        assert_eq!(sev, Severity::Error);
+        assert!(line.contains("2 problems"), "{line}");
+        assert!(line.ends_with("harbor doctor"), "{line}");
+        // One problem reads as one problem.
+        let one = cfg("[connection.bad]\n");
+        assert!(summary(&quick(&one)).unwrap().1.contains("1 problem in"));
+    }
+}

--- a/crates/harbor/src/main.rs
+++ b/crates/harbor/src/main.rs
@@ -22,6 +22,8 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+mod doctor;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> ExitCode {

--- a/crates/harbor/src/main.rs
+++ b/crates/harbor/src/main.rs
@@ -24,6 +24,13 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod doctor;
 
+// Paths, names, permissions and durations live in harbor-common so pilot and
+// ducktable cannot drift from them. What stays here is what only a server
+// does: claiming a berth, and creating the directory it claims in.
+use harbor_common::lifetime::parse_duration;
+use harbor_common::perms::{chmod, write_private};
+use harbor_common::normalize;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> ExitCode {
@@ -119,25 +126,6 @@ struct Opts {
     max_temp_size: Option<String>,
 }
 
-/// "90s", "10m", "2h", or bare seconds.
-fn parse_duration(s: &str) -> Result<Duration, String> {
-    // Split off a trailing alphabetic unit. `trim_end_matches` works in whole
-    // chars, so a multibyte unit (`5µs`, `5é`) can't land `split_at` inside a
-    // UTF-8 char and panic — it just fails the unit match below.
-    let num = s.trim_end_matches(char::is_alphabetic);
-    let unit = &s[num.len()..];
-    let n: u64 = num.parse().map_err(|_| format!("bad duration {s:?}"))?;
-    // checked, because `n * 3600` wraps in release: `--idle-exit 9999999999999999h`
-    // parsed fine and then meant something arbitrary and small.
-    let secs = match unit {
-        "" | "s" => Some(n),
-        "m" => n.checked_mul(60),
-        "h" => n.checked_mul(3600),
-        _ => return Err(format!("bad duration unit in {s:?} (use s, m, h)")),
-    };
-    let secs = secs.ok_or_else(|| format!("duration {s:?} is too large"))?;
-    Ok(Duration::from_secs(secs))
-}
 
 fn parse_opts(rest: Vec<String>) -> Result<Opts, String> {
     let mut it = rest.into_iter();
@@ -210,112 +198,29 @@ fn parse_opts(rest: Vec<String>) -> Result<Opts, String> {
     Ok(o)
 }
 
-/// Berth names are registry filenames: [a-z0-9_-], 1..=64.
-fn normalize(name: &str) -> Result<String, String> {
-    let n: String = name
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
-        .collect();
-    if n.is_empty() || n.len() > 64 {
-        return Err(format!("bad berth name {name:?}"));
-    }
-    Ok(n)
-}
 
-/// The config root: $HARBOR_HOME, else ~/.config/harbor. Holds config.toml
-/// and the runtime/ dir; nothing else.
+/// The runtime dir, created and tightened before use.
 ///
-/// Guarded 0700 for the same reason runtime/ is, and it is not a lesser case:
-/// config.toml holds bearer tokens outright, and `token-cmd`, which pilot runs
-/// through `sh -c`. A world-writable config root is therefore not a leak but
-/// code execution as its owner, the next time anyone opens a berth.
-fn config_root() -> Result<PathBuf, String> {
-    match std::env::var("HARBOR_HOME") {
-        Ok(h) => Ok(PathBuf::from(h)),
-        Err(_) => {
-            let h = std::env::var("HOME")
-                .or_else(|_| std::env::var("USERPROFILE"))
-                .map_err(|_| "neither $HOME nor %USERPROFILE% is set")?;
-            Ok(Path::new(&h).join(".config").join("harbor"))
+/// Harbor is the only thing that writes here, so it is the only thing that
+/// creates it. Both this and the state root are chmod'd on every run, not
+/// just at creation: they hold sockets and token files, which are the local
+/// access control, and a directory made earlier by hand or under a sloppy
+/// umask must not be allowed to stay world-listable.
+///
+/// The config root is tightened only if it already exists. Nothing of
+/// harbor's lives there, and a server should not conjure a config directory.
+fn harbor_home() -> Result<PathBuf, String> {
+    let run = harbor_common::runtime_dir()?;
+    harbor_common::perms::ensure_private_dir(&run)?;
+    if let Ok(state) = harbor_common::state_root() {
+        let _ = chmod(&state, 0o700);
+    }
+    if let Ok(cfg) = harbor_common::config_root() {
+        if cfg.exists() {
+            let _ = chmod(&cfg, 0o700);
         }
     }
-}
-
-/// The runtime dir: $HARBOR_HOME/runtime — sockets, locks, sidecars, tokens,
-/// history, log/. Created on demand; chmod'd 0700 unconditionally, because
-/// sockets and tokens are the local access control and a dir made earlier by
-/// hand (or a sloppy umask) must not stay world-listable.
-fn harbor_home() -> Result<PathBuf, String> {
-    let root = config_root()?;
-    let run = root.join("runtime");
-    if !run.exists() {
-        // Created 0700 rather than created-then-tightened. `create_dir_all`
-        // applies the umask, so the plain form makes the directory 0755 for
-        // the instant before the chmod below — and this is the directory that
-        // holds every token file, so a race in that window lets another local
-        // user plant a `<name>.token` this process would then adopt as its own
-        // credential. Being born with the right mode has no window at all.
-        create_dir_private(&run)
-            .map_err(|e| format!("cannot create {}: {e}", run.display()))?;
-    }
-    // Both, unconditionally, every run: the root carries config.toml (tokens
-    // and token-cmd) and the runtime dir carries sockets and token files, so
-    // neither may be left readable — or writable — by anyone else, whatever
-    // umask or hand-made directory got there first.
-    let _ = chmod(&root, 0o700);
-    let _ = chmod(&run, 0o700);
     Ok(run)
-}
-
-/// Create a file that is 0600 from its first byte, and write `contents` to it.
-///
-/// The point is the absence of a window: `fs::write` followed by `chmod` is
-/// correct at rest and wrong in between, and "in between" is where a secret
-/// leaks.
-fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        f.write_all(contents.as_bytes())
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(path, contents)
-    }
-}
-
-/// Create a directory that is 0700 from the moment it exists. Same reasoning
-/// as `write_private`, for the directory the tokens live in.
-fn create_dir_private(path: &Path) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::DirBuilderExt;
-        std::fs::DirBuilder::new().recursive(true).mode(0o700).create(path)
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::create_dir_all(path)
-    }
-}
-
-fn chmod(path: &Path, mode: u32) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-    use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (path, mode);
-        Ok(())
-    }
 }
 
 /// Claim a berth name for this process's lifetime. Unix uses flock so the

--- a/crates/pilot/Cargo.toml
+++ b/crates/pilot/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 # one request at a time buys nothing. Pilot is deliberately TLS-free; remote
 # human access goes through SSH, while Caddy serves HTTPS application clients.
 [dependencies]
+# Paths, names, the permission gate and the config schema — shared with harbor
+# so client and server cannot disagree about where anything lives.
+harbor-common = { path = "../common" }
 crossterm = "0.29.0"
 wire = { path = "../wire" }
 # OSC 11 background query for light/dark auto-detection: poll(2)+read(2) on the

--- a/crates/pilot/src/config.rs
+++ b/crates/pilot/src/config.rs
@@ -1,256 +1,108 @@
-//! The client address book: $HARBOR_HOME/config.toml (PLAN.md D10a).
+//! pilot's half of the config.
 //!
-//! Purely additive — zero-config local always works. The config only teaches
-//! pilot what the filesystem cannot reveal: remote urls, their credentials
-//! (never on argv: token-file or token-cmd), spawn aliases, and taste.
-//!
-//! `token-cmd` is run through `sh -c`, so the file is only read when it — and
-//! the directory holding it — is yours and unwritable by anyone else.
-//!
-//! ```toml
-//! [defaults]
-//! mode = "duckbox"
-//! timer = true
-//! theme = "duck"           # duck | mono | vivid
-//! appearance = "auto"      # auto | light | dark
-//!
-//! [connection.medlabs]
-//! url = "http://127.0.0.1:9495"
-//! token-file = "~/.config/harbor/runtime/medlabs.token"     # or token-cmd = "op read ..."
-//!
-//! [connection.scratch]
-//! path = "~/Data/scratch.duckdb"             # spawn-on-demand alias (D9)
-//! idle-exit = "10m"
-//! ```
+//! The schema, the roots and the trust check live in `harbor-common`, so the
+//! client and the server cannot drift on where config lives or what a berth
+//! is called. What stays here is the one thing that must not be shared:
+//! [`resolve_token`] runs `token-cmd` through `sh -c`, and harbor has no
+//! business linking a code path that shells out for a credential.
 
-use serde::Deserialize;
-use std::collections::HashMap;
+pub use harbor_common::config::{Connection, Defaults, FileConfig};
+pub use harbor_common::paths::expand;
 
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct FileConfig {
-    #[serde(default)]
-    pub defaults: Defaults,
-    #[serde(default)]
-    pub connection: HashMap<String, Connection>,
+use std::path::PathBuf;
+
+/// Where the live fleet is on disk. harbor creates and guards it; pilot only
+/// reads and writes inside it.
+///
+/// A `Result`, deliberately. The old version fell back to `"."` when no home
+/// variable was set, which meant pilot silently looked for sockets in a
+/// *relative* directory and found none — a failure that looked like an empty
+/// fleet rather than a broken environment.
+pub fn runtime_dir() -> Result<PathBuf, String> {
+    harbor_common::runtime_dir()
 }
 
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct Defaults {
-    pub mode: Option<String>,
-    pub timer: Option<bool>,
-    pub maxrows: Option<usize>,
-    pub nullvalue: Option<String>,
-    /// Syntax-highlight theme name: duck | mono | vivid (default duck).
-    pub theme: Option<String>,
-    /// Palette to build the theme for: auto | light | dark (default auto,
-    /// which asks the terminal for its background color).
-    pub appearance: Option<String>,
-}
-
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct Connection {
-    pub url: Option<String>,
-    pub path: Option<String>,
-    pub token: Option<String>,
-    pub token_file: Option<String>,
-    pub token_cmd: Option<String>,
-    pub idle_exit: Option<String>,
-}
-
-impl Connection {
-    /// flag > env beat the config; within it: token > token-file > token-cmd.
-    pub fn resolve_token(&self) -> Option<String> {
-        if let Some(t) = &self.token {
-            return Some(t.clone());
-        }
-        if let Some(f) = &self.token_file {
-            if let Ok(t) = std::fs::read_to_string(expand(f)) {
-                let t = t.trim().to_string();
-                if !t.is_empty() {
-                    return Some(t);
-                }
-            }
-        }
-        if let Some(cmd) = &self.token_cmd {
-            let out = std::process::Command::new("sh").arg("-c").arg(cmd).output().ok()?;
-            if out.status.success() {
-                let t = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                if !t.is_empty() {
-                    return Some(t);
-                }
-            }
-        }
-        None
-    }
-}
-
-/// The config root: $HARBOR_HOME, else ~/.config/harbor. Holds config.toml
-/// and the runtime/ dir.
-pub fn config_root() -> std::path::PathBuf {
-    if let Ok(h) = std::env::var("HARBOR_HOME") {
-        return std::path::PathBuf::from(h);
-    }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".into());
-    std::path::Path::new(&home).join(".config").join("harbor")
-}
-
-/// The runtime dir: $HARBOR_HOME/runtime — where the live fleet lives on
-/// disk (sockets, sidecars, tokens, history). harbor creates and guards it;
-/// pilot only reads and writes inside it.
-pub fn harbor_home() -> std::path::PathBuf {
-    config_root().join("runtime")
+/// The REPL history file, or nothing if there is no home to put it in — in
+/// which case the caller keeps history in memory and says so.
+pub fn history_file() -> Option<PathBuf> {
+    harbor_common::history_file().ok()
 }
 
 pub fn load() -> FileConfig {
-    load_from(&config_root())
+    harbor_common::config::load_or_empty("pilot")
 }
 
-fn load_from(root: &std::path::Path) -> FileConfig {
-    let path = root.join("config.toml");
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return FileConfig::default();
-    };
-    // Anyone who can rewrite this file is not editing settings, they are
-    // writing a program: `token-cmd` runs through `sh -c`, and `url` decides
-    // who receives the bearer token. So refuse it whole, the way ssh refuses
-    // a loose identity file, rather than trust it in part.
-    if let Some(bad) = [&path, &root.to_path_buf()].into_iter().find(|p| exposed(p)) {
-        let who = match *bad == path {
-            true => "it is".to_string(),
-            false => format!("{} is", bad.display()),
-        };
-        eprintln!(
-            "pilot: ignoring {} — {who} writable by others or not yours (chmod go-w it)",
-            path.display()
-        );
-        return FileConfig::default();
+/// flag > env beat the config; within it: token > token-file > token-cmd.
+pub fn resolve_token(c: &Connection) -> Option<String> {
+    if let Some(t) = &c.token {
+        return Some(t.clone());
     }
-    match toml::from_str(&text) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("pilot: {} is not valid: {e}", path.display());
-            FileConfig::default()
+    if let Some(f) = &c.token_file {
+        if let Ok(t) = std::fs::read_to_string(expand(f)) {
+            let t = t.trim().to_string();
+            if !t.is_empty() {
+                return Some(t);
+            }
         }
     }
-}
-
-/// True if someone other than us could swap this path's contents out from
-/// under us: group- or world-writable, or owned by another user. A sticky
-/// directory (/tmp) is writable by all but hijackable by none, so it passes.
-#[cfg(unix)]
-fn exposed(path: &std::path::Path) -> bool {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-    let Ok(md) = std::fs::metadata(path) else {
-        return false;
-    };
-    let mode = md.permissions().mode();
-    let sticky = md.is_dir() && mode & 0o1000 != 0;
-    let uid = unsafe { libc::getuid() };
-    (mode & 0o022 != 0 && !sticky) || (md.uid() != uid && md.uid() != 0)
-}
-
-#[cfg(not(unix))]
-fn exposed(_path: &std::path::Path) -> bool {
-    false
-}
-
-/// `~/` expansion, nothing fancier.
-pub fn expand(p: &str) -> std::path::PathBuf {
-    if let Some(rest) = p.strip_prefix("~/") {
-        if let Ok(h) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-            return std::path::Path::new(&h).join(rest);
+    if let Some(cmd) = &c.token_cmd {
+        let out = std::process::Command::new("sh").arg("-c").arg(cmd).output().ok()?;
+        if out.status.success() {
+            let t = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !t.is_empty() {
+                return Some(t);
+            }
         }
     }
-    std::path::PathBuf::from(p)
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn conn(toml_src: &str) -> Connection {
+        let c: FileConfig = toml::from_str(toml_src).unwrap();
+        c.connection.into_values().next().unwrap()
+    }
+
     #[test]
-    fn parses_the_documented_shape() {
-        let c: FileConfig = toml::from_str(
+    fn a_literal_token_beats_a_command_that_would_run() {
+        // If precedence ever inverted, this would shell out. It must not.
+        let c = conn(
             r#"
-            [defaults]
-            mode = "csv"
-            timer = true
-
-            [connection.medlabs]
-            url = "http://127.0.0.1:9495"
-            token-file = "~/.config/harbor/runtime/medlabs.token"
-
-            [connection.scratch]
-            path = "~/Data/scratch.duckdb"
-            idle-exit = "10m"
+            [connection.x]
+            url = "https://h"
+            token = "literal"
+            token-cmd = "exit 1"
             "#,
-        )
-        .unwrap();
-        assert_eq!(c.defaults.mode.as_deref(), Some("csv"));
-        assert_eq!(c.connection["medlabs"].url.as_deref(), Some("http://127.0.0.1:9495"));
-        assert_eq!(c.connection["scratch"].idle_exit.as_deref(), Some("10m"));
+        );
+        assert_eq!(resolve_token(&c), Some("literal".into()));
     }
 
     #[test]
-    fn empty_config_is_fine() {
-        let c: FileConfig = toml::from_str("").unwrap();
-        assert!(c.connection.is_empty());
-    }
-
-    #[cfg(unix)]
-    fn scratch(tag: &str) -> std::path::PathBuf {
-        let d = std::env::temp_dir().join(format!("pilot-cfg-{}-{tag}", std::process::id()));
-        std::fs::remove_dir_all(&d).ok();
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(
-            d.join("config.toml"),
-            "[connection.x]\nurl = \"http://127.0.0.1:1\"\ntoken-cmd = \"echo pwned\"\n",
-        )
-        .unwrap();
-        d
-    }
-
-    #[cfg(unix)]
-    fn chmod(p: &std::path::Path, mode: u32) {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(p, std::fs::Permissions::from_mode(mode)).unwrap();
+    fn token_cmd_is_the_last_resort_and_its_output_is_trimmed() {
+        let c = conn(
+            r#"
+            [connection.x]
+            url = "https://h"
+            token-cmd = "printf '  shelled  \n'"
+            "#,
+        );
+        assert_eq!(resolve_token(&c), Some("shelled".into()));
     }
 
     #[test]
-    #[cfg(unix)]
-    fn a_config_only_its_owner_can_write_is_used() {
-        let d = scratch("ok");
-        chmod(&d, 0o755);
-        chmod(&d.join("config.toml"), 0o644);
-        assert!(load_from(&d).connection.contains_key("x"));
-        std::fs::remove_dir_all(&d).ok();
+    fn a_failing_or_empty_token_cmd_yields_nothing() {
+        for cmd in ["exit 1", "printf ''", "printf '   '"] {
+            let c = conn(&format!("[connection.x]\nurl = \"https://h\"\ntoken-cmd = \"{cmd}\"\n"));
+            assert_eq!(resolve_token(&c), None, "{cmd:?}");
+        }
     }
 
     #[test]
-    #[cfg(unix)]
-    fn a_group_writable_config_is_refused_whole() {
-        let d = scratch("file");
-        chmod(&d, 0o755);
-        chmod(&d.join("config.toml"), 0o664);
-        // Not merely token-cmd: the whole file, url and all, is untrusted.
-        assert!(load_from(&d).connection.is_empty());
-        std::fs::remove_dir_all(&d).ok();
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn a_config_in_a_writable_directory_is_refused() {
-        // The file itself is tight, but the directory lets anyone replace it.
-        let d = scratch("dir");
-        chmod(&d.join("config.toml"), 0o600);
-        chmod(&d, 0o777);
-        assert!(load_from(&d).connection.is_empty());
-        chmod(&d, 0o755);
-        std::fs::remove_dir_all(&d).ok();
+    fn nothing_configured_is_not_an_error() {
+        let c = conn("[connection.x]\nurl = \"https://h\"\n");
+        assert_eq!(resolve_token(&c), None);
     }
 }

--- a/crates/pilot/src/main.rs
+++ b/crates/pilot/src/main.rs
@@ -188,7 +188,7 @@ fn resolve(cfg: &config::FileConfig, target: &str, flag_token: Option<String>) -
 
     // Explicit config entry shadows a same-named live berth (ssh_config rule).
     if let Some(entry) = cfg.connection.get(target) {
-        let home = config::harbor_home();
+        let home = config::runtime_dir()?;
         if berth_sock(&home, target).exists() {
             // Warn only when they actually diverge. When the entry's path IS
             // the database the live berth serves, following the config joins
@@ -210,7 +210,7 @@ fn resolve(cfg: &config::FileConfig, target: &str, flag_token: Option<String>) -
                 eprintln!("pilot: config entry {target:?} shadows a live local berth of the same name");
             }
         }
-        let token = flag_token.or(env_token).or_else(|| entry.resolve_token());
+        let token = flag_token.or(env_token).or_else(|| config::resolve_token(entry));
         if let Some(url) = &entry.url {
             return Ok(Conn { transport: url_transport(url)?, token });
         }
@@ -242,7 +242,7 @@ fn resolve(cfg: &config::FileConfig, target: &str, flag_token: Option<String>) -
         return Err("Unix socket targets are not supported on Windows; use a berth name or http://host:port".into());
     }
 
-    let home = config::harbor_home();
+    let home = config::runtime_dir()?;
     #[cfg(unix)]
     {
         let sock = berth_sock(&home, target);
@@ -345,7 +345,7 @@ fn ensure_berth(
     path: &std::path::Path,
     idle_exit: &str,
 ) -> Result<(Transport, Option<String>), String> {
-    let home = config::harbor_home();
+    let home = config::runtime_dir()?;
     let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
     // Already owned? The sidecar json says which berth claims this file.
@@ -420,7 +420,13 @@ fn fleet_hint(home: &std::path::Path) -> String {
 /// design, so this needs no tokens. Named config entries resolve on demand but
 /// are not merged into this list.
 fn list_fleet() -> ExitCode {
-    let home = config::harbor_home();
+    let home = match config::runtime_dir() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("pilot: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
     let berths = berth_entries(&home);
     if berths.is_empty() {
         println!("no live berths in {} (start one: harbor add <db>)", home.display());

--- a/crates/pilot/src/repl.rs
+++ b/crates/pilot/src/repl.rs
@@ -281,7 +281,7 @@ fn make_editor(completer: &SqlCompleter, vi: bool) -> Reedline {
         Box::new(Emacs::new(kb))
     };
     let menu = ColumnarMenu::default().with_name("completion_menu");
-    let history = crate::config::harbor_home().join("history");
+    let history = crate::config::history_file();
     Reedline::create()
         .with_validator(Box::new(SqlValidator))
         .with_highlighter(Box::new(crate::highlight::SqlHighlighter))
@@ -296,9 +296,9 @@ fn make_editor(completer: &SqlCompleter, vi: bool) -> Reedline {
             // in-memory history and say so, rather than .expect() panicking with
             // a backtrace before the prompt is even drawn.
             let history: Box<dyn reedline::History> =
-                match FileBackedHistory::with_file(1000, history) {
-                    Ok(h) => Box::new(h),
-                    Err(_) => {
+                match history.map(|p| FileBackedHistory::with_file(1000, p)) {
+                    Some(Ok(h)) => Box::new(h),
+                    _ => {
                         eprintln!("pilot: history file unavailable; using in-memory history");
                         Box::new(FileBackedHistory::default())
                     }


### PR DESCRIPTION
Both binaries had their own copies of "where does config live", "what is a
legal berth name" and "may I trust this file", and the copies disagreed. With
no `\$HOME` set, harbor refused to start while pilot silently resolved to
`./.config/harbor` and then looked for sockets in a relative directory — a
broken environment that presented as an empty fleet.

Sharing these needs a library between the binaries: harbor's own `[lib]` is the
DuckDB engine and pilot must never link it (D8), and `wire`'s manifest says
types and codes only, no I/O. So a third crate is the only place left.

## `crates/common` (package `harbor-common`)

Paths, the permission gate, the config schema, berth lifetimes, berth states,
and the terminal renderer. Nothing that spawns, shells out, or links an engine:
every line here also runs inside the process holding an exclusive write lock on
a database.

**Two roots instead of one.** Config is `~/.config/harbor/config.toml`; state is
`~/.local/state/harbor/`, where sockets, locks, logs and the REPL history
belong and where deleting the directory is a supported act rather than a
surprise. `\$HARBOR_HOME`, when absolute, still collapses both into one
directory for tests and containers. A relative value is now ignored rather than
resolved, because a relative state root moves the fleet with the working
directory.

**One config namespace**, so "where do I configure medlabs" has one answer: an
entry with a `path` is a local berth, one with a `url` is a remote, and one
with both is reported rather than guessed at. The berth's name is the section
key and never the database file's stem — which is how `[connection.warehouse]`
pointing at `inventory.duckdb` used to produce a berth called `inventory` that
no alias could reach.

**Lifetime is one knob with a resolution order**, not three modes: a flag, then
the entry, then the defaults, then who asked. The invariant that makes it safe
is that a client which *joins* a running berth never changes its lifetime; only
the client that *summoned* one sets it. Without that, closing a ducktable
window would take down a berth someone else is using.

**State is meaning, not color.** `State::level()` returns Idle/Good/Warn/Bad and
each front end maps that to its own palette, so the ANSI sits behind the default
`term` feature and a GUI takes `default-features = false`. The renderer
sanitizes every string from disk before measuring it: a database path carrying
an escape sequence cannot repaint a terminal or forge a table row. Widths are
counted in terminal cells, so a path with CJK in it does not shear a column.
`NO_COLOR` and `TERM=dumb` are honored, neither of which was true anywhere
before.

`doctor` lives in harbor, not here — harbor audits, pilot connects. Its rule is
that it reports only what nothing else has a moment to notice: a misspelled key
is the parser's job, but two berths naming one database is nobody's, and DuckDB
takes a single writer. Every finding carries a fix, with a test that refuses to
let a complaint in without one.

## Both binaries now run on it

Nothing named `config_root`, `normalize`, `write_private`, `create_dir_private`,
`chmod`, `parse_duration` or `exposed` survives in either. `pilot`'s
`runtime_dir()` returns a `Result` and its callers handle it; the REPL's history
path is an `Option`, and no home simply means history stays in memory.

`resolve_token` deliberately did not move. It runs `token-cmd` through `sh -c`,
and harbor has no business linking a code path that shells out for a credential.

## Verified

157 cargo tests and all 11 integration suites (unit, asserts, types, spec, fuzz,
deployment, stress, hostile, catalog, sessions, cancel).

End to end, not just compiled: a berth started by the release binaries lands in
`~/.local/state/harbor/runtime` with both directories 0700, its token 0600 and
its socket `srw-------`, and pilot resolves it by name and queries it. The live
`medlabs` berth was stopped cleanly (WAL checkpointed), the binaries installed
to `~/.local/bin`, and medlabs brought back up on the new paths and queried.

## Not in this PR

The verbs that consume the crate — `show`, `forget`, `doctor`, and `start`
reading config. Those consume the API rather than change it.