### PR TITLE
DuckTable 0.18.2: simplify port copy

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "harbor-common",
  "serde",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/README.md
+++ b/ducktable/README.md
@@ -57,13 +57,13 @@ On Intel, or to build from source: clone the repo and run
 ## Databases by port
 
 Choose **File → Open Database URL…** when Harbor is already listening on a TCP
-port. Give the database a sidebar name, host, and Harbor port. `localhost`
+port. Give the database a sidebar name, host, and port. `localhost`
 connects directly; any other host makes DuckTable create the SSH tunnel:
 
 ```text
-Name         Production
-Host         foo.bar.com
-Harbor port  9494
+Name  Production
+Host  foo.bar.com
+Port  9494
 ```
 
 DuckTable asks macOS's `/usr/bin/ssh` to forward an arbitrary local IPv4
@@ -87,7 +87,7 @@ url = "http://foo.bar.com:9494"
 
 For a local listener, save `http://localhost:9494`; DuckTable normalizes that
 to IPv4 `127.0.0.1` when connecting. Use **File → Open Database File…** when
-starting from a DuckDB filename instead of a Harbor port.
+starting from a DuckDB filename instead of a port.
 
 ## Why Harbor-only
 

--- a/ducktable/crates/ducktable/src/add_database.rs
+++ b/ducktable/crates/ducktable/src/add_database.rs
@@ -42,8 +42,8 @@ pub(crate) fn open(view: WeakEntity<DuckTable>, window: &mut Window, cx: &mut Ap
                 )
                 .child(
                     field()
-                        .label("Harbor port")
-                        .description("The Harbor listener on that host")
+                        .label("Port")
+                        .description("The port that Harbor listens on that host")
                         .required(true)
                         .child(Input::new(&port)),
                 );

--- a/ducktable/crates/ducktable/src/app.rs
+++ b/ducktable/crates/ducktable/src/app.rs
@@ -615,7 +615,7 @@ impl DuckTable {
         );
     }
 
-    /// File → Open Database URL: persist the named Harbor port, then connect
+    /// File → Open Database URL: persist the named port, then connect
     /// through the same path a sidebar click uses. A failed dial still leaves
     /// the database saved so Retry has something durable to target.
     pub(crate) fn add_database(

--- a/ducktable/crates/harbor-client/src/fleet.rs
+++ b/ducktable/crates/harbor-client/src/fleet.rs
@@ -900,9 +900,9 @@ fn harbor_port(port: &str) -> Result<u16, String> {
     let port = port.trim();
     let parsed = port
         .parse::<u16>()
-        .map_err(|_| "Harbor port must be between 1 and 65535".to_string())?;
+        .map_err(|_| "Port must be between 1 and 65535".to_string())?;
     if parsed == 0 {
-        return Err("Harbor port must be between 1 and 65535".into());
+        return Err("Port must be between 1 and 65535".into());
     }
     Ok(parsed)
 }

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -51,7 +51,7 @@ Cmd reads as Ctrl.
 
 The File menu offers the two pieces of information a user can start with.
 **Open Database File…** chooses a DuckDB path. **Open Database URL…** asks for a
-sidebar name, host, and Harbor port. Host defaults to `localhost`, which
+sidebar name, host, and port. Host defaults to `localhost`, which
 DuckTable resolves explicitly to IPv4 `127.0.0.1` and connects to directly. Any
 other host tells DuckTable to create an SSH tunnel to that host and forward its
 Harbor loopback port. A tunneled row remains a normal DATABASES row and says


### PR DESCRIPTION
## Summary
- label the URL dialog field simply as `Port`
- describe it as `The port that Harbor listens on that host`
- align validation and documentation terminology
- sync DuckTable lockfile dependencies with Harbor 0.31.1
- bump DuckTable to 0.18.2

## Verification
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `scripts/macos-app.sh release`
- verified bundle version is 0.18.2
- `git diff --check`