### PR TITLE
DuckTable 0.18.3: keep Harbor connections alive

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.18.2"
+version = "0.18.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/harbor-client/src/fleet.rs
+++ b/ducktable/crates/harbor-client/src/fleet.rs
@@ -9,12 +9,11 @@
 //! wants: config-named remotes, size on disk, and the whole connection half
 //! (Conn, connect).
 //!
-//! The lifecycle law is harbor's own, verbatim: **a detached start is
-//! ephemeral — it lives while anyone is connected; an attached (or bare)
-//! start is persistent — it lives until stopped.** DuckTable holds no anchor
-//! connection (its requests are one-shot), so when it summons a database it
-//! summons a persistent `start` — up until stopped — rather than a refcounted
-//! one that would retire between clicks.
+//! The lifecycle law is harbor's own: **a detached start is ephemeral — it
+//! lives while anyone is connected; an attached (or bare) start is persistent
+//! — it lives until stopped.** DuckTable owns one quiet anchor connection for
+//! as long as a database is open, so an ephemeral server stays present between
+//! its otherwise one-shot requests and retires when the database closes.
 
 use crate::http::{Transport, request};
 use harbor_common::State;
@@ -284,6 +283,10 @@ fn sock_ready(sock: &Path) -> bool {
 pub struct Conn {
     pub name: String,
     transport: Transport,
+    /// Presence is shared with every clone, just like the tunnel. The final
+    /// clone closes it, allowing an ephemeral Harbor server to retire.
+    #[allow(dead_code)]
+    anchor: Arc<crate::http::Anchor>,
     /// True when this connect raised the server (worth a status line).
     /// A summoned server is an ephemeral `start` — it self-retires once its
     /// last client disconnects, so closing the window that opened it lets it
@@ -296,12 +299,24 @@ pub struct Conn {
 }
 
 impl Conn {
-    fn plain(name: String, transport: Transport, summoned: bool) -> Self {
-        Self { name, transport, summoned, tunnel: None }
+    fn plain(name: String, transport: Transport, summoned: bool) -> Result<Self, String> {
+        let anchor = crate::http::hold(&transport)
+            .map(Arc::new)
+            .map_err(|e| format!("connecting to Harbor: {e}"))?;
+        Ok(Self { name, transport, anchor, summoned, tunnel: None })
     }
 
-    fn tunneled(name: String, transport: Transport, tunnel: SshTunnel) -> Self {
-        Self { name, transport, summoned: false, tunnel: Some(Arc::new(tunnel)) }
+    fn tunneled(name: String, transport: Transport, tunnel: SshTunnel) -> Result<Self, String> {
+        let anchor = crate::http::hold(&transport)
+            .map(Arc::new)
+            .map_err(|e| format!("connecting to Harbor through SSH: {e}"))?;
+        Ok(Self {
+            name,
+            transport,
+            anchor,
+            summoned: false,
+            tunnel: Some(Arc::new(tunnel)),
+        })
     }
 
     pub fn transport(&self) -> Result<&Transport, String> {
@@ -332,9 +347,9 @@ pub fn connect(name: &str) -> Result<Conn, String> {
             if !target.is_local() {
                 validate_ssh_host(&target.host)?;
                 let (transport, tunnel) = open_tunnel(&target.host, target.port)?;
-                return Ok(Conn::tunneled(name, transport, tunnel));
+                return Conn::tunneled(name, transport, tunnel);
             }
-            return Ok(Conn::plain(name, Transport::Tcp(target.addr()), false));
+            return Conn::plain(name, Transport::Tcp(target.addr()), false);
         }
         let db = entry
             .database()
@@ -347,14 +362,17 @@ pub fn connect(name: &str) -> Result<Conn, String> {
         let sock21 = paths::socket_for(&home, &db)?;
         let sock19 = paths::sock_file(&home, &name);
         let join = |summoned: bool| {
-            [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn::plain(
-                name.clone(),
-                #[cfg(unix)]
-                Transport::Unix(s.clone()),
-                #[cfg(not(unix))]
-                Transport::Tcp(String::new()),
-                summoned,
-            ))
+            [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).and_then(|s| {
+                Conn::plain(
+                    name.clone(),
+                    #[cfg(unix)]
+                    Transport::Unix(s.clone()),
+                    #[cfg(not(unix))]
+                    Transport::Tcp(String::new()),
+                    summoned,
+                )
+                .ok()
+            })
         };
         if let Some(conn) = join(false) {
             return Ok(conn);
@@ -384,11 +402,11 @@ pub fn connect(name: &str) -> Result<Conn, String> {
     if let Some(l) = discover().into_iter().find(|l| l.name == name) {
         #[cfg(unix)]
         {
-            return Ok(Conn::plain(
+            return Conn::plain(
                 name,
                 Transport::Unix(l.sock),
                 false,
-            ));
+            );
         }
     }
     Err(format!(
@@ -416,14 +434,17 @@ pub fn connect_path(db: &Path) -> Result<Conn, String> {
     let sock21 = paths::socket_for(&home, &db)?;
     let sock19 = paths::sock_file(&home, &name);
     let join = |summoned: bool| {
-        [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).map(|s| Conn::plain(
-            name.clone(),
-            #[cfg(unix)]
-            Transport::Unix(s.clone()),
-            #[cfg(not(unix))]
-            Transport::Tcp(String::new()),
-            summoned,
-        ))
+        [&sock21, &sock19].into_iter().find(|s| sock_ready(s)).and_then(|s| {
+            Conn::plain(
+                name.clone(),
+                #[cfg(unix)]
+                Transport::Unix(s.clone()),
+                #[cfg(not(unix))]
+                Transport::Tcp(String::new()),
+                summoned,
+            )
+            .ok()
+        })
     };
     if let Some(conn) = join(false) {
         return Ok(conn);
@@ -941,6 +962,30 @@ pub fn info(conn: &Conn) -> Result<wire::InfoResponse, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write as _;
+
+    fn accepting_transport() -> (Transport, std::thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0_u8; 1];
+            while stream.read(&mut byte).unwrap() == 1 {
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            assert!(String::from_utf8(request).unwrap().contains("Connection: keep-alive"));
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .unwrap();
+            let mut byte = [0_u8; 1];
+            assert_eq!(stream.read(&mut byte).unwrap(), 0);
+        });
+        (Transport::Tcp(addr.to_string()), server)
+    }
 
     // The name law and the socket-naming rule live in harbor-common,
     // shared with harbor itself — no client-side copy to drift.
@@ -1000,6 +1045,19 @@ mod tests {
         assert!(!http_target("http://foo.bar.com:9494").unwrap().is_local());
     }
 
+    #[test]
+    fn the_last_connection_clone_releases_its_harbor_presence() {
+        let (transport, server) = accepting_transport();
+        let conn = Conn::plain("local".into(), transport, true).unwrap();
+        let last = conn.clone();
+        drop(conn);
+
+        // The shared anchor still belongs to the remaining connection.
+        assert!(!server.is_finished());
+        drop(last);
+        server.join().unwrap();
+    }
+
     #[cfg(unix)]
     #[test]
     fn the_last_connection_clone_closes_its_ssh_process() {
@@ -1014,19 +1072,22 @@ mod tests {
         };
         let child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
         let pid = child.id().to_string();
+        let (transport, server) = accepting_transport();
         let conn = Conn::tunneled(
             "remote".into(),
-            Transport::Tcp("127.0.0.1:1".into()),
+            transport,
             SshTunnel {
                 child: Mutex::new(child),
                 stderr: Arc::new(Mutex::new(Vec::new())),
                 host: "remote".into(),
             },
-        );
+        )
+        .unwrap();
         let last = conn.clone();
         drop(conn);
         assert!(exists(&pid));
         drop(last);
         assert!(!exists(&pid));
+        server.join().unwrap();
     }
 }

--- a/ducktable/crates/harbor-client/src/http.rs
+++ b/ducktable/crates/harbor-client/src/http.rs
@@ -12,6 +12,7 @@ use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 #[cfg(unix)]
 use std::path::PathBuf;
+use std::sync::mpsc;
 use std::time::Duration;
 use wire::endpoint::Route;
 
@@ -22,9 +23,52 @@ pub enum Transport {
     Tcp(String), // host:port
 }
 
+/// One quiet keep-alive connection that keeps a Harbor database present while
+/// its DuckTable connection is alive. It refreshes before Harbor's idle clock,
+/// and closes promptly when the final owner drops it.
+pub struct Anchor {
+    stop: Option<mpsc::Sender<()>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+pub fn hold(transport: &Transport) -> io::Result<Anchor> {
+    let first = keepalive(transport)?;
+    let transport = transport.clone();
+    let (stop, stopped) = mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let mut held = first;
+        let mut wait = Duration::from_secs(240);
+        loop {
+            match stopped.recv_timeout(wait) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => match keepalive(&transport) {
+                    Ok(next) => {
+                        drop(std::mem::replace(&mut held, next));
+                        wait = Duration::from_secs(240);
+                    }
+                    // Keep the current connection and retry well inside the
+                    // remaining idle-time margin.
+                    Err(_) => wait = Duration::from_secs(5),
+                },
+            }
+        }
+        drop(held);
+    });
+    Ok(Anchor { stop: Some(stop), worker: Some(worker) })
+}
+
+impl Drop for Anchor {
+    fn drop(&mut self) {
+        self.stop.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
 pub struct Response {
     pub status: u16,
-    pub body: Box<dyn BufRead>,
+    pub body: Box<dyn BufRead + Send>,
 }
 
 impl Response {
@@ -35,8 +79,8 @@ impl Response {
     }
 }
 
-trait Stream: Read + Write {}
-impl<T: Read + Write> Stream for T {}
+trait Stream: Read + Write + Send {}
+impl<T: Read + Write + Send> Stream for T {}
 
 /// The route carries its own verb, so a caller cannot pair `GET` with a path
 /// harbor only answers to `POST` — the mistake that reads as a 404.
@@ -45,6 +89,33 @@ pub fn request(
     route: &Route,
     body: Option<&str>,
     timeout: Option<Duration>,
+) -> io::Result<Response> {
+    request_inner(transport, route, body, timeout, false)
+}
+
+fn keepalive(transport: &Transport) -> io::Result<Response> {
+    let response = request_inner(
+        transport,
+        &wire::endpoint::READY,
+        None,
+        Some(Duration::from_secs(5)),
+        true,
+    )?;
+    if response.status != 200 {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("Harbor readiness returned HTTP {}", response.status),
+        ));
+    }
+    Ok(response)
+}
+
+fn request_inner(
+    transport: &Transport,
+    route: &Route,
+    body: Option<&str>,
+    timeout: Option<Duration>,
+    keep_alive: bool,
 ) -> io::Result<Response> {
     let (stream, host): (Box<dyn Stream>, String) = match transport {
         #[cfg(unix)]
@@ -61,7 +132,8 @@ pub fn request(
     };
     let mut stream = stream;
 
-    let mut req = format!("{route} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n");
+    let connection = if keep_alive { "keep-alive" } else { "close" };
+    let mut req = format!("{route} HTTP/1.1\r\nHost: {host}\r\nConnection: {connection}\r\n");
     req.push_str(&format!("Accept: {}\r\n", wire::CONTENT_NDJSON));
     if let Some(b) = body {
         req.push_str(&format!(
@@ -108,7 +180,7 @@ pub fn request(
         }
     }
 
-    let body: Box<dyn BufRead> = if chunked {
+    let body: Box<dyn BufRead + Send> = if chunked {
         Box::new(BufReader::new(ChunkedReader::new(reader)))
     } else if let Some(n) = content_length {
         Box::new(BufReader::new(reader.take(n)))

--- a/ducktable/crates/harbor-client/tests/live.rs
+++ b/ducktable/crates/harbor-client/tests/live.rs
@@ -67,6 +67,40 @@ fn a_live_berth_answers_sql() {
     assert_eq!(result.rows[0][2], serde_json::Value::Null);
 }
 
+/// The File→Open lifetime regression: with a sub-second Harbor linger, pause
+/// well beyond zero clients and prove the same DuckTable connection still
+/// answers. Run with:
+/// `HARBOR_BIN="$(pwd)/../harbor/target/debug/harbor" HARBOR_FIXTURE="$(pwd)/../harbor/sample.duckdb" HARBOR_LINGER_MS=500 cargo test -p harbor-client --test live an_open_database_outlives_harbors_linger -- --ignored`
+#[test]
+#[ignore]
+fn an_open_database_outlives_harbors_linger() {
+    let fixture = std::env::var("HARBOR_FIXTURE").expect("set HARBOR_FIXTURE");
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let db = std::env::temp_dir().join(format!("ducktable-anchor-{unique}.duckdb"));
+    std::fs::copy(fixture, &db).expect("copy fixture");
+    let socket = harbor_common::paths::socket_for(
+        &harbor_common::paths::runtime_dir().expect("runtime dir"),
+        &db,
+    )
+    .expect("socket path");
+
+    let conn = fleet::connect_path(&db).expect("connect_path");
+    harbor_client::query(&conn, "SELECT 1").expect("first query");
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    harbor_client::query(&conn, "SELECT 2").expect("query after Harbor linger");
+    drop(conn);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while socket.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(!socket.exists(), "ephemeral Harbor stayed after its connection closed");
+    let _ = std::fs::remove_file(db);
+}
+
 /// The exact wire sequence the GUI's ⌘S performs (docs/EDITING.md):
 /// a session pins one connection, BEGIN..COMMIT spans requests on it,
 /// parameters bind instead of concatenating, and UPDATE answers with a


### PR DESCRIPTION
Fix DuckTable's local database lifecycle by retaining a quiet Harbor keep-alive connection for the lifetime of each open database. The anchor is shared across connection clones, refreshed before Harbor's idle timeout, and released with the final clone; tunneled connections retain the same ownership behavior.

Adds unit coverage for shared anchor and SSH lifetimes plus a live regression that proves an ephemeral Harbor survives beyond its linger while DuckTable is connected and retires after disconnect. Bumps DuckTable to 0.18.3.

Validation:
- cargo check --workspace --all-targets
- cargo test --workspace
- cargo clippy -p harbor-client --all-targets -- -D warnings
- live ephemeral-linger regression with HARBOR_LINGER_MS=500
- macOS release app build; bundle version 0.18.3