### PR TITLE
Use httpfs in Harbor init examples

### DIFF
--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -81,13 +81,13 @@ requirement, not an option.
 **Standing settings live in config**: a database's `[connection.*]` entry
 supplies its own memory, threads, and boot SQL, so a bare start — a summon, an
 autostart at boot — honors them without flags; explicit flags override. `init`
-is the open door: `init = ["INSTALL ui", "LOAD ui"]` or any `SET`/secret runs
-verbatim on the control connection before serving, so harbor passes a berth's
-customizations straight to DuckDB without knowing what they are. A
-`[connection.<name>.settings]` block is the same door in key-value form — each
-`key = value` becomes `SET key = value` (applied after `init`, so it can tune
-an extension just loaded), for any DuckDB option harbor has no typed field for.
-TCP exposure (`port`) is config-settable but honored only by an explicit
+is the open door: `init = ["INSTALL httpfs", "LOAD httpfs"]` or any
+`SET`/secret runs verbatim on the control connection before serving, so harbor
+passes a berth's customizations straight to DuckDB without knowing what they
+are. A `[connection.<name>.settings]` block is the same door in key-value form
+— each `key = value` becomes `SET key = value` (applied after `init`, so it can
+tune an extension just loaded), for any DuckDB option harbor has no typed field
+for. TCP exposure (`port`) is config-settable but honored only by an explicit
 start; it binds loopback, and a summon stays on the Unix socket. A config file
 others can write is refused whole before any of it is read.
 

--- a/harbor/crates/common/src/config.rs
+++ b/harbor/crates/common/src/config.rs
@@ -10,7 +10,7 @@
 //! [connection.medlabs]      # has `path` -> a local berth, harbor can start it
 //! path = "~/Data/Code/medlabs/api/db/medlabs.duckdb"
 //! memory-limit = "8GB"      # typed tuning fields mirror `harbor start` flags
-//! init = ["INSTALL ui", "LOAD ui"]   # any boot SQL: extensions, secrets, SET
+//! init = ["INSTALL httpfs", "LOAD httpfs"]  # any boot SQL: extensions, secrets, SET
 //!
 //! [connection.medlabs.settings]      # any DuckDB option -> SET <key> = <value>
 //! enable_progress_bar = true         # keys are DuckDB's own, passed through


### PR DESCRIPTION
Use the familiar `httpfs` extension in Harbor configuration examples. Documentation-only; no release required.