### PR TITLE
Release Harbor 0.31.0 and DuckTable 0.18.0

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "harbor-common",
  "serde",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/README.md
+++ b/ducktable/README.md
@@ -56,7 +56,7 @@ On Intel, or to build from source: clone the repo and run
 
 ## Databases by port
 
-Choose **File → Add Database…** when Harbor is already listening on a TCP
+Choose **File → Open Database URL…** when Harbor is already listening on a TCP
 port. Give the database a sidebar name, host, and Harbor port. `localhost`
 connects directly; any other host makes DuckTable create the SSH tunnel:
 

--- a/ducktable/crates/ducktable/src/add_database.rs
+++ b/ducktable/crates/ducktable/src/add_database.rs
@@ -1,4 +1,4 @@
-//! File → Add Database: save a Harbor host and port under a sidebar name.
+//! File → Open Database URL: save a Harbor host and port under a sidebar name.
 //! Localhost connects directly; any other host is reached through SSH.
 
 use crate::app::DuckTable;
@@ -49,9 +49,9 @@ pub(crate) fn open(view: WeakEntity<DuckTable>, window: &mut Window, cx: &mut Ap
                 );
 
             dialog
-                .title("Add Database")
+                .title("Open Database URL")
                 .confirm()
-                .button_props(DialogButtonProps::default().ok_text("Add Database"))
+                .button_props(DialogButtonProps::default().ok_text("Open Database"))
                 .child(form)
                 .when_some(error.borrow().clone(), |dialog, message| {
                     dialog.child(div().text_sm().text_color(cx.theme().danger).child(message))

--- a/ducktable/crates/ducktable/src/app.rs
+++ b/ducktable/crates/ducktable/src/app.rs
@@ -54,7 +54,7 @@ pub(crate) enum Phase {
         conn: Conn,
         info: wire::InfoResponse,
         /// The one snapshot everything schema-shaped renders from: tables,
-        /// columns, DDL, row estimates, and the file's size on disk all
+        /// columns, DDL, exact row counts, and the file's size on disk all
         /// arrive in this single document (harbor 0.18+).
         catalog: harbor_client::Catalog,
     },
@@ -615,7 +615,7 @@ impl DuckTable {
         );
     }
 
-    /// File → Add Database: persist the named Harbor port, then connect
+    /// File → Open Database URL: persist the named Harbor port, then connect
     /// through the same path a sidebar click uses. A failed dial still leaves
     /// the database saved so Retry has something durable to target.
     pub(crate) fn add_database(

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -28,7 +28,7 @@ actions!(
     [
         ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, TablePrev,
         TableNext, View1, View2, View3, ToggleFullScreen, ToggleRowNumbers, ToggleRightAlign,
-        ToggleNullTags, OpenDatabase, AddDatabase
+        ToggleNullTags, OpenDatabase, OpenDatabaseUrl
     ]
 );
 
@@ -169,7 +169,7 @@ fn app_menus() -> Vec<Menu> {
                 // The platform picker, then the same door a drop uses.
                 // ⌘O advertises itself from the keymap binding.
                 MenuItem::action("Open Database File…", OpenDatabase),
-                MenuItem::action("Add Database…", AddDatabase),
+                MenuItem::action("Open Database URL…", OpenDatabaseUrl),
             ],
         },
         // macOS shows each item's key equivalent from the keymap, so this
@@ -420,7 +420,7 @@ fn main() {
             })
             .detach();
         });
-        cx.on_action(|_: &AddDatabase, cx| {
+        cx.on_action(|_: &OpenDatabaseUrl, cx| {
             let view = cx.try_global::<AppView>().map(|v| v.0.clone());
             cx.defer(move |cx| {
                 let Some(view) = view else { return };

--- a/ducktable/crates/ducktable/src/sidebar.rs
+++ b/ducktable/crates/ducktable/src/sidebar.rs
@@ -465,10 +465,10 @@ impl DuckTable {
                     // "users (35)" — the column count hugs the name; a
                     // long name truncates but keeps its count visible.
                     .child(named_count(&table.name, Some(table.columns.len()), t))
-                    // Row count in compact SI form — rows are what a
+                    // Exact row count in compact SI form — rows are what a
                     // scan of a database cares about; column counts
                     // live in the footer status and Structure view.
-                    .when_some(table.estimated_rows, |d, n| {
+                    .when_some(table.row_count, |d, n| {
                         d.child(dim(t, crate::util::human(n as f64, "")))
                     })
                     .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
@@ -600,7 +600,7 @@ fn named_count(name: &str, count: Option<usize>, t: Pal) -> Div {
         })
 }
 
-/// A row's right-side magnitude (size on disk, row estimate), muted.
+/// A row's right-side magnitude (size on disk, exact row count), muted.
 fn dim(t: Pal, text: String) -> Div {
     div().text_xs().text_color(t.muted).child(text)
 }

--- a/ducktable/crates/harbor-client/src/catalog.rs
+++ b/ducktable/crates/harbor-client/src/catalog.rs
@@ -35,10 +35,9 @@ pub struct Catalog {
 pub struct Table {
     pub name: String,
     pub schema: String,
-    /// The engine's cardinality estimate (harbor 0.18+) — a sidebar
-    /// figure, not a COUNT(*).
+    /// Exact COUNT(*) from the full catalog; absent from the lite inventory.
     #[serde(default)]
-    pub estimated_rows: Option<u64>,
+    pub row_count: Option<u64>,
     /// The engine's own CREATE TABLE rendering (harbor 0.18+).
     #[serde(default)]
     pub ddl: Option<String>,
@@ -92,11 +91,9 @@ pub fn catalog(conn: &Conn) -> Result<Catalog, String> {
     fetch(conn, &wire::endpoint::CATALOG)
 }
 
-/// The catalog's lite style (harbor 0.18+): the versions, the sizes, and
-/// each table as name, schema, and `estimatedRows` — enough to draw a
-/// database list without paying for columns, DDL, or sequences. An older
-/// harbor ignores the parameter and answers the full document, so this
-/// degrades to correct-but-heavier, never to an error.
+/// The catalog's lite style: versions, sizes, and table names/schemas — enough
+/// to draw a database list without paying for counts, columns, DDL, or
+/// sequences.
 pub fn catalog_lite(conn: &Conn) -> Result<Catalog, String> {
     fetch(conn, &wire::endpoint::catalog_lite())
 }
@@ -134,11 +131,11 @@ mod tests {
             "databaseSizeBytes": 1310720,
             "walSizeBytes": 0,
             "tables": [
-                {"name": "events", "schema": "main", "estimatedRows": 42,
+                {"name": "events", "schema": "main", "rowCount": 42,
                  "columns": [{"name": "id", "type": "INTEGER", "notNull": true, "default": "nextval('id')", "primary": true}],
                  "primaryKey": ["id"], "uniqueConstraints": [], "indexes": [], "foreignKeys": [],
                  "ddl": "CREATE TABLE events(id INTEGER PRIMARY KEY DEFAULT(nextval('id')));"},
-                {"name": "zeta", "schema": "audit", "columns": [], "primaryKey": []}
+                {"name": "zeta", "schema": "audit", "rowCount": 7, "columns": [], "primaryKey": []}
             ],
             "sequences": [{"name": "id", "start": 1}],
             "viewsSomeday": []
@@ -147,13 +144,20 @@ mod tests {
         assert_eq!(c.schemas(), vec!["main", "audit"]);
         assert_eq!(c.tables_in("main")[0].columns[0].duck_type, "INTEGER");
         assert!(c.tables_in("main")[0].columns[0].primary);
-        assert_eq!(c.tables_in("main")[0].estimated_rows, Some(42));
+        assert_eq!(c.tables_in("main")[0].row_count, Some(42));
         assert!(c.tables_in("main")[0].ddl.as_deref().unwrap().starts_with("CREATE TABLE"));
-        // The audit table came from an older Harbor with no enrichment:
-        // every new field is an absence, never an error.
-        assert_eq!(c.tables_in("audit")[0].estimated_rows, None);
+        assert_eq!(c.tables_in("audit")[0].row_count, Some(7));
         assert_eq!(c.database_size_bytes, Some(1310720));
         assert_eq!(c.wal_size_bytes, Some(0));
         assert_eq!(c.sequences[0].name, "id");
+    }
+
+    #[test]
+    fn lite_catalog_omits_row_counts() {
+        let c: Catalog = serde_json::from_str(
+            r#"{"tables":[{"name":"events","schema":"main"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(c.tables[0].row_count, None);
     }
 }

--- a/ducktable/docs/DESIGN.md
+++ b/ducktable/docs/DESIGN.md
@@ -35,7 +35,7 @@ DuckDB  -- ATTACH/scanners reach SQLite, Postgres, MySQL, Parquet, CSV, ...
   HTTP layer (blocking client, NDJSON streaming, chunked decoding) lives in
   DuckTable's own client crate.
 - **A database can be opened by file or added by port.** File → Open Database
-  File chooses a DuckDB path. File → Add Database saves a sidebar name and a
+  File chooses a DuckDB path. File → Open Database URL saves a sidebar name and a
   Harbor host and port. `localhost` means a direct IPv4-loopback connection;
   any other host means SSH. DuckTable runs `/usr/bin/ssh` directly, forwards an
   arbitrary local `127.0.0.1` port to that machine's Harbor loopback port, and

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -50,7 +50,7 @@ Keyboard shortcuts are written as Cmd here; on Linux and Windows every
 Cmd reads as Ctrl.
 
 The File menu offers the two pieces of information a user can start with.
-**Open Database File…** chooses a DuckDB path. **Add Database…** asks for a
+**Open Database File…** chooses a DuckDB path. **Open Database URL…** asks for a
 sidebar name, host, and Harbor port. Host defaults to `localhost`, which
 DuckTable resolves explicitly to IPv4 `127.0.0.1` and connects to directly. Any
 other host tells DuckTable to create an SSH tunnel to that host and forward its
@@ -112,9 +112,9 @@ and stays INTERNAL: on-screen labels use user words (DATABASES, TABLES,
 **TABLES** shows the connected berth's tables from Harbor's catalog
 endpoint as a flat list (schema headings appear only when there is more
 than one schema), each row carrying its column count in parentheses and
-an SI-rounded row count right-justified (13k, 4.6M — estimated_size,
-which matches exact counts in practice). Sequences follow in their own
-SEQUENCES section. Views, macros, and ATTACHed sibling catalogs join
+an SI-rounded exact row count right-justified (13k, 4.6M). Sequences
+follow in their own SEQUENCES section. Views, macros, and ATTACHed sibling
+catalogs join
 the tree when the catalog endpoint carries them. Each section header
 has its own filter glyph — a filter field only appears once a section
 exceeds 10 items — and a refresh glyph. Refresh refetches then swaps in

--- a/ducktable/vendor/gpui-component/src/dialog.rs
+++ b/ducktable/vendor/gpui-component/src/dialog.rs
@@ -9,7 +9,7 @@ use gpui::{
 use rust_i18n::t;
 
 use crate::{
-    ActiveTheme as _, IconName, Root, Sizable as _, StyledExt, WindowExt as _,
+    ActiveTheme as _, IconName, Sizable as _, StyledExt, WindowExt as _,
     actions::{Cancel, Confirm},
     animation::cubic_bezier,
     button::{Button, ButtonVariant, ButtonVariants as _},
@@ -98,6 +98,9 @@ pub struct Dialog {
     /// This will be change when open the dialog, the focus handle is create when open the dialog.
     pub(crate) focus_handle: FocusHandle,
     pub(crate) layer_ix: usize,
+    // DuckTable patch: Root supplies this while constructing the rendered
+    // layer, avoiding a nested Root read during Root's own render update.
+    pub(crate) layer_count: usize,
     pub(crate) overlay_visible: bool,
 }
 
@@ -124,6 +127,7 @@ impl Dialog {
             overlay: true,
             keyboard: true,
             layer_ix: 0,
+            layer_count: 1,
             overlay_visible: false,
             on_close: Rc::new(|_, _, _| {}),
             on_ok: None,
@@ -401,7 +405,7 @@ impl RenderOnce for Dialog {
                     })
                     .when(self.overlay, |this| {
                         // Only the last dialog owns the `mouse down - close dialog` event.
-                        if (self.layer_ix + 1) != Root::read(window, cx).active_dialogs.len() {
+                        if (self.layer_ix + 1) != self.layer_count {
                             return this;
                         }
 

--- a/ducktable/vendor/gpui-component/src/root.rs
+++ b/ducktable/vendor/gpui-component/src/root.rs
@@ -281,24 +281,32 @@ impl Root {
         cx: &mut App,
     ) -> Option<impl IntoElement + use<>> {
         let root = window.root::<Root>()??;
+        let root = root.read(cx);
+        Some(Self::notification_layer(
+            root.active_sheet.clone().map(|sheet| sheet.placement),
+            root.sheet_size,
+            root.notification.clone(),
+        ))
+    }
 
-        let active_sheet_placement = root.read(cx).active_sheet.clone().map(|d| d.placement);
-
+    fn notification_layer(
+        active_sheet_placement: Option<Placement>,
+        sheet_size: Option<DefiniteLength>,
+        notification: Entity<NotificationList>,
+    ) -> impl IntoElement + use<> {
         let (mt, mr) = match active_sheet_placement {
-            Some(Placement::Right) => (None, root.read(cx).sheet_size),
-            Some(Placement::Top) => (root.read(cx).sheet_size, None),
+            Some(Placement::Right) => (None, sheet_size),
+            Some(Placement::Top) => (sheet_size, None),
             _ => (None, None),
         };
 
-        Some(
-            div()
-                .absolute()
-                .top_0()
-                .right_0()
-                .when_some(mt, |this, offset| this.mt(offset))
-                .when_some(mr, |this, offset| this.mr(offset))
-                .child(root.read(cx).notification.clone()),
-        )
+        div()
+            .absolute()
+            .top_0()
+            .right_0()
+            .when_some(mt, |this, offset| this.mt(offset))
+            .when_some(mr, |this, offset| this.mr(offset))
+            .child(notification)
     }
 
     /// Render the Sheet layer.
@@ -307,8 +315,17 @@ impl Root {
         cx: &mut App,
     ) -> Option<impl IntoElement + use<>> {
         let root = window.root::<Root>()??;
+        let active_sheet = root.read(cx).active_sheet.clone();
+        Self::sheet_layer(active_sheet, root, window, cx)
+    }
 
-        if let Some(active_sheet) = root.read(cx).active_sheet.clone() {
+    fn sheet_layer(
+        active_sheet: Option<ActiveSheet>,
+        root: Entity<Self>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<impl IntoElement + use<>> {
+        if let Some(active_sheet) = active_sheet {
             let mut sheet = Sheet::new(window, cx);
             sheet = (active_sheet.builder)(sheet, window, cx);
             sheet.focus_handle = active_sheet.focus_handle.clone();
@@ -337,9 +354,15 @@ impl Root {
         cx: &mut App,
     ) -> Option<impl IntoElement + use<>> {
         let root = window.root::<Root>()??;
-
         let active_dialogs = root.read(cx).active_dialogs.clone();
+        Self::dialog_layer(active_dialogs, window, cx)
+    }
 
+    fn dialog_layer(
+        active_dialogs: Vec<ActiveDialog>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<impl IntoElement + use<>> {
         if active_dialogs.is_empty() {
             return None;
         }
@@ -361,6 +384,7 @@ impl Root {
                 dialog.focus_handle = active_dialog.focus_handle.clone();
 
                 dialog.layer_ix = i;
+                dialog.layer_count = active_dialogs.len();
                 // Find the dialog which one needs to show overlay.
                 if dialog.has_overlay() {
                     show_overlay_ix = Some(i);
@@ -397,18 +421,37 @@ impl Render for Root {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         window.set_rem_size(cx.theme().font_size);
 
-        window_border().child(
-            div()
-                .id("root")
-                .key_context(CONTEXT)
-                .on_action(cx.listener(Self::on_action_tab))
-                .on_action(cx.listener(Self::on_action_tab_prev))
-                .relative()
-                .size_full()
-                .font_family(cx.theme().font_family.clone())
-                .bg(cx.theme().background)
-                .text_color(cx.theme().foreground)
-                .child(self.view.clone()),
-        )
+        // DuckTable patch: gpui-component 0.5.1 stores these layers on Root,
+        // but its render path never paints them. Keep the content first and
+        // overlays afterward so dialogs, sheets, and notices are visible.
+        let root = window
+            .root::<Root>()
+            .flatten()
+            .expect("BUG: window first layer should be a gpui_component::Root.");
+        let sheet = Self::sheet_layer(self.active_sheet.clone(), root, window, cx);
+        let dialog = Self::dialog_layer(self.active_dialogs.clone(), window, cx);
+        let notification = Self::notification_layer(
+            self.active_sheet.clone().map(|sheet| sheet.placement),
+            self.sheet_size,
+            self.notification.clone(),
+        );
+
+        window_border()
+            .child(
+                div()
+                    .id("root")
+                    .key_context(CONTEXT)
+                    .on_action(cx.listener(Self::on_action_tab))
+                    .on_action(cx.listener(Self::on_action_tab_prev))
+                    .relative()
+                    .size_full()
+                    .font_family(cx.theme().font_family.clone())
+                    .bg(cx.theme().background)
+                    .text_color(cx.theme().foreground)
+                    .child(self.view.clone()),
+            )
+            .children(sheet)
+            .children(dialog)
+            .child(notification)
     }
 }

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.30.0"
+version = "0.31.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -87,8 +87,8 @@ POST /shutdown             drain, checkpoint, and stop
 GET  /info                 identity — database path, versions, pid, uptime,
                            and the live client count
 GET  /catalog              everything about the database in one stable JSON
-                           document — schema, sizes, row estimates, DDL
-                           (?style=lite for the cheap sketch)
+                           document — schema, sizes, exact row counts, DDL
+                           (?style=lite for the count-free inventory)
 
 POST /sql                  run one statement, stream the result as NDJSON
                            (Accept: application/json for one document instead)
@@ -253,26 +253,24 @@ you.
 
 `GET /catalog` answers what a client would otherwise ask in a dozen queries:
 every table with its columns, primary key, unique constraints, foreign keys,
-indexes and sequences — plus the engine's row estimate and its own
-`CREATE TABLE` rendering per table, and the database and WAL file sizes in
-exact bytes at the top:
+indexes and sequences — plus its exact row count and the engine's own `CREATE
+TABLE` rendering per table, and the database and WAL file sizes in exact bytes
+at the top:
 
 ```json
-{"harborVersion":"0.30.0","duckdbVersion":"v2.0.0-dev83323",
+{"harborVersion":"0.31.0","duckdbVersion":"v2.0.0-dev83323",
  "databaseSizeBytes":12582912,"walSizeBytes":0,
- "tables":[{"name":"orders","schema":"main","estimatedRows":300000,
+ "tables":[{"name":"orders","schema":"main","rowCount":300000,
             "columns":[…],"primaryKey":["id"],
             "ddl":"CREATE TABLE orders(id BIGINT PRIMARY KEY, …);"}, …],
  …}
 ```
 
 The document is stable — same database, same bytes — so clients can diff it.
-A client that only wants to paint a sidebar asks
-`GET /catalog?style=lite` and gets the versions, the sizes, and
-`{name, schema, estimatedRows}` per table: what exists and how big, without
-how it is built, at a fraction of the bytes. An unknown style value is a loud
-`400`; unknown parameters pass, which is what lets an older harbor answer a
-newer client's ask with the full document instead of a 404.
+A client that only wants an inventory asks `GET /catalog?style=lite` and gets
+the versions, the sizes, and `{name, schema}` per table: what exists, without
+counting it or describing how it is built, at a fraction of the work and bytes.
+An unknown style value is a loud `400`; unknown parameters pass.
 
 ## Get it running
 
@@ -328,7 +326,7 @@ with `sudo` in front of the whole command — the installer never escalates on
 its own. On Windows the binary lands in `%LOCALAPPDATA%\Programs\harbor\bin`,
 which the installer adds to your user `PATH`.
 
-Pin a version with `... | bash -s v0.30.0` (or `-Tag v0.30.0` on Windows). Each
+Pin a version with `... | bash -s v0.31.0` (or `-Tag v0.31.0` on Windows). Each
 [release](https://github.com/shreeve/duckdb-harbor/releases)
 ships one self-contained archive per
 platform (osx-arm64, linux-amd64, linux-arm64, windows-amd64, windows-arm64):

--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -2490,12 +2490,11 @@ fn cell_bool(row: &[serde_json::Value], i: usize) -> bool {
     row.get(i).and_then(|v| v.as_bool()).unwrap_or(false)
 }
 
-fn cell_u64(row: &[serde_json::Value], i: usize) -> u64 {
+fn cell_opt_u64(row: &[serde_json::Value], i: usize) -> Option<u64> {
     // The executor's integer policy quotes a value past JSON's exact range,
     // so a cell can arrive as either a number or its decimal string.
     row.get(i)
         .and_then(|v| v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
-        .unwrap_or(0)
 }
 
 fn cell_list(row: &[serde_json::Value], i: usize) -> Vec<String> {
@@ -2646,7 +2645,7 @@ struct CatalogFk {
 struct CatalogTable {
     schema: String,
     name: String,
-    estimated_rows: u64,
+    row_count: u64,
     ddl: Option<String>,
     columns: Vec<CatalogColumn>,
     primary_key: Vec<String>,
@@ -2694,7 +2693,8 @@ fn database_disk_sizes() -> (Option<u64>, Option<u64>) {
 }
 
 /// Which fidelity `/catalog` answers at. Lite is the inventory — what
-/// exists and how big; full adds how everything is built.
+/// exists; full adds how everything is built and its exact row counts.
+#[derive(Clone, Copy)]
 enum CatalogStyle {
     Full,
     Lite,
@@ -2720,6 +2720,35 @@ fn catalog_style(url: &str) -> Result<CatalogStyle, String> {
         }
     }
     Ok(CatalogStyle::Full)
+}
+
+/// Build the one exact-count statement for a catalog inventory. The ordinal
+/// travels through the result and is sorted explicitly: UNION ALL preserves
+/// duplicates, not branch order, and the caller must never attach a count to
+/// the wrong table. Identifiers come only from DuckDB's catalog and are still
+/// quoted as SQL identifiers, including embedded double quotes.
+fn catalog_count_sql(table_rows: &[Vec<serde_json::Value>]) -> Option<String> {
+    if table_rows.is_empty() {
+        return None;
+    }
+    let mut sql = String::from("SELECT table_ordinal, row_count FROM (");
+    for (i, row) in table_rows.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(" UNION ALL ");
+        }
+        let schema = catalog_identifier(&cell_str(row, 0));
+        let table = catalog_identifier(&cell_str(row, 1));
+        let _ = write!(
+            sql,
+            "SELECT {i}::UBIGINT AS table_ordinal, count(*)::UBIGINT AS row_count FROM {schema}.{table}"
+        );
+    }
+    sql.push_str(") AS exact_counts ORDER BY table_ordinal");
+    Some(sql)
+}
+
+fn catalog_identifier(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
 }
 
 /// `GET /catalog` — the complete schema shape a migration differ needs, as
@@ -2748,20 +2777,18 @@ fn catalog_style(url: &str) -> Result<CatalogStyle, String> {
 /// uniqueness at all. PRIMARY KEY is its own constraint type and its own
 /// field, and never appears here.
 ///
-/// The document also carries what a browsing client otherwise dials three
-/// more queries for: each table's `estimatedRows` (the engine's cardinality
-/// estimate — a sidebar figure, not a COUNT(*)), each table's `ddl` as the
-/// engine renders it, and `databaseSizeBytes`/`walSizeBytes` statted from
-/// the served file by the one process sitting next to it — exact bytes,
-/// never the engine's pretty-printed strings, and null for a berth serving
-/// no file.
+/// The document also carries what a browsing client otherwise dials more
+/// queries for: each table's exact `rowCount`, each table's `ddl` as the
+/// engine renders it, and `databaseSizeBytes`/`walSizeBytes` statted from the
+/// served file by the one process sitting next to it — exact bytes, never
+/// the engine's pretty-printed strings, and null for a berth serving no file.
 ///
 /// `?style=lite` answers the inventory alone: the versions, the sizes, and
-/// each table as name, schema, and `estimatedRows` — enough to draw a
-/// database list without paying for columns, constraints, indexes, DDL, or
-/// sequences, in queries here or in bytes on the wire. It is the same
-/// document family at lower fidelity, not a second contract: a field a
-/// style omits is absent, never differently shaped.
+/// each table's name and schema — enough to draw a database list without
+/// paying for counts, columns, constraints, indexes, DDL, or sequences, in
+/// queries here or in bytes on the wire. It is the same document family at
+/// lower fidelity, not a second contract: a field a style omits is absent,
+/// never differently shaped.
 ///
 /// Ordering is part of the contract: tables by (schema, name), columns in
 /// ordinal position, indexes and sequences by name, unique constraints by
@@ -2782,19 +2809,26 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
         Ok(rows) => rows,
         Err(failure) => return catalog_refuse(req, failure),
     };
-    let table_rows = match catalog_rows(
-        jobs,
-        "SELECT schema_name, table_name, estimated_size, sql FROM duckdb_tables() \
-         WHERE database_name = current_database() AND NOT internal AND NOT temporary \
-         ORDER BY schema_name, table_name",
-    ) {
+    let table_sql = match style {
+        CatalogStyle::Full => {
+            "SELECT schema_name, table_name, sql FROM duckdb_tables() \
+             WHERE database_name = current_database() AND NOT internal AND NOT temporary \
+             ORDER BY schema_name, table_name"
+        }
+        CatalogStyle::Lite => {
+            "SELECT schema_name, table_name FROM duckdb_tables() \
+             WHERE database_name = current_database() AND NOT internal AND NOT temporary \
+             ORDER BY schema_name, table_name"
+        }
+    };
+    let table_rows = match catalog_rows(jobs, table_sql) {
         Ok(rows) => rows,
         Err(failure) => return catalog_refuse(req, failure),
     };
     let duckdb_version = version_rows.first().map(|r| cell_str(r, 0)).unwrap_or_default();
 
     // The lite style stops here: everything it answers is already in hand,
-    // and the four shape queries below never run.
+    // and the count plus four shape queries below never run.
     if let CatalogStyle::Lite = style {
         let mut out = catalog_header(&duckdb_version);
         out.push_str(",\"tables\":[");
@@ -2806,14 +2840,51 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
             push_json_string(&mut out, &cell_str(row, 1));
             out.push_str(",\"schema\":");
             push_json_string(&mut out, &cell_str(row, 0));
-            out.push_str(",\"estimatedRows\":");
-            out.push_str(&cell_u64(row, 2).to_string());
             out.push('}');
         }
         out.push_str("]}");
         let _ = req.respond(json_response(200, &out));
         return (true, 200);
     }
+
+    // SQL cannot turn values returned by duckdb_tables() into relation
+    // identifiers. Build those identifiers here, where they can be quoted
+    // exactly, then let one UNION ALL statement count every table under one
+    // query snapshot. COUNT(*) projects no application columns; it reads the
+    // engine's visibility information and therefore excludes deleted rows
+    // that the physical storage cardinality still includes.
+    let count_rows = if let Some(sql) = catalog_count_sql(&table_rows) {
+        match catalog_rows(jobs, &sql) {
+            Ok(rows) => rows,
+            Err(failure) => return catalog_refuse(req, failure),
+        }
+    } else {
+        Vec::new()
+    };
+    let row_counts = if count_rows.len() == table_rows.len() {
+        count_rows
+            .iter()
+            .enumerate()
+            .map(|(i, row)| {
+                if cell_opt_u64(row, 0) != Some(i as u64) {
+                    return None;
+                }
+                cell_opt_u64(row, 1)
+            })
+            .collect::<Option<Vec<_>>>()
+    } else {
+        None
+    };
+    let Some(row_counts) = row_counts else {
+        return catalog_refuse(
+            req,
+            CatalogFailure::Refused(Refusal {
+                status: 500,
+                code: "internal",
+                message: "the catalog row-count query returned an invalid shape".to_string(),
+            }),
+        );
+    };
 
     let column_rows = match catalog_rows(
         jobs,
@@ -2866,15 +2937,15 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
     // map, so nothing about the output depends on hash order.
     let mut tables: Vec<CatalogTable> = Vec::new();
     let mut index_of: HashMap<(String, String), usize> = HashMap::new();
-    for row in &table_rows {
+    for (row, row_count) in table_rows.iter().zip(row_counts) {
         let schema = cell_str(row, 0);
         let name = cell_str(row, 1);
         index_of.insert((schema.clone(), name.clone()), tables.len());
         tables.push(CatalogTable {
             schema,
             name,
-            estimated_rows: cell_u64(row, 2),
-            ddl: cell_opt_str(row, 3),
+            row_count,
+            ddl: cell_opt_str(row, 2),
             columns: Vec::new(),
             primary_key: Vec::new(),
             unique_constraints: Vec::new(),
@@ -2956,8 +3027,8 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
         push_json_string(&mut out, &table.name);
         out.push_str(",\"schema\":");
         push_json_string(&mut out, &table.schema);
-        out.push_str(",\"estimatedRows\":");
-        out.push_str(&table.estimated_rows.to_string());
+        out.push_str(",\"rowCount\":");
+        out.push_str(&table.row_count.to_string());
         out.push_str(",\"columns\":[");
         for (j, column) in table.columns.iter().enumerate() {
             if j > 0 {
@@ -4093,7 +4164,7 @@ mod tests {
     use super::fenced_setting;
     use super::route_exists;
     use super::index_columns;
-    use super::{IndexPart, index_parts};
+    use super::{IndexPart, catalog_count_sql, index_parts};
     use crate::encode::varint_to_decimal;
     use super::{Cancel, SlotRun};
     use std::time::{Duration, Instant};
@@ -4406,6 +4477,24 @@ mod tests {
             vec![r#""a, b""#, r#""c'd""#, "plain"]
         );
         assert_eq!(index_columns("[]"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn exact_catalog_counts_quote_every_relation() {
+        let rows = vec![
+            vec![serde_json::json!("main"), serde_json::json!("orders")],
+            vec![serde_json::json!("odd schema"), serde_json::json!("say \"hi\"")],
+        ];
+        assert_eq!(
+            catalog_count_sql(&rows).as_deref(),
+            Some(
+                "SELECT table_ordinal, row_count FROM (\
+SELECT 0::UBIGINT AS table_ordinal, count(*)::UBIGINT AS row_count FROM \"main\".\"orders\" \
+UNION ALL SELECT 1::UBIGINT AS table_ordinal, count(*)::UBIGINT AS row_count FROM \
+\"odd schema\".\"say \"\"hi\"\"\") AS exact_counts ORDER BY table_ordinal"
+            )
+        );
+        assert_eq!(catalog_count_sql(&[]), None);
     }
 
     /// `indexes[].columns` exists to be joined against `columns[].name`, so

--- a/harbor/crates/wire/src/lib.rs
+++ b/harbor/crates/wire/src/lib.rs
@@ -95,12 +95,9 @@ pub mod endpoint {
         Route::built("DELETE", format!("/sql/queries/{id}"))
     }
 
-    /// GET — the catalog's lite style (harbor 0.17+): what exists and how
-    /// big — tables with their schema and `estimatedRows`, the database's
-    /// sizes — without how it is built (no columns, keys, indexes, DDL, or
-    /// sequences). An older harbor ignores the parameter and answers the
-    /// full document, so a client degrades to correct-but-heavier, never
-    /// to an error.
+    /// GET — the catalog's lite style: what exists — tables with their
+    /// schemas and the database's sizes — without counts or how it is built
+    /// (no columns, keys, indexes, DDL, or sequences).
     pub fn catalog_lite() -> Route {
         Route::built("GET", "/catalog?style=lite".to_string())
     }

--- a/harbor/test/scripts/catalog.py
+++ b/harbor/test/scripts/catalog.py
@@ -146,7 +146,8 @@ CREATE TABLE posts (
   title VARCHAR
 );
 CREATE INDEX idx_posts_title ON posts(title);
-INSERT INTO posts VALUES (1, NULL, 'ada'), (2, NULL, 'bo'), (3, NULL, 'cy');
+INSERT INTO posts VALUES
+  (1, NULL, 'ada'), (2, NULL, 'bo'), (3, NULL, 'cy'), (4, NULL, 'deleted');
 CREATE TABLE awkward (
   "a b" INTEGER,
   "c'd" INTEGER,
@@ -169,7 +170,11 @@ CREATE TABLE app.post_tags (
   tag_id INTEGER REFERENCES app.tags(id),
   note VARCHAR
 );
+CREATE SCHEMA "odd schema";
+CREATE TABLE "odd schema"."say ""hi"" now" (i INTEGER);
+INSERT INTO "odd schema"."say ""hi"" now" VALUES (1), (2);
 CHECKPOINT;
+DELETE FROM posts WHERE id = 4;
 """
 
 
@@ -246,7 +251,7 @@ def run_fixture(base):
         table.pop("ddl", None)
 
     expected = [
-        {"name": "post_tags", "schema": "app", "estimatedRows": 0,
+        {"name": "post_tags", "schema": "app", "rowCount": 0,
          "columns": [
              {"name": "tag_id", "type": "INTEGER", "notNull": False, "default": None, "primary": False},
              {"name": "note", "type": "VARCHAR", "notNull": False, "default": None, "primary": False},
@@ -257,7 +262,7 @@ def run_fixture(base):
          "foreignKeys": [
              {"columns": ["tag_id"], "refTable": "tags", "refSchema": "app", "refColumns": ["id"]},
          ]},
-        {"name": "tags", "schema": "app", "estimatedRows": 0,
+        {"name": "tags", "schema": "app", "rowCount": 0,
          "columns": [
              {"name": "id", "type": "INTEGER", "notNull": True, "default": None, "primary": True},
              {"name": "label", "type": "VARCHAR", "notNull": False, "default": None, "primary": False},
@@ -268,7 +273,7 @@ def run_fixture(base):
          ],
          "indexes": [],
          "foreignKeys": []},
-        {"name": "memberships", "schema": "main", "estimatedRows": 0,
+        {"name": "memberships", "schema": "main", "rowCount": 0,
          "columns": [
              {"name": "org_id", "type": "INTEGER", "notNull": False, "default": None, "primary": False},
              {"name": "user_id", "type": "INTEGER", "notNull": False, "default": None, "primary": False},
@@ -281,7 +286,7 @@ def run_fixture(base):
          ],
          "indexes": [],
          "foreignKeys": []},
-        {"name": "posts", "schema": "main", "estimatedRows": 3,
+        {"name": "posts", "schema": "main", "rowCount": 3,
          "columns": [
              {"name": "id", "type": "INTEGER", "notNull": True, "default": None, "primary": True},
              {"name": "user_id", "type": "INTEGER", "notNull": False, "default": None, "primary": False},
@@ -295,7 +300,7 @@ def run_fixture(base):
          "foreignKeys": [
              {"columns": ["user_id"], "refTable": "users", "refSchema": "main", "refColumns": ["id"]},
          ]},
-        {"name": "users", "schema": "main", "estimatedRows": 0,
+        {"name": "users", "schema": "main", "rowCount": 0,
          "columns": [
              {"name": "id", "type": "INTEGER", "notNull": True, "primary": True},
              {"name": "email", "type": "VARCHAR", "notNull": True, "primary": False},
@@ -313,8 +318,14 @@ def run_fixture(base):
         eq(f"{want['schema']}.{want['name']} answers its whole shape", want, got)
     eq("tables are ordered by (schema, name)",
        [("app", "post_tags"), ("app", "tags"), ("main", "awkward"), ("main", "memberships"),
-        ("main", "posts"), ("main", "users")],
+        ("main", "posts"), ("main", "users"), ("odd schema", 'say "hi" now')],
        [(t["schema"], t["name"]) for t in doc["tables"]])
+    eq("every full table has one exact rowCount", [],
+       [t["name"] for t in doc["tables"] if not isinstance(t.get("rowCount"), int)])
+    eq("physical deletes do not inflate rowCount", 3,
+       next(t for t in doc["tables"] if t["name"] == "posts")["rowCount"])
+    eq("quoted relations are counted exactly", 2,
+       next(t for t in doc["tables"] if t["name"] == 'say "hi" now')["rowCount"])
     eq("the sequence is there, with its start", [{"name": "users_seq", "start": 1}], doc["sequences"])
 
     # The point of the endpoint: the foreign key arrived from structured
@@ -368,23 +379,23 @@ def run_fixture(base):
     eq("a plain index has no expressions", [], by_name["idx_awk_space"]["expressions"])
 
     # -----------------------------------------------------------------------
-    section("The lite style: what exists and how big, not how it is built")
+    section("The lite style: what exists, not how big or how it is built")
     # -----------------------------------------------------------------------
     # Same document family at lower fidelity: the versions, the sizes, and
-    # each table as name/schema/estimatedRows — nothing else, so a client
-    # drawing a database list pays neither the shape queries nor the DDL
-    # bytes. A field a style omits is absent, never differently shaped.
+    # each table as name/schema — nothing else, so a client drawing a
+    # database list pays neither the count/shape queries nor the DDL bytes. A
+    # field a style omits is absent, never differently shaped.
     st, lbody, _ = fetch(base, "/catalog?style=lite")
     eq("lite is a 200", 200, st)
     lite = json.loads(lbody)
     eq("its keys are the inventory alone",
        ["harborVersion", "duckdbVersion", "databaseSizeBytes", "walSizeBytes", "tables"],
        list(lite.keys()))
-    eq("a lite table is name, schema, estimatedRows — nothing else",
-       [], [t for t in lite["tables"] if sorted(t.keys()) != ["estimatedRows", "name", "schema"]])
+    eq("a lite table is name and schema — nothing else",
+       [], [t for t in lite["tables"] if sorted(t.keys()) != ["name", "schema"]])
     eq("the same tables in the same order as the full document",
-       [(t["schema"], t["name"], t["estimatedRows"]) for t in doc["tables"]],
-       [(t["schema"], t["name"], t["estimatedRows"]) for t in lite["tables"]])
+       [(t["schema"], t["name"]) for t in doc["tables"]],
+       [(t["schema"], t["name"]) for t in lite["tables"]])
     eq("and the same sizes", (doc["databaseSizeBytes"], doc["walSizeBytes"]),
        (lite["databaseSizeBytes"], lite["walSizeBytes"]))
     eq("lite too answers byte-identical documents", lbody, fetch(base, "/catalog?style=lite")[1])

--- a/harbor/test/scripts/deployment.sh
+++ b/harbor/test/scripts/deployment.sh
@@ -346,7 +346,7 @@ section "Data at rest"
 tables=$(scalar "SELECT count(*) AS n FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','pg_catalog')")
 if [[ "$tables" =~ ^[0-9]+$ ]] && (( tables > 0 )); then
   ok "the attached database has tables" "$tables"
-  (( verbose )) && post "SELECT table_name, estimated_size FROM duckdb_tables() ORDER BY 1" | jq -rs 'map(select(.type=="row"))|.[]|.values|"       \(.[0]) — \(.[1]) rows"'
+  (( verbose )) && post "SELECT schema_name, table_name FROM duckdb_tables() WHERE NOT internal ORDER BY 1, 2" | jq -rs 'map(select(.type=="row"))|.[]|.values|"       \(.[0]).\(.[1])"'
 else
   soft "the attached database has tables" "none found — is this the database you meant to serve?"
 fi

--- a/harbor/test/scripts/fixture.sh
+++ b/harbor/test/scripts/fixture.sh
@@ -127,5 +127,5 @@ if [[ -f "$out.wal" ]]; then
   exit 1
 fi
 
-duckdb -no-init -readonly "$out" -c "SELECT table_name, estimated_size AS rows FROM duckdb_tables() ORDER BY 1"
+duckdb -no-init -readonly "$out" -c "SELECT schema_name, table_name FROM duckdb_tables() WHERE NOT internal ORDER BY 1, 2"
 echo "fixture: wrote $out ($(du -h "$out" | cut -f1))"


### PR DESCRIPTION
## Summary

- repair gpui-component root overlay rendering so Open Database URL can be reopened reliably
- present separate Open Database File and Open Database URL menu actions
- return exact per-table rowCount values from one generated UNION ALL catalog query
- keep the lite catalog count-free and update DuckTable to consume exact counts
- bump Harbor to 0.31.0 and DuckTable to 0.18.0

## Verification

- Harbor PR-grade suites: unit, lifecycle, types, spec, catalog, sessions, cancel
- Harbor workspace tests and release build
- DuckTable workspace tests, all-target check, and release app build
- catalog integration coverage for deleted rows and quoted relation names
- git diff --check