### PR TITLE
DuckTable 0.18.1: fix dark dialog colors

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/vendor/gpui-component/src/dialog.rs
+++ b/ducktable/vendor/gpui-component/src/dialog.rs
@@ -427,6 +427,7 @@ impl RenderOnce for Dialog {
                         v_flex()
                             .id(layer_ix)
                             .bg(cx.theme().background)
+                            .text_color(cx.theme().foreground)
                             .border_1()
                             .border_color(cx.theme().border)
                             .rounded(cx.theme().radius_lg)


### PR DESCRIPTION
## Summary
- make dialogs inherit the active theme foreground color
- restore readable titles and field labels in Duck Dark and Midnight
- bump DuckTable to 0.18.1

## Verification
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `scripts/macos-app.sh release`
- verified bundle version is 0.18.1
- `git diff --check`