### PR TITLE
Harbor 0.30.0 and DuckTable 0.17.0: managed SSH tunnels

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "harbor-common",
  "serde",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/README.md
+++ b/ducktable/README.md
@@ -54,6 +54,41 @@ Uninstall with `... | bash -s -- --uninstall` — the app goes; your settings
 On Intel, or to build from source: clone the repo and run
 `ducktable/scripts/macos-app.sh release`.
 
+## Databases by port
+
+Choose **File → Add Database…** when Harbor is already listening on a TCP
+port. Give the database a sidebar name, host, and Harbor port. `localhost`
+connects directly; any other host makes DuckTable create the SSH tunnel:
+
+```text
+Name         Production
+Host         foo.bar.com
+Harbor port  9494
+```
+
+DuckTable asks macOS's `/usr/bin/ssh` to forward an arbitrary local IPv4
+loopback port to `127.0.0.1:9494` as seen from `foo.bar.com`, then speaks Harbor
+through that local port. SSH runs unattended and honors `~/.ssh/config`, keys,
+certificates, ProxyJump, ssh-agent, and the macOS Keychain. Run `ssh
+foo.bar.com` once in Terminal if a host key or login still needs confirmation.
+
+The SSH process belongs to that database connection. It uses protocol
+keepalives, stays alive while queries still hold the connection, and is closed
+and reaped when the database is closed, removed, replaced by another database,
+or DuckTable exits. Removing the sidebar entry forgets only its connection
+details; it never changes the database server.
+
+The saved form is intentionally small:
+
+```toml
+[connection.production]
+url = "http://foo.bar.com:9494"
+```
+
+For a local listener, save `http://localhost:9494`; DuckTable normalizes that
+to IPv4 `127.0.0.1` when connecting. Use **File → Open Database File…** when
+starting from a DuckDB filename instead of a Harbor port.
+
 ## Why Harbor-only
 
 - One wire protocol, one type system, one EXPLAIN dialect.

--- a/ducktable/crates/ducktable/src/add_database.rs
+++ b/ducktable/crates/ducktable/src/add_database.rs
@@ -1,0 +1,88 @@
+//! File → Add Database: save a Harbor host and port under a sidebar name.
+//! Localhost connects directly; any other host is reached through SSH.
+
+use crate::app::DuckTable;
+use gpui::{
+    App, AppContext as _, ParentElement as _, Styled as _, WeakEntity, Window, div,
+    prelude::FluentBuilder as _,
+};
+use gpui_component::dialog::DialogButtonProps;
+use gpui_component::form::{field, v_form};
+use gpui_component::input::{Input, InputState};
+use gpui_component::{ActiveTheme as _, WindowExt as _};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) fn open(view: WeakEntity<DuckTable>, window: &mut Window, cx: &mut App) {
+    let name = cx.new(|cx| InputState::new(window, cx).placeholder("Production"));
+    let host = cx.new(|cx| InputState::new(window, cx).default_value("localhost"));
+    let port = cx.new(|cx| InputState::new(window, cx).default_value("9495"));
+    let error = Rc::new(RefCell::new(None::<String>));
+
+    window.open_dialog(cx, {
+        let name = name.clone();
+        let host = host.clone();
+        let port = port.clone();
+        let error = Rc::clone(&error);
+        move |dialog, _window, cx| {
+            let form = v_form()
+                .child(
+                    field()
+                        .label("Name")
+                        .description("How this database appears in the sidebar")
+                        .required(true)
+                        .child(Input::new(&name)),
+                )
+                .child(
+                    field()
+                        .label("Host")
+                        .description("localhost connects directly; another host connects over SSH")
+                        .required(true)
+                        .child(Input::new(&host)),
+                )
+                .child(
+                    field()
+                        .label("Harbor port")
+                        .description("The Harbor listener on that host")
+                        .required(true)
+                        .child(Input::new(&port)),
+                );
+
+            dialog
+                .title("Add Database")
+                .confirm()
+                .button_props(DialogButtonProps::default().ok_text("Add Database"))
+                .child(form)
+                .when_some(error.borrow().clone(), |dialog, message| {
+                    dialog.child(div().text_sm().text_color(cx.theme().danger).child(message))
+                })
+                .on_ok({
+                    let name = name.clone();
+                    let host = host.clone();
+                    let port = port.clone();
+                    let error = Rc::clone(&error);
+                    let view = view.clone();
+                    move |_, window, cx| {
+                        let name = name.read(cx).value().to_string();
+                        let host = host.read(cx).value().to_string();
+                        let port = port.read(cx).value().to_string();
+                        if let Err(message) = harbor_client::fleet::validate_database(
+                            &name,
+                            &host,
+                            &port,
+                        ) {
+                            *error.borrow_mut() = Some(message);
+                            window.refresh();
+                            return false;
+                        }
+                        if let Some(view) = view.upgrade() {
+                            view.update(cx, |app, cx| {
+                                app.add_database(name, host, port, cx);
+                            });
+                        }
+                        true
+                    }
+                })
+        }
+    });
+}

--- a/ducktable/crates/ducktable/src/app.rs
+++ b/ducktable/crates/ducktable/src/app.rs
@@ -443,6 +443,10 @@ impl DuckTable {
                 .map(|row| {
                     let known = connected.clone();
                     cx.background_executor().spawn(async move {
+                        let connected_here = matches!(
+                            &known,
+                            Some((name, _)) if *name == row.name
+                        );
                         let tables = match &known {
                             Some((name, count)) if *name == row.name => Some(*count),
                             _ => row
@@ -458,7 +462,7 @@ impl DuckTable {
                                 .flatten(),
                         };
                         RowVm {
-                            state: row.state,
+                            state: if connected_here { State::Running } else { row.state },
                             attached: row.attached,
                             autostart: row.autostart,
                             path: row.path,
@@ -509,7 +513,7 @@ impl DuckTable {
                 // cleanly and point the way back, rather than leaving a dead
                 // connection to fail the next catalog or query with an OS error.
                 let connected = match &state.phase {
-                    Phase::Connected { info, .. } => Some(clone_str(&info.name)),
+                    Phase::Connected { conn, .. } => Some(clone_str(&conn.name)),
                     _ => None,
                 };
                 if let Some(name) = connected
@@ -609,6 +613,44 @@ impl DuckTable {
             },
             cx,
         );
+    }
+
+    /// File → Add Database: persist the named Harbor port, then connect
+    /// through the same path a sidebar click uses. A failed dial still leaves
+    /// the database saved so Retry has something durable to target.
+    pub(crate) fn add_database(
+        &mut self,
+        name: String,
+        host: String,
+        port: String,
+        cx: &mut Context<Self>,
+    ) {
+        let shown = harbor_client::paths::normalize(&name).unwrap_or(name);
+        self.dial(
+            clone_str(&shown),
+            move || {
+                let name = fleet::add_database(&shown, &host, &port)?;
+                let conn = fleet::connect(&name)?;
+                let info = fleet::info(&conn)?;
+                let catalog = harbor_client::catalog(&conn)?;
+                Ok((conn, info, catalog))
+            },
+            cx,
+        );
+    }
+
+    /// Forget a port-based database and close its tunnel if it is the one on
+    /// screen. No remote shutdown is sent: removing connection details must
+    /// never mutate the database they point at.
+    pub(crate) fn remove_remote_database(&mut self, name: String, cx: &mut Context<Self>) {
+        let connected_here = matches!(
+            &self.phase,
+            Phase::Connected { conn, .. } if conn.name == name
+        );
+        if connected_here {
+            self.drop_connection(cx);
+        }
+        self.fleet_then_refresh(move || fleet::remove_remote(&name), cx);
     }
 
     /// The shared spine of connect / open_path: show `shown` as the connecting

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -3,6 +3,7 @@
 //! file (`app.rs` state, `sidebar.rs`, `content.rs`, `theme.rs`).
 
 mod app;
+mod add_database;
 mod chrome;
 mod content;
 mod copy_button;
@@ -27,7 +28,7 @@ actions!(
     [
         ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, TablePrev,
         TableNext, View1, View2, View3, ToggleFullScreen, ToggleRowNumbers, ToggleRightAlign,
-        ToggleNullTags, OpenDatabase
+        ToggleNullTags, OpenDatabase, AddDatabase
     ]
 );
 
@@ -80,6 +81,14 @@ pub struct DetachBerth {
 pub struct ToggleAutostart {
     pub path: String,
     pub on: bool,
+}
+
+/// Remove a saved port-based database. This forgets only its connection
+/// details; it never reaches the database server itself.
+#[derive(Clone, Default, PartialEq, Debug, Action)]
+#[action(namespace = ducktable, no_json)]
+pub struct RemoveRemoteDatabase {
+    pub name: String,
 }
 
 /// ⌥←/⌥→: the previous/next table in the sidebar (App::step_table).
@@ -159,7 +168,8 @@ fn app_menus() -> Vec<Menu> {
             items: vec![
                 // The platform picker, then the same door a drop uses.
                 // ⌘O advertises itself from the keymap binding.
-                MenuItem::action("Open Database…", OpenDatabase),
+                MenuItem::action("Open Database File…", OpenDatabase),
+                MenuItem::action("Add Database…", AddDatabase),
             ],
         },
         // macOS shows each item's key equivalent from the keymap, so this
@@ -410,6 +420,16 @@ fn main() {
             })
             .detach();
         });
+        cx.on_action(|_: &AddDatabase, cx| {
+            let view = cx.try_global::<AppView>().map(|v| v.0.clone());
+            cx.defer(move |cx| {
+                let Some(view) = view else { return };
+                if let Some(w) = cx.active_window() {
+                    w.update(cx, |_, window, cx| add_database::open(view, window, cx))
+                        .ok();
+                }
+            });
+        });
         // Right-click → Stop. Reaches the view through AppView (the menu
         // fires at App level) and defers, the FitColumns pattern — a menu
         // action arrives inside the window's update, so the view is touched
@@ -452,6 +472,14 @@ fn main() {
             if let Some(view) = cx.try_global::<AppView>().and_then(|v| v.0.upgrade()) {
                 cx.defer(move |cx| {
                     view.update(cx, |this, cx| this.toggle_autostart(path, on, cx));
+                });
+            }
+        });
+        cx.on_action(|a: &RemoveRemoteDatabase, cx| {
+            let name = a.name.clone();
+            if let Some(view) = cx.try_global::<AppView>().and_then(|v| v.0.upgrade()) {
+                cx.defer(move |cx| {
+                    view.update(cx, |this, cx| this.remove_remote_database(name, cx));
                 });
             }
         });

--- a/ducktable/crates/ducktable/src/sidebar.rs
+++ b/ducktable/crates/ducktable/src/sidebar.rs
@@ -280,13 +280,15 @@ impl DuckTable {
                             let path =
                                 row.path.as_ref().map(|p| p.to_string_lossy().into_owned());
                             move |menu, _, _| {
-                                // A remote has no local file, so no lifecycle —
-                                // only a (no-op) Stop, as the menu had before.
+                                // A remote has no local server lifecycle. Its
+                                // one operation forgets the saved connection;
+                                // dropping the active Conn also closes SSH.
                                 let Some(path) = path.clone() else {
-                                    return menu.menu_with_disabled(
-                                        "Stop",
-                                        Box::new(StopBerth { name: clone_str(&name) }),
-                                        !running,
+                                    return menu.menu(
+                                        "Remove Database",
+                                        Box::new(crate::RemoveRemoteDatabase {
+                                            name: clone_str(&name),
+                                        }),
                                     );
                                 };
                                 // Running axis: exactly one of Start / Stop.

--- a/ducktable/crates/harbor-client/examples/open-path.rs
+++ b/ducktable/crates/harbor-client/examples/open-path.rs
@@ -19,7 +19,7 @@ fn main() {
     // ephemeral server we summoned, we stop.
     if conn.summoned {
         harbor_client::http::request(
-            &conn.transport,
+            conn.transport().expect("transport"),
             &wire::endpoint::SHUTDOWN,
             None,
             Some(std::time::Duration::from_secs(5)),

--- a/ducktable/crates/harbor-client/src/catalog.rs
+++ b/ducktable/crates/harbor-client/src/catalog.rs
@@ -103,7 +103,7 @@ pub fn catalog_lite(conn: &Conn) -> Result<Catalog, String> {
 
 fn fetch(conn: &Conn, route: &wire::endpoint::Route) -> Result<Catalog, String> {
     let r = request(
-        &conn.transport,
+        conn.transport()?,
         route,
         None,
         Some(Duration::from_secs(15)),

--- a/ducktable/crates/harbor-client/src/fleet.rs
+++ b/ducktable/crates/harbor-client/src/fleet.rs
@@ -20,7 +20,10 @@ use crate::http::{Transport, request};
 use harbor_common::State;
 use harbor_common::config;
 use harbor_common::paths::{self, runtime_dir};
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// One sidebar row: a database's honest state, plus the size on disk only
@@ -220,7 +223,14 @@ pub fn survey() -> Fleet {
         if out.iter().any(|s| s.name == name) {
             continue;
         }
-        let transport = entry.url.as_deref().and_then(|u| url_transport(u).ok());
+        // Surveying must never open SSH sessions. A tunneled database is
+        // dialed only when the user selects it; while selected, app.rs folds
+        // the already-connected phase back into this row as Running.
+        let target = entry.url.as_deref().and_then(|url| http_target(url).ok());
+        let transport = target
+            .as_ref()
+            .filter(|target| target.is_local())
+            .map(|target| Transport::Tcp(target.addr()));
         let alive = transport.as_ref().is_some_and(probe);
         // Best-effort version, so the card can note a remote running behind
         // your own binary. Informational only — you cannot restart a remote
@@ -235,7 +245,10 @@ pub fn survey() -> Fleet {
             attached: true,
             autostart: false, // a remote has no local login item
             path: None,
-            note: None,
+            note: target
+                .as_ref()
+                .filter(|target| !target.is_local())
+                .map(|target| format!("Connects over SSH to {}", target.host)),
             size: None,
             version,
             ephemeral: false,
@@ -270,12 +283,33 @@ fn sock_ready(sock: &Path) -> bool {
 #[derive(Clone)]
 pub struct Conn {
     pub name: String,
-    pub transport: Transport,
+    transport: Transport,
     /// True when this connect raised the server (worth a status line).
     /// A summoned server is an ephemeral `start` — it self-retires once its
     /// last client disconnects, so closing the window that opened it lets it
     /// go. The explicit Start action is the way to keep a server up.
     pub summoned: bool,
+    /// Every clone participating in this database connection shares the
+    /// tunnel. The final clone closes SSH, so an in-flight query cannot lose
+    /// its route merely because the window switched databases.
+    tunnel: Option<Arc<SshTunnel>>,
+}
+
+impl Conn {
+    fn plain(name: String, transport: Transport, summoned: bool) -> Self {
+        Self { name, transport, summoned, tunnel: None }
+    }
+
+    fn tunneled(name: String, transport: Transport, tunnel: SshTunnel) -> Self {
+        Self { name, transport, summoned: false, tunnel: Some(Arc::new(tunnel)) }
+    }
+
+    pub fn transport(&self) -> Result<&Transport, String> {
+        if let Some(tunnel) = &self.tunnel {
+            tunnel.ensure_running()?;
+        }
+        Ok(&self.transport)
+    }
 }
 
 /// Resolution: config entry (url, else spawn-or-join the path's server),
@@ -294,7 +328,13 @@ pub fn connect(name: &str) -> Result<Conn, String> {
             return Err(format!("config entry {name:?} needs exactly one of url or path"));
         }
         if let Some(url) = &entry.url {
-            return Ok(Conn { name, transport: url_transport(url)?, summoned: false });
+            let target = http_target(url)?;
+            if !target.is_local() {
+                validate_ssh_host(&target.host)?;
+                let (transport, tunnel) = open_tunnel(&target.host, target.port)?;
+                return Ok(Conn::tunneled(name, transport, tunnel));
+            }
+            return Ok(Conn::plain(name, Transport::Tcp(target.addr()), false));
         }
         let db = entry
             .database()
@@ -307,14 +347,14 @@ pub fn connect(name: &str) -> Result<Conn, String> {
         let sock21 = paths::socket_for(&home, &db)?;
         let sock19 = paths::sock_file(&home, &name);
         let join = |summoned: bool| {
-            [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn {
-                name: name.clone(),
+            [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn::plain(
+                name.clone(),
                 #[cfg(unix)]
-                transport: Transport::Unix(s.clone()),
+                Transport::Unix(s.clone()),
                 #[cfg(not(unix))]
-                transport: Transport::Tcp(String::new()),
+                Transport::Tcp(String::new()),
                 summoned,
-            })
+            ))
         };
         if let Some(conn) = join(false) {
             return Ok(conn);
@@ -344,11 +384,11 @@ pub fn connect(name: &str) -> Result<Conn, String> {
     if let Some(l) = discover().into_iter().find(|l| l.name == name) {
         #[cfg(unix)]
         {
-            return Ok(Conn {
+            return Ok(Conn::plain(
                 name,
-                transport: Transport::Unix(l.sock),
-                summoned: false,
-            });
+                Transport::Unix(l.sock),
+                false,
+            ));
         }
     }
     Err(format!(
@@ -376,14 +416,14 @@ pub fn connect_path(db: &Path) -> Result<Conn, String> {
     let sock21 = paths::socket_for(&home, &db)?;
     let sock19 = paths::sock_file(&home, &name);
     let join = |summoned: bool| {
-        [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn {
-            name: name.clone(),
+        [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn::plain(
+            name.clone(),
             #[cfg(unix)]
-            transport: Transport::Unix(s.clone()),
+            Transport::Unix(s.clone()),
             #[cfg(not(unix))]
-            transport: Transport::Tcp(String::new()),
+            Transport::Tcp(String::new()),
             summoned,
-        })
+        ))
     };
     if let Some(conn) = join(false) {
         return Ok(conn);
@@ -612,25 +652,275 @@ fn summon(db: &Path, ephemeral: bool) -> Result<(), String> {
     Ok(())
 }
 
-fn url_transport(url: &str) -> Result<Transport, String> {
-    if let Some(rest) = url.strip_prefix("http://") {
-        let (addr, extra) = rest.split_once('/').map_or((rest, ""), |(a, p)| (a, p));
-        if !extra.is_empty() {
-            return Err("path-prefixed HTTP targets are not supported".into());
-        }
-        let addr = if addr.contains(':') { addr.to_string() } else { format!("{addr}:9495") };
-        return Ok(Transport::Tcp(addr));
+#[derive(Debug, PartialEq, Eq)]
+struct HttpTarget {
+    host: String,
+    port: u16,
+}
+
+impl HttpTarget {
+    fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
     }
+
+    fn is_local(&self) -> bool {
+        self.host == "127.0.0.1"
+    }
+}
+
+/// The deliberately small URL grammar Harbor speaks: plain HTTP, one host,
+/// one optional port, and no path. IPv6 literals are outside DuckTable's
+/// transport contract; Harbor's TCP door is IPv4-only.
+fn http_target(url: &str) -> Result<HttpTarget, String> {
     if url.starts_with("https://") {
         return Err("TLS terminates in front of Harbor; use http:// or the socket".into());
     }
-    Err(format!("not a url: {url}"))
+    let rest = url
+        .strip_prefix("http://")
+        .ok_or_else(|| format!("not a url: {url}"))?;
+    if rest.contains(['/', '?', '#']) {
+        return Err("path-prefixed HTTP targets are not supported".into());
+    }
+    if rest.is_empty() {
+        return Err("database address has no host".into());
+    }
+    if rest.matches(':').count() > 1 || rest.starts_with('[') {
+        return Err("IPv6 database addresses are not supported".into());
+    }
+    let (host, port) = match rest.rsplit_once(':') {
+        Some((host, port)) => {
+            let port = port.parse::<u16>().map_err(|_| format!("bad port in {url}"))?;
+            if port == 0 {
+                return Err("database port must be between 1 and 65535".into());
+            }
+            (host, port)
+        }
+        None => (rest, 9495),
+    };
+    if host.is_empty() || host.chars().any(char::is_whitespace) {
+        return Err("database address has an invalid host".into());
+    }
+    let host = if host.eq_ignore_ascii_case("localhost") {
+        "127.0.0.1".to_string()
+    } else {
+        host.to_string()
+    };
+    Ok(HttpTarget { host, port })
+}
+
+/// One app-owned OpenSSH process. It is shared by every clone of its Conn;
+/// the last clone kills and reaps it, which binds tunnel lifetime to the
+/// matching database connection without a global registry.
+struct SshTunnel {
+    child: Mutex<Child>,
+    stderr: Arc<Mutex<Vec<u8>>>,
+    host: String,
+}
+
+impl SshTunnel {
+    fn ensure_running(&self) -> Result<(), String> {
+        let mut child = self.child.lock().map_err(|_| "SSH process lock failed")?;
+        match child.try_wait().map_err(|e| format!("checking SSH to {}: {e}", self.host))? {
+            None => Ok(()),
+            Some(status) => Err(ssh_failure(&self.host, status.to_string(), &self.stderr)),
+        }
+    }
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        if let Ok(child) = self.child.get_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn ssh_failure(host: &str, status: String, stderr: &Arc<Mutex<Vec<u8>>>) -> String {
+    let detail = stderr
+        .lock()
+        .ok()
+        .map(|bytes| String::from_utf8_lossy(&bytes).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!("ssh exited with {status}"));
+    format!(
+        "SSH connection to {host} failed: {detail}\n\nVerify the connection in Terminal:\n    ssh {host}"
+    )
+}
+
+fn ssh_command(ssh_host: &str, remote_port: u16, local_port: u16) -> Command {
+    let mut command = Command::new("/usr/bin/ssh");
+    command
+        .arg("-N")
+        .arg("-T")
+        .arg("-S")
+        .arg("none")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ExitOnForwardFailure=yes")
+        .arg("-o")
+        .arg("ServerAliveInterval=15")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3")
+        .arg("-o")
+        .arg("TCPKeepAlive=yes")
+        .arg("-L")
+        .arg(format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"))
+        .arg(ssh_host)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn capture_stderr(mut pipe: impl Read + Send + 'static, captured: Arc<Mutex<Vec<u8>>>) {
+    std::thread::spawn(move || {
+        let mut buf = [0_u8; 1024];
+        while let Ok(n) = pipe.read(&mut buf) {
+            if n == 0 {
+                break;
+            }
+            let Ok(mut out) = captured.lock() else { break };
+            let room = (64_usize * 1024).saturating_sub(out.len());
+            out.extend_from_slice(&buf[..n.min(room)]);
+        }
+    });
+}
+
+fn open_tunnel(ssh_host: &str, remote_port: u16) -> Result<(Transport, SshTunnel), String> {
+    for attempt in 0..5 {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+            .map_err(|e| format!("choosing a local SSH port: {e}"))?;
+        let local_port = listener
+            .local_addr()
+            .map_err(|e| format!("reading the local SSH port: {e}"))?
+            .port();
+        drop(listener);
+
+        let mut child = ssh_command(ssh_host, remote_port, local_port)
+            .spawn()
+            .map_err(|e| format!("cannot run /usr/bin/ssh: {e}"))?;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        if let Some(stderr) = child.stderr.take() {
+            capture_stderr(stderr, Arc::clone(&captured));
+        }
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|e| format!("checking SSH to {ssh_host}: {e}"))?
+            {
+                // Let the stderr reader consume the final bytes before the
+                // diagnostic is built.
+                std::thread::sleep(Duration::from_millis(10));
+                let message = ssh_failure(ssh_host, status.to_string(), &captured);
+                let port_race = message.contains("Address already in use")
+                    || message.contains("cannot listen to port");
+                if port_race && attempt < 4 {
+                    break;
+                }
+                return Err(message);
+            }
+            let addr = std::net::SocketAddrV4::new(std::net::Ipv4Addr::LOCALHOST, local_port);
+            if std::net::TcpStream::connect_timeout(&addr.into(), Duration::from_millis(100))
+                .is_ok()
+            {
+                return Ok((
+                    Transport::Tcp(format!("127.0.0.1:{local_port}")),
+                    SshTunnel {
+                        child: Mutex::new(child),
+                        stderr: captured,
+                        host: ssh_host.to_string(),
+                    },
+                ));
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "SSH connection to {} timed out\n\nVerify the connection in Terminal:\n    ssh {}",
+                    ssh_host, ssh_host
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+    Err("could not allocate a local SSH port after five attempts".into())
+}
+
+/// Validate and persist the dialog's port-based database without opening its
+/// network connection. The returned name is the normalized sidebar identity.
+pub fn add_database(name: &str, host: &str, port: &str) -> Result<String, String> {
+    let name = harbor_common::normalize(name)?;
+    let url = database_url(host, port)?;
+    harbor_common::membership::add_remote(&name, &url)
+}
+
+/// Remove only a configured remote. The kind check prevents a stale UI action
+/// from ever deleting a local database's membership entry.
+pub fn remove_remote(name: &str) -> Result<(), String> {
+    let name = harbor_common::normalize(name)?;
+    let cfg = load_config()?;
+    match cfg.get(&name) {
+        None => return Ok(()),
+        Some(entry) if entry.kind() == config::Kind::Remote => {}
+        Some(_) => return Err(format!("'{name}' is not a port-based database")),
+    }
+    harbor_common::membership::remove_named(&name).map(|_| ())
+}
+
+pub fn validate_database(name: &str, host: &str, port: &str) -> Result<(), String> {
+    let name = harbor_common::normalize(name)?;
+    database_url(host, port)?;
+    if load_config()?.get(&name).is_some() {
+        return Err(format!("'{name}' already exists — choose another name"));
+    }
+    Ok(())
+}
+
+fn database_url(host: &str, port: &str) -> Result<String, String> {
+    let host = host.trim();
+    if host.is_empty() {
+        return Err("Host is required".into());
+    }
+    let port = harbor_port(port)?;
+    let local = host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1";
+    if !local {
+        validate_ssh_host(host)?;
+    }
+    let host = if local { "localhost" } else { host };
+    let url = format!("http://{host}:{port}");
+    http_target(&url)?;
+    Ok(url)
+}
+
+fn harbor_port(port: &str) -> Result<u16, String> {
+    let port = port.trim();
+    let parsed = port
+        .parse::<u16>()
+        .map_err(|_| "Harbor port must be between 1 and 65535".to_string())?;
+    if parsed == 0 {
+        return Err("Harbor port must be between 1 and 65535".into());
+    }
+    Ok(parsed)
+}
+
+fn validate_ssh_host(host: &str) -> Result<(), String> {
+    if host.is_empty() {
+        return Err("SSH host is empty".into());
+    }
+    if host.starts_with('-') || host.chars().any(char::is_whitespace) {
+        return Err("SSH host must be a host, SSH alias, or user@host".into());
+    }
+    Ok(())
 }
 
 /// `GET /info` — server identity, for the inspector's Metadata section.
 pub fn info(conn: &Conn) -> Result<wire::InfoResponse, String> {
     let r = request(
-        &conn.transport,
+        conn.transport()?,
         &wire::endpoint::INFO,
         None,
         Some(Duration::from_secs(5)),
@@ -656,10 +946,87 @@ mod tests {
     // shared with harbor itself — no client-side copy to drift.
 
     #[test]
-    fn url_transport_defaults_the_port_and_refuses_tls() {
-        assert!(matches!(url_transport("http://box").unwrap(), Transport::Tcp(a) if a == "box:9495"));
-        assert!(matches!(url_transport("http://box:9600").unwrap(), Transport::Tcp(a) if a == "box:9600"));
-        assert!(url_transport("https://box").is_err());
-        assert!(url_transport("http://box/api").is_err());
+    fn http_target_defaults_the_port_normalizes_localhost_and_refuses_tls() {
+        let local = http_target("http://localhost").unwrap();
+        assert_eq!(local.addr(), "127.0.0.1:9495");
+        assert!(local.is_local());
+        assert_eq!(http_target("http://box:9600").unwrap().addr(), "box:9600");
+        assert!(http_target("https://box").is_err());
+        assert!(http_target("http://box/api").is_err());
+        assert!(http_target("http://[::1]:9495").is_err());
+    }
+
+    #[test]
+    fn ssh_command_is_loopback_only_unattended_and_owned() {
+        let command = ssh_command("foo.bar.com", 9494, 53172);
+        assert_eq!(command.get_program(), "/usr/bin/ssh");
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.windows(2).any(|a| a == ["-S", "none"]));
+        assert!(args.windows(2).any(|a| a == ["-o", "BatchMode=yes"]));
+        assert!(args.windows(2).any(|a| a == ["-o", "ExitOnForwardFailure=yes"]));
+        assert!(args.windows(2).any(|a| a == ["-o", "ServerAliveInterval=15"]));
+        assert!(args.windows(2).any(|a| a == ["-o", "ServerAliveCountMax=3"]));
+        assert!(args.windows(2).any(|a| a == ["-o", "TCPKeepAlive=yes"]));
+        assert!(args.windows(2).any(|a| {
+            a == ["-L", "127.0.0.1:53172:127.0.0.1:9494"]
+        }));
+        assert_eq!(args.last().map(String::as_str), Some("foo.bar.com"));
+    }
+
+    #[test]
+    fn database_form_accepts_only_a_real_port_and_safe_host() {
+        assert_eq!(harbor_port("9494"), Ok(9494));
+        assert!(harbor_port("0").is_err());
+        assert!(harbor_port("65536").is_err());
+        assert!(validate_ssh_host("deploy@warehouse").is_ok());
+        assert!(validate_ssh_host("").is_err());
+        assert!(validate_ssh_host("-oProxyCommand=bad").is_err());
+        assert!(validate_ssh_host("two hosts").is_err());
+        assert_eq!(database_url("localhost", "9495").unwrap(), "http://localhost:9495");
+        assert_eq!(database_url("127.0.0.1", "9495").unwrap(), "http://localhost:9495");
+        assert_eq!(
+            database_url("deploy@warehouse", "9494").unwrap(),
+            "http://deploy@warehouse:9494"
+        );
+    }
+
+    #[test]
+    fn the_url_host_selects_direct_or_ssh_transport() {
+        assert!(http_target("http://localhost:9495").unwrap().is_local());
+        assert!(http_target("http://127.0.0.1:9495").unwrap().is_local());
+        assert!(!http_target("http://foo.bar.com:9494").unwrap().is_local());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_last_connection_clone_closes_its_ssh_process() {
+        let exists = |pid: &str| {
+            Command::new("/bin/kill")
+                .args(["-0", pid])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap()
+                .success()
+        };
+        let child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let pid = child.id().to_string();
+        let conn = Conn::tunneled(
+            "remote".into(),
+            Transport::Tcp("127.0.0.1:1".into()),
+            SshTunnel {
+                child: Mutex::new(child),
+                stderr: Arc::new(Mutex::new(Vec::new())),
+                host: "remote".into(),
+            },
+        );
+        let last = conn.clone();
+        drop(conn);
+        assert!(exists(&pid));
+        drop(last);
+        assert!(!exists(&pid));
     }
 }

--- a/ducktable/crates/harbor-client/src/query.rs
+++ b/ducktable/crates/harbor-client/src/query.rs
@@ -39,7 +39,7 @@ pub fn exec(
     })
     .map_err(|e| e.to_string())?;
     let resp = http::request(
-        &conn.transport,
+        conn.transport()?,
         &endpoint::SQL,
         Some(&body),
         Some(Duration::from_secs(120)),
@@ -82,9 +82,10 @@ pub fn exec(
 /// requests. Release it with [`session_release`] — which rolls back
 /// anything uncommitted, so an abandoned session can never half-commit.
 pub fn session_new(conn: &Conn) -> Result<String, String> {
+    let transport = conn.transport()?;
     let open = |route: &wire::endpoint::Route| {
         http::request(
-            &conn.transport,
+            transport,
             route,
             Some("{}"),
             Some(Duration::from_secs(10)),
@@ -114,10 +115,12 @@ pub fn session_new(conn: &Conn) -> Result<String, String> {
 /// transaction. Best-effort by design: the server's TTL reaps what a
 /// dropped connection leaves behind.
 pub fn session_release(conn: &Conn, session_id: &str) {
-    let _ = http::request(
-        &conn.transport,
-        &endpoint::session(session_id),
-        None,
-        Some(Duration::from_secs(10)),
-    );
+    if let Ok(transport) = conn.transport() {
+        let _ = http::request(
+            transport,
+            &endpoint::session(session_id),
+            None,
+            Some(Duration::from_secs(10)),
+        );
+    }
 }

--- a/ducktable/docs/DESIGN.md
+++ b/ducktable/docs/DESIGN.md
@@ -12,7 +12,8 @@ values. No charting, no multi-engine driver matrix, no sync, no plugins.
 
 ```
 DuckTable (Rust + GPUI, single static binary)
-    |  HTTP over a local socket or loopback TCP
+    |  HTTP over a local socket or IPv4 loopback TCP
+    |  optional app-owned OpenSSH local forward
     v
 DuckDB Harbor (required; owns engine, files, versions)
     |
@@ -33,6 +34,16 @@ DuckDB  -- ATTACH/scanners reach SQLite, Postgres, MySQL, Parquet, CSV, ...
   monorepo checks the wire contract on both sides of every commit. The
   HTTP layer (blocking client, NDJSON streaming, chunked decoding) lives in
   DuckTable's own client crate.
+- **A database can be opened by file or added by port.** File → Open Database
+  File chooses a DuckDB path. File → Add Database saves a sidebar name and a
+  Harbor host and port. `localhost` means a direct IPv4-loopback connection;
+  any other host means SSH. DuckTable runs `/usr/bin/ssh` directly, forwards an
+  arbitrary local `127.0.0.1` port to that machine's Harbor loopback port, and
+  keeps the tunnel inside the connection's reference-counted lifetime. No
+  survey opens SSH; selecting the database does. The last connection clone
+  kills and reaps the process. `-S none` makes that process the owner,
+  `BatchMode=yes` keeps GUI failures visible rather than interactive, and SSH
+  protocol keepalives detect a dead path.
 - **A connected berth is kept alive by presence, not pulses.** Under Harbor
   0.20+ a held connection *is* the keepalive — the old `GET /keepalive`
   route died with the idle-exit machinery it served. The lifetime rule is

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -49,6 +49,16 @@ double-clicking a divider toggles; and Cmd+0 (sidebar) / Cmd+Alt+0
 Keyboard shortcuts are written as Cmd here; on Linux and Windows every
 Cmd reads as Ctrl.
 
+The File menu offers the two pieces of information a user can start with.
+**Open Database File…** chooses a DuckDB path. **Add Database…** asks for a
+sidebar name, host, and Harbor port. Host defaults to `localhost`, which
+DuckTable resolves explicitly to IPv4 `127.0.0.1` and connects to directly. Any
+other host tells DuckTable to create an SSH tunnel to that host and forward its
+Harbor loopback port. A tunneled row remains a normal DATABASES row and says
+“Connects over SSH to <host>” in its tooltip. Its context menu says **Remove
+Database**, which forgets the saved route and closes its tunnel without sending
+a shutdown request to the database server.
+
 ## Sizing
 
 Rigidity is part of feeling native: content pushes back instead of

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -155,9 +155,9 @@ registry.
 
 ## The local access boundary
 
-Unix sockets live in a `0700` runtime directory. TCP binds loopback only —
-`127.0.0.1` and, where available, `::1` — and is added with `--port` or the
-matching config entry. Remote clients arrive through SSH or an edge proxy;
+Unix sockets live in a `0700` runtime directory. TCP binds IPv4 loopback only —
+`127.0.0.1` — and is added with `--port` or the matching config entry. Remote
+clients arrive through SSH or an edge proxy;
 Harbor itself does not expose a non-loopback listener.
 
 ## Caddy is the optional edge; UDS is the default face

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -61,7 +61,7 @@ and simpler than everything it replaces.
 If it can speak HTTP and parse JSON, it can query your database.
 
 ```console
-$ curl -s localhost:9495/sql -H 'Content-Type: application/json' \
+$ curl -s 127.0.0.1:9495/sql -H 'Content-Type: application/json' \
        -d '{"sql":"SELECT id, total FROM orders LIMIT 2"}'
 {"type":"schema","columns":[{"name":"id","duckdbType":"BIGINT","lossless":true},
                             {"name":"total","duckdbType":"DECIMAL(10,2)","lossless":true,
@@ -149,9 +149,9 @@ are the whole server.
 Name a statement when you send it, and you can stop it:
 
 ```console
-$ curl -s localhost:9495/sql -H 'Content-Type: application/json' \
+$ curl -s 127.0.0.1:9495/sql -H 'Content-Type: application/json' \
        -d '{"sql":"SELECT count(*) FROM huge","queryId":"report-7"}' &
-$ curl -s -X DELETE localhost:9495/sql/queries/report-7
+$ curl -s -X DELETE 127.0.0.1:9495/sql/queries/report-7
 {"cancelled":true}
 ```
 
@@ -207,13 +207,13 @@ per statement means no transaction can span two. A session bridges that: a
 connection pinned to you until you commit, roll back, or stop answering.
 
 ```console
-$ sid=$(curl -s -X POST localhost:9495/sql/sessions | jq -r .sessionId)
-$ post() { curl -s localhost:9495/sql -H 'Content-Type: application/json' -d "{\"sql\":\"$1\",\"sessionId\":\"$sid\"}"; }
+$ sid=$(curl -s -X POST 127.0.0.1:9495/sql/sessions | jq -r .sessionId)
+$ post() { curl -s 127.0.0.1:9495/sql -H 'Content-Type: application/json' -d "{\"sql\":\"$1\",\"sessionId\":\"$sid\"}"; }
 $ post "BEGIN"
 $ post "INSERT INTO orders (total) VALUES (19.99) RETURNING id"
 $ post "INSERT INTO order_items (order_id, price) VALUES (1, 19.99)"
 $ post "COMMIT"
-$ curl -s -X DELETE localhost:9495/sql/sessions/$sid
+$ curl -s -X DELETE 127.0.0.1:9495/sql/sessions/$sid
 ```
 
 This is PgBouncer's transaction pooling, or ActiveRecord checking a connection
@@ -258,7 +258,7 @@ indexes and sequences — plus the engine's row estimate and its own
 exact bytes at the top:
 
 ```json
-{"harborVersion":"0.29.0","duckdbVersion":"v2.0.0-dev83323",
+{"harborVersion":"0.30.0","duckdbVersion":"v2.0.0-dev83323",
  "databaseSizeBytes":12582912,"walSizeBytes":0,
  "tables":[{"name":"orders","schema":"main","estimatedRows":300000,
             "columns":[…],"primaryKey":["id"],
@@ -328,7 +328,7 @@ with `sudo` in front of the whole command — the installer never escalates on
 its own. On Windows the binary lands in `%LOCALAPPDATA%\Programs\harbor\bin`,
 which the installer adds to your user `PATH`.
 
-Pin a version with `... | bash -s v0.29.0` (or `-Tag v0.29.0` on Windows). Each
+Pin a version with `... | bash -s v0.30.0` (or `-Tag v0.30.0` on Windows). Each
 [release](https://github.com/shreeve/duckdb-harbor/releases)
 ships one self-contained archive per
 platform (osx-arm64, linux-amd64, linux-arm64, windows-amd64, windows-arm64):
@@ -411,7 +411,7 @@ $ harbor http://127.0.0.1:9495 -c "SELECT count(*) FROM orders"
 An explicit start can also take its port from the matching
 `[connection.<name>]` entry in `~/.config/harbor/config.toml`; a summon stays
 on the Unix socket, so opening a database never silently adds a TCP listener.
-TCP binds `127.0.0.1` and, where available, `::1`.
+TCP binds IPv4 loopback only: `127.0.0.1`.
 
 Remote access is Caddy's job at the edge (TLS and access policy); harbor itself speaks
 plain HTTP over a unix socket or a loopback TCP port. A human reaches a
@@ -448,7 +448,7 @@ job, and it does them better than harbor would.
 There is nothing to install on the client side. Shell:
 
 ```console
-$ curl -sN localhost:9495/sql -H 'Content-Type: application/json' \
+$ curl -sN 127.0.0.1:9495/sql -H 'Content-Type: application/json' \
        -d '{"sql":"SELECT count(*) FROM orders"}'
 ```
 

--- a/harbor/crates/common/src/config.rs
+++ b/harbor/crates/common/src/config.rs
@@ -16,8 +16,11 @@
 //! enable_progress_bar = true         # keys are DuckDB's own, passed through
 //! default_null_order  = "NULLS LAST" # verbatim (string quoted, bool/int bare)
 //!
-//! [connection.prod]         # has `url` -> a remote, harbor never touches it
-//! url = "http://127.0.0.1:9495"
+//! [connection.local]        # localhost -> connect directly over IPv4
+//! url = "http://localhost:9495"
+//!
+//! [connection.warehouse]    # another host -> DuckTable owns the SSH tunnel
+//! url = "http://warehouse.example.com:9495"
 //! ```
 //!
 //! Harbor reads this file too: a berth's entry supplies its standing
@@ -289,8 +292,11 @@ mod tests {
         memory-limit = "8GB"
         init = ["SET threads=4"]
 
-        [connection.prod]
-        url = "http://127.0.0.1:9495"
+        [connection.local]
+        url = "http://localhost:9495"
+
+        [connection.tunneled]
+        url = "http://warehouse.example.com:9495"
     "#;
 
     #[test]
@@ -301,7 +307,7 @@ mod tests {
         let berths: Vec<_> = c.berths().iter().map(|(n, _)| *n).collect();
         assert_eq!(berths, ["medlabs", "warehouse"]);
         let remotes: Vec<_> = c.remotes().iter().map(|(n, _)| *n).collect();
-        assert_eq!(remotes, ["prod"]);
+        assert_eq!(remotes, ["local", "tunneled"]);
 
         let w = c.get("warehouse").unwrap();
         assert_eq!(w.memory_limit.as_deref(), Some("8GB"));

--- a/harbor/crates/common/src/membership.rs
+++ b/harbor/crates/common/src/membership.rs
@@ -1,6 +1,7 @@
 //! The membership store: the `[connection.<name>]` sections of config.toml.
 //!
-//! `attach` and `detach` add or remove one connection, editing the file through
+//! Local attach/detach and DuckTable's remote-database flow add or remove one
+//! connection, editing the file through
 //! toml_edit's DOM so the comments and ordering the operator wrote survive
 //! untouched — we mutate one node, we don't reserialize the file. The full
 //! schema stays with the `config` reader; here we only ever touch a section's
@@ -74,6 +75,39 @@ pub fn detach(db: &Path) -> Result<(String, bool), String> {
     verify(&text, &name, false)?;
     write(&text)?;
     Ok((name, true))
+}
+
+/// Add a named database reached through an existing Harbor TCP listener.
+pub fn add_remote(name: &str, url: &str) -> Result<String, String> {
+    let name = paths::normalize(name)?;
+    let url = url.trim();
+    if url.is_empty() {
+        return Err("database address is empty".into());
+    }
+    let mut doc = parse(&read()?)?;
+    if find(&doc, &name)?.is_some() {
+        return Err(format!("'{name}' already exists — choose another name"));
+    }
+    insert_remote(&mut doc, &name, url)?;
+    let text = doc.to_string();
+    verify(&text, &name, true)?;
+    write(&text)?;
+    Ok(name)
+}
+
+/// Remove a named connection without interpreting what kind it is. Front ends
+/// establish that policy before calling; this layer only preserves the TOML.
+pub fn remove_named(name: &str) -> Result<bool, String> {
+    let name = paths::normalize(name)?;
+    let mut doc = parse(&read()?)?;
+    let Some((key, _)) = find(&doc, &name)? else {
+        return Ok(false);
+    };
+    remove(&mut doc, &key)?;
+    let text = doc.to_string();
+    verify(&text, &name, false)?;
+    write(&text)?;
+    Ok(true)
 }
 
 /// The name a database files under: its stem, normalized to the registry
@@ -151,6 +185,22 @@ fn insert(doc: &mut DocumentMut, name: &str, stored: &str) -> Result<(), String>
         .ok_or("`connection` in config.toml is not a table")?;
     let mut entry = Table::new();
     entry["path"] = value(stored);
+    conn.insert(name, Item::Table(entry));
+    Ok(())
+}
+
+/// Add a remote section without disturbing the document around it.
+fn insert_remote(doc: &mut DocumentMut, name: &str, url: &str) -> Result<(), String> {
+    if doc.get("connection").is_none() {
+        let mut parent = Table::new();
+        parent.set_implicit(true);
+        doc.insert("connection", Item::Table(parent));
+    }
+    let conn = doc["connection"]
+        .as_table_mut()
+        .ok_or("`connection` in config.toml is not a table")?;
+    let mut entry = Table::new();
+    entry["url"] = value(url);
     conn.insert(name, Item::Table(entry));
     Ok(())
 }
@@ -310,5 +360,16 @@ url = \"https://x\"
     #[test]
     fn invalid_toml_is_rejected_not_edited() {
         assert!(parse("[connection.foo\npath =").is_err());
+    }
+
+    #[test]
+    fn remote_addition_is_named_and_transport_explicit() {
+        let mut doc = parse("# mine\n").unwrap();
+        insert_remote(&mut doc, "prod", "http://foo.bar.com:9494").unwrap();
+        let text = doc.to_string();
+        assert!(text.contains("# mine"));
+        assert!(text.contains("[connection.prod]"));
+        assert!(text.contains("url = \"http://foo.bar.com:9494\""));
+        verify(&text, "prod", true).unwrap();
     }
 }

--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -1014,7 +1014,7 @@ pub fn open_pool(con: Connection) -> Result<(), String> {
 /// also answering TCP. Plain Tcp exists for Windows, which has no unix
 /// sockets.
 ///
-/// TCP is loopback only, always: this process trusts its own machine and
+/// TCP is IPv4 loopback only, always: this process trusts its own machine and
 /// nothing else, and anything wider — remote reach, access policy — belongs to an
 /// edge proxy in front of it.
 pub enum Listen {
@@ -1025,20 +1025,13 @@ pub enum Listen {
     Dual { port: u16, sock: std::path::PathBuf },
 }
 
-/// The TCP door on loopback. Localhost is two addresses: 127.0.0.1 is
-/// required, and ::1 is added when the host has IPv6 — a client dialing
-/// `localhost` resolves to either, and answering only one strands the
-/// other. The ::1 bind reuses whatever port IPv4 actually got, so an
-/// ephemeral port (0) still yields one number for both.
-fn loopback(port: u16) -> Result<Vec<justhttp::Listener>, String> {
+/// The TCP door is deliberately one IPv4 loopback listener. Callers use the
+/// literal `127.0.0.1`, so name resolution never changes which address Harbor
+/// serves.
+fn ipv4_loopback(port: u16) -> Result<Vec<justhttp::Listener>, String> {
     let v4 = std::net::TcpListener::bind(("127.0.0.1", port))
         .map_err(|e| format!("harbor: cannot bind 127.0.0.1:{port}: {e}"))?;
-    let port = v4.local_addr().map_err(|e| format!("harbor: local_addr: {e}"))?.port();
-    let mut doors = vec![justhttp::Listener::from(v4)];
-    if let Ok(v6) = std::net::TcpListener::bind(("::1", port)) {
-        doors.push(justhttp::Listener::from(v6));
-    }
-    Ok(doors)
+    Ok(vec![justhttp::Listener::from(v4)])
 }
 
 pub fn start(listen: Listen, workers: usize, log: bool) -> Result<String, String> {
@@ -1075,14 +1068,14 @@ pub fn start(listen: Listen, workers: usize, log: bool) -> Result<String, String
     drop(pool);
 
     let bound = match &listen {
-        Listen::Tcp { port } => loopback(*port).and_then(|doors| {
+        Listen::Tcp { port } => ipv4_loopback(*port).and_then(|doors| {
             Server::serve(doors).map_err(|e| format!("harbor: cannot serve: {e}"))
         }),
         #[cfg(unix)]
         Listen::Unix(path) => Server::http_unix(path.as_path())
             .map_err(|e| format!("harbor: cannot bind {}: {e}", path.display())),
         #[cfg(unix)]
-        Listen::Dual { port, sock } => loopback(*port).and_then(|mut doors| {
+        Listen::Dual { port, sock } => ipv4_loopback(*port).and_then(|mut doors| {
             let unix = std::os::unix::net::UnixListener::bind(sock)
                 .map_err(|e| format!("harbor: cannot bind {}: {e}", sock.display()))?;
             doors.push(justhttp::Listener::from(unix));
@@ -4104,6 +4097,16 @@ mod tests {
     use crate::encode::varint_to_decimal;
     use super::{Cancel, SlotRun};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn the_tcp_door_is_one_ipv4_listener() {
+        let doors = super::ipv4_loopback(0).unwrap();
+        assert_eq!(doors.len(), 1);
+        let justhttp::Listener::Tcp(listener) = &doors[0] else {
+            panic!("the TCP door returned a unix listener");
+        };
+        assert_eq!(listener.local_addr().unwrap().ip(), std::net::Ipv4Addr::LOCALHOST);
+    }
 
     fn idle() -> SlotRun {
         SlotRun { job: 0, started: Instant::now(), pending: None, cancelled: false, deadline: None, request: None }

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -15,7 +15,7 @@
 //! The socket IS the runtime registration: its name is derived from the
 //! database's canonical path (`socket_for`). Shared config supplies named
 //! connections and standing settings. The 0700 runtime directory protects
-//! Unix sockets; TCP, when `--port` adds it, binds loopback only. Remote reach
+//! Unix sockets; TCP, when `--port` adds it, binds IPv4 loopback only. Remote reach
 //! and policy belong to an edge proxy.
 
 use std::io::IsTerminal;
@@ -217,8 +217,8 @@ client options:
 
 start options:
   --port <p>           also listen on TCP, beside the unix socket — loopback
-                       only (127.0.0.1, plus ::1 when the host has IPv6);
-                       remote reach and access policy belong to an edge proxy
+                       only (127.0.0.1); remote reach and access policy
+                       belong to an edge proxy
   --workers <n>        executor pool size (default 6)
   --memory-limit <s>   DuckDB memory_limit (default 2GB)
   --threads <n>        DuckDB threads (default: DuckDB's own)


### PR DESCRIPTION
## Summary

- bind Harbor TCP listeners exclusively to IPv4 loopback
- add DuckTable’s File → Add Database flow for Harbor host/port connections
- connect directly for localhost and automatically manage an SSH local forward for other hosts
- own, monitor, keep alive, close, and reap each SSH process with its matching database connection
- persist named URL connections without a separate tunnel mode
- update documentation and bump Harbor to 0.30.0 and DuckTable to 0.17.0

## Verification

- `cargo test --workspace` (DuckTable)
- `make test SUITES="unit lifecycle types spec catalog sessions cancel"` (Harbor release profile)
- `ducktable/scripts/macos-app.sh release`
- Harbor macOS release archive structure/version check
- `git diff --check`