### PR TITLE
Release Harbor 0.31.1

### DIFF
--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.31.0"
+version = "0.31.1"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -258,7 +258,7 @@ TABLE` rendering per table, and the database and WAL file sizes in exact bytes
 at the top:
 
 ```json
-{"harborVersion":"0.31.0","duckdbVersion":"v2.0.0-dev83323",
+{"harborVersion":"0.31.1","duckdbVersion":"v2.0.0-dev83323",
  "databaseSizeBytes":12582912,"walSizeBytes":0,
  "tables":[{"name":"orders","schema":"main","rowCount":300000,
             "columns":[…],"primaryKey":["id"],
@@ -326,7 +326,7 @@ with `sudo` in front of the whole command — the installer never escalates on
 its own. On Windows the binary lands in `%LOCALAPPDATA%\Programs\harbor\bin`,
 which the installer adds to your user `PATH`.
 
-Pin a version with `... | bash -s v0.31.0` (or `-Tag v0.31.0` on Windows). Each
+Pin a version with `... | bash -s v0.31.1` (or `-Tag v0.31.1` on Windows). Each
 [release](https://github.com/shreeve/duckdb-harbor/releases)
 ships one self-contained archive per
 platform (osx-arm64, linux-amd64, linux-arm64, windows-amd64, windows-arm64):


### PR DESCRIPTION
## Summary
- bump Harbor workspace packages to 0.31.1
- update current-version documentation examples
- pair the Harbor patch release with DuckTable 0.18.1

## Verification
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `cargo build --release -p harbor`
- release binary reports `harbor 0.31.1`
- `git diff --check`