### PR TITLE
Add staged row insertion to DuckTable

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "harbor-common",
  "serde",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.18.3"
+version = "0.19.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/assets/icons/plus.svg
+++ b/ducktable/assets/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14"/>
+  <path d="M12 5v14"/>
+</svg>

--- a/ducktable/crates/ducktable/src/edits.rs
+++ b/ducktable/crates/ducktable/src/edits.rs
@@ -29,9 +29,28 @@ pub struct CellEdit {
 /// One row's staged fate.
 #[derive(Clone, Debug, PartialEq)]
 pub enum RowChange {
+    /// A not-yet-persisted row. Missing columns mean SQL DEFAULT; a
+    /// present cell means the user explicitly supplied a value or NULL.
+    Insert(BTreeMap<usize, CellEdit>),
     /// Schema column index -> staged cell.
     Update(BTreeMap<usize, CellEdit>),
     Delete,
+}
+
+/// How commit verifies one generated statement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatementExpectation {
+    /// UPDATE/DELETE return DuckDB's one-cell affected-row count.
+    AffectedOne,
+    /// INSERT ... RETURNING * must return exactly one row.
+    ReturnedOne,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Statement {
+    pub sql: String,
+    pub params: Vec<Value>,
+    pub expectation: StatementExpectation,
 }
 
 /// One undo step: the row entry's state before and after a mutation.
@@ -60,6 +79,7 @@ pub struct Edits {
     changes: HashMap<String, Entry>,
     undo: Vec<Op>,
     redo: Vec<Op>,
+    next_draft: u64,
 }
 
 /// A row identity's map key: its canonical JSON. Values compare by
@@ -77,6 +97,7 @@ impl Edits {
             changes: HashMap::new(),
             undo: Vec::new(),
             redo: Vec::new(),
+            next_draft: 1,
         }
     }
 
@@ -100,14 +121,19 @@ impl Edits {
             && self.columns == other.columns
     }
 
-    /// (updates, deletes) — the verb-split the status line shows.
-    pub fn counts(&self) -> (usize, usize) {
+    /// (inserts, updates, deletes) — the verb-split status line.
+    pub fn counts(&self) -> (usize, usize, usize) {
+        let inserts = self
+            .changes
+            .values()
+            .filter(|e| matches!(e.change, RowChange::Insert(_)))
+            .count();
         let deletes = self
             .changes
             .values()
             .filter(|e| matches!(e.change, RowChange::Delete))
             .count();
-        (self.changes.len() - deletes, deletes)
+        (inserts, self.changes.len() - inserts - deletes, deletes)
     }
 
     /// The staged display text for a cell, if any. `Some(None)` means
@@ -115,7 +141,9 @@ impl Edits {
     #[cfg(test)]
     pub fn staged_text(&self, key: &str, col: usize) -> Option<Option<SharedString>> {
         match &self.changes.get(key)?.change {
-            RowChange::Update(cells) => cells.get(&col).map(|c| c.text.clone()),
+            RowChange::Insert(cells) | RowChange::Update(cells) => {
+                cells.get(&col).map(|c| c.text.clone())
+            }
             RowChange::Delete => None,
         }
     }
@@ -139,6 +167,76 @@ impl Edits {
 
     pub fn column_name(&self, ix: usize) -> &str {
         self.columns.get(ix).map(String::as_str).unwrap_or("?")
+    }
+
+    /// The first INSERT cell DuckTable can prove is missing before it
+    /// asks the server. CHECK/UNIQUE/FK remain DuckDB's verdict.
+    pub fn first_missing_required(
+        &self,
+        not_null: &[bool],
+        defaults: &[Option<String>],
+        generated: &[bool],
+    ) -> Option<(String, usize)> {
+        self.entries().into_iter().find_map(|(key, _, change)| {
+            let RowChange::Insert(cells) = change else { return None };
+            not_null.iter().enumerate().find_map(|(col, required)| {
+                (*required
+                    && !generated.get(col).copied().unwrap_or(false)
+                    && defaults.get(col).and_then(Option::as_ref).is_none()
+                    && !cells.contains_key(&col))
+                .then(|| (key.to_string(), col))
+            })
+        })
+    }
+
+    /// Add an intentional all-DEFAULT draft. It is staged immediately:
+    /// DEFAULT VALUES can itself be a valid insert, and one undo removes it.
+    pub fn stage_insert(&mut self) -> String {
+        let key = format!("draft:{:020}", self.next_draft);
+        self.next_draft += 1;
+        self.apply(Op {
+            key: key.clone(),
+            identity: Vec::new(),
+            prev: None,
+            next: Some(RowChange::Insert(BTreeMap::new())),
+        });
+        key
+    }
+
+    /// Supply one draft cell. `text = None` is explicit SQL NULL; an
+    /// untouched/removed cell is DEFAULT and is absent from the map.
+    pub fn stage_insert_cell(
+        &mut self,
+        key: &str,
+        col: usize,
+        text: Option<SharedString>,
+        value: Value,
+    ) {
+        let Some(entry) = self.changes.get(key) else { return };
+        let RowChange::Insert(mut cells) = entry.change.clone() else { return };
+        let prev = Some(entry.change.clone());
+        cells.insert(col, CellEdit { original: None, text, value });
+        let next = Some(RowChange::Insert(cells));
+        if prev == next {
+            return;
+        }
+        self.apply(Op { key: key.to_string(), identity: Vec::new(), prev, next });
+    }
+
+    /// Restore a draft cell to DEFAULT by omitting it from INSERT.
+    pub fn stage_insert_default(&mut self, key: &str, col: usize) {
+        let Some(entry) = self.changes.get(key) else { return };
+        let RowChange::Insert(mut cells) = entry.change.clone() else { return };
+        let prev = Some(entry.change.clone());
+        if cells.remove(&col).is_none() {
+            return;
+        }
+        self.apply(Op {
+            key: key.to_string(),
+            identity: Vec::new(),
+            prev,
+            next: Some(RowChange::Insert(cells)),
+        });
     }
 
     fn apply(&mut self, op: Op) {
@@ -252,10 +350,11 @@ impl Edits {
         self.redo.clear();
     }
 
-    /// The staged set as parameterized statements, updates before
-    /// deletes, deterministic order. The WHERE binds the ORIGINAL key
-    /// values — a row's identity is what we fetched, not what we typed.
-    pub fn statements(&self) -> Vec<(String, Vec<Value>)> {
+    /// The staged set as parameterized statements: inserts, updates,
+    /// deletes, deterministic within each verb. Missing insert columns
+    /// stay out of the statement so DuckDB supplies DEFAULT. The WHERE
+    /// binds the ORIGINAL key values for existing rows.
+    pub fn statements(&self) -> Vec<Statement> {
         let mut out = Vec::new();
         let where_clause = self
             .pk_cols
@@ -263,6 +362,29 @@ impl Edits {
             .map(|c| format!("{} = ?", qident(c)))
             .collect::<Vec<_>>()
             .join(" AND ");
+        for (_, _, change) in self.entries() {
+            if let RowChange::Insert(cells) = change {
+                let (sql, params) = if cells.is_empty() {
+                    (format!("INSERT INTO {} DEFAULT VALUES RETURNING *", self.source), Vec::new())
+                } else {
+                    let names = cells
+                        .keys()
+                        .map(|ix| qident(self.column_name(*ix)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let marks = std::iter::repeat_n("?", cells.len()).collect::<Vec<_>>().join(", ");
+                    (
+                        format!("INSERT INTO {} ({names}) VALUES ({marks}) RETURNING *", self.source),
+                        cells.values().map(|c| c.value.clone()).collect(),
+                    )
+                };
+                out.push(Statement {
+                    sql,
+                    params,
+                    expectation: StatementExpectation::ReturnedOne,
+                });
+            }
+        }
         for (_, identity, change) in self.entries() {
             if let RowChange::Update(cells) = change {
                 let set = cells
@@ -273,18 +395,20 @@ impl Edits {
                 let mut params: Vec<Value> =
                     cells.values().map(|c| c.value.clone()).collect();
                 params.extend(identity.iter().cloned());
-                out.push((
-                    format!("UPDATE {} SET {} WHERE {}", self.source, set, where_clause),
+                out.push(Statement {
+                    sql: format!("UPDATE {} SET {} WHERE {}", self.source, set, where_clause),
                     params,
-                ));
+                    expectation: StatementExpectation::AffectedOne,
+                });
             }
         }
         for (_, identity, change) in self.entries() {
             if matches!(change, RowChange::Delete) {
-                out.push((
-                    format!("DELETE FROM {} WHERE {}", self.source, where_clause),
-                    identity.to_vec(),
-                ));
+                out.push(Statement {
+                    sql: format!("DELETE FROM {} WHERE {}", self.source, where_clause),
+                    params: identity.to_vec(),
+                    expectation: StatementExpectation::AffectedOne,
+                });
             }
         }
         out
@@ -369,7 +493,7 @@ mod tests {
     fn a_cell_edited_back_to_its_original_auto_cleans() {
         let mut e = edits();
         e.stage_cell(vec![json!(1)], 1, txt("a"), txt("b"), json!("b"));
-        assert_eq!(e.counts(), (1, 0));
+        assert_eq!(e.counts(), (0, 1, 0));
         e.stage_cell(vec![json!(1)], 1, txt("a"), txt("a"), json!("a"));
         assert!(e.is_empty(), "diff, not log: equal-to-original leaves no entry");
     }
@@ -408,11 +532,11 @@ mod tests {
         e.stage_delete(vec![json!(9)]);
         let stmts = e.statements();
         assert_eq!(stmts.len(), 2);
-        assert_eq!(stmts[0].0, "UPDATE \"main\".\"t\" SET \"id\" = ?, \"qty\" = ? WHERE \"id\" = ?");
+        assert_eq!(stmts[0].sql, "UPDATE \"main\".\"t\" SET \"id\" = ?, \"qty\" = ? WHERE \"id\" = ?");
         // A PK edit is just an update: SET binds the new value, WHERE the original.
-        assert_eq!(stmts[0].1, vec![json!(7), Value::Null, json!(5)]);
-        assert_eq!(stmts[1].0, "DELETE FROM \"main\".\"t\" WHERE \"id\" = ?");
-        assert_eq!(stmts[1].1, vec![json!(9)]);
+        assert_eq!(stmts[0].params, vec![json!(7), Value::Null, json!(5)]);
+        assert_eq!(stmts[1].sql, "DELETE FROM \"main\".\"t\" WHERE \"id\" = ?");
+        assert_eq!(stmts[1].params, vec![json!(9)]);
     }
 
     #[test]
@@ -422,7 +546,7 @@ mod tests {
         e.stage_delete(vec![json!(1)]);
         let key = key_of(&[json!(1)]);
         assert!(e.is_deleted(&key));
-        assert_eq!(e.counts(), (0, 1));
+        assert_eq!(e.counts(), (0, 0, 1));
         assert!(e.undo());
         assert!(!e.is_deleted(&key));
         assert_eq!(e.staged_text(&key, 1), Some(txt("b")));
@@ -436,5 +560,65 @@ mod tests {
         assert_eq!(parse_value("null", "VARCHAR").unwrap(), json!("null"));
         assert_eq!(parse_value("19.99", "DECIMAL(10,2)").unwrap(), json!("19.99"));
         assert_eq!(parse_value("true", "BOOLEAN").unwrap(), json!(true));
+    }
+
+    #[test]
+    fn inserts_omit_defaults_bind_values_and_undo_as_rows() {
+        let mut e = edits();
+        let defaults = e.stage_insert();
+        let supplied = e.stage_insert();
+        e.stage_insert_cell(&supplied, 1, txt("Ada"), json!("Ada"));
+        e.stage_insert_cell(&supplied, 2, None, Value::Null);
+        assert_eq!(e.counts(), (2, 0, 0));
+
+        let stmts = e.statements();
+        assert_eq!(stmts[0].sql, "INSERT INTO \"main\".\"t\" DEFAULT VALUES RETURNING *");
+        assert!(stmts[0].params.is_empty());
+        assert_eq!(
+            stmts[1].sql,
+            "INSERT INTO \"main\".\"t\" (\"name\", \"qty\") VALUES (?, ?) RETURNING *"
+        );
+        assert_eq!(stmts[1].params, vec![json!("Ada"), Value::Null]);
+        assert_eq!(stmts[1].expectation, StatementExpectation::ReturnedOne);
+
+        e.discard(&defaults);
+        assert_eq!(e.counts(), (1, 0, 0));
+        assert!(e.undo());
+        assert_eq!(e.counts(), (2, 0, 0));
+    }
+
+    #[test]
+    fn restoring_a_draft_cell_to_default_removes_it_from_insert() {
+        let mut e = edits();
+        let key = e.stage_insert();
+        e.stage_insert_cell(&key, 0, txt("7"), json!(7));
+        e.stage_insert_default(&key, 0);
+        assert_eq!(
+            e.statements()[0].sql,
+            "INSERT INTO \"main\".\"t\" DEFAULT VALUES RETURNING *"
+        );
+    }
+
+    #[test]
+    fn required_insert_validation_respects_defaults_and_generated_columns() {
+        let mut e = edits();
+        let key = e.stage_insert();
+        assert_eq!(
+            e.first_missing_required(
+                &[true, true, true],
+                &[Some("nextval('s')".into()), None, None],
+                &[false, false, true],
+            ),
+            Some((key.clone(), 1))
+        );
+        e.stage_insert_cell(&key, 1, txt("Ada"), json!("Ada"));
+        assert_eq!(
+            e.first_missing_required(
+                &[true, true, true],
+                &[Some("nextval('s')".into()), None, None],
+                &[false, false, true],
+            ),
+            None
+        );
     }
 }

--- a/ducktable/crates/ducktable/src/footer.rs
+++ b/ducktable/crates/ducktable/src/footer.rs
@@ -13,7 +13,7 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::button::ButtonVariants as _;
 use gpui_component::tooltip::Tooltip;
-use gpui_component::{Sizable as _, StyledExt as _};
+use gpui_component::{Disableable as _, Sizable as _, StyledExt as _};
 
 /// A key value as the review popover shows it: strings bare, everything
 /// else in its JSON spelling.
@@ -249,14 +249,27 @@ impl Grid {
                 // read as separate controls, not a fused cluster.
                 d.child(div().ml_1().child(self.columns_popover(cx)))
             })
+            .when(view == ViewMode::Data && self.edits.is_some(), |d| {
+                d.child(
+                    gpui_component::button::Button::new("add-row")
+                        .icon(gpui_component::IconName::Plus)
+                        .ghost()
+                        .xsmall()
+                        .disabled(self.committing)
+                        .tooltip("Add row")
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.add_row(window, cx);
+                        })),
+                )
+            })
             // The staging story, told where the eye rests between edits:
             // the verb-split count while changes wait, "committing…"
             // while the transaction runs, or the read-only reason when
             // there is no primary key to key changes by (docs/EDITING.md
             // — a refusal is stated, never a mystery).
             .when(view == ViewMode::Data, |d| {
-                let (updates, deletes) =
-                    self.edits.as_ref().map(|e| e.counts()).unwrap_or((0, 0));
+                let (inserts, updates, deletes) =
+                    self.edits.as_ref().map(|e| e.counts()).unwrap_or((0, 0, 0));
                 if self.committing {
                     d.child(
                         div()
@@ -265,8 +278,12 @@ impl Grid {
                             .text_color(t.muted)
                             .child("committing\u{2026}"),
                     )
-                } else if updates + deletes > 0 {
-                    d.child(div().ml_2().child(self.staged_popover(updates, deletes, cx)))
+                } else if inserts + updates + deletes > 0 {
+                    d.child(
+                        div()
+                            .ml_2()
+                            .child(self.staged_popover(inserts, updates, deletes, cx)),
+                    )
                 } else if self.edits.is_none() && !loading_empty {
                     d.child(
                         div()
@@ -389,6 +406,7 @@ impl Grid {
     /// Commit and Discard all sit at the bottom.
     fn staged_popover(
         &self,
+        inserts: usize,
         updates: usize,
         deletes: usize,
         cx: &mut Context<Self>,
@@ -402,9 +420,15 @@ impl Grid {
                 format!("{n} {word}s")
             }
         };
-        // Verb-split label: updates in accent, deletes in the danger
+        // Verb-split label: inserts/updates in accent, deletes in the danger
         // color — destruction never hides inside a neutral count.
         let mut label = div().h_flex().items_center().gap_1().text_xs();
+        if inserts > 0 {
+            label = label.child(div().text_color(t.accent).child(plural(inserts, "insert")));
+        }
+        if inserts > 0 && (updates > 0 || deletes > 0) {
+            label = label.child(div().text_color(t.muted).child("\u{00b7}"));
+        }
         if updates > 0 {
             label = label.child(div().text_color(t.accent).child(plural(updates, "update")));
         }
@@ -441,6 +465,29 @@ impl Grid {
                                     .collect::<Vec<_>>()
                                     .join(", ");
                                 match change {
+                                    crate::edits::RowChange::Insert(cells) => (
+                                        key.to_string(),
+                                        "new row".to_string(),
+                                        if cells.is_empty() {
+                                            vec!["all columns: DEFAULT".to_string()]
+                                        } else {
+                                            cells
+                                                .iter()
+                                                .map(|(col, cell)| {
+                                                    format!(
+                                                        "{}: {}",
+                                                        e.column_name(*col),
+                                                        cell
+                                                            .text
+                                                            .as_ref()
+                                                            .map(|s| s.as_ref())
+                                                            .unwrap_or("NULL"),
+                                                    )
+                                                })
+                                                .collect()
+                                        },
+                                        false,
+                                    ),
                                     crate::edits::RowChange::Delete => (
                                         key.to_string(),
                                         format!("row ({id})"),

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -95,6 +95,13 @@ pub(crate) struct Grid {
     /// NOT NULL per schema column (from the catalog, by name) — staging
     /// NULL into one refuses at the fingers, not at the server.
     not_null: Vec<bool>,
+    /// Declared defaults per schema column. A missing draft cell is
+    /// omitted from INSERT; this tells validation whether NOT NULL is
+    /// already satisfied by the engine.
+    defaults: Vec<Option<String>>,
+    /// Generated columns are visible but never writable. DuckDB computes
+    /// them from the supplied columns and INSERT RETURNING exposes them.
+    generated: Vec<bool>,
     /// A commit is in flight; ⌘S is a no-op until it resolves.
     pub(crate) committing: bool,
     /// Focus should return to the table on the next frame — set by paths
@@ -172,6 +179,12 @@ struct CellEditor {
     row: usize,
     /// Schema column index.
     col: usize,
+    /// Present for a synthetic INSERT row; existing rows resolve through
+    /// their fetched identity instead.
+    draft_key: Option<String>,
+    /// Distinguishes an untouched DEFAULT cell from explicit NULL; both
+    /// render without ordinary text.
+    draft_explicit: bool,
     input: Entity<gpui_component::input::InputState>,
     replace: bool,
 }
@@ -213,6 +226,15 @@ pub(crate) struct GridDelegate {
     /// Projection of the staged layer onto this page: (row, schema col)
     /// -> staged display text (None = staged NULL).
     staged: std::collections::HashMap<(usize, usize), Option<SharedString>>,
+    /// Synthetic INSERT rows prepended to the fetched page, in display
+    /// order. Their private keys live only in Edits and never enter SQL.
+    draft_keys: Vec<String>,
+    /// Explicit draft values. Absence means DEFAULT, distinct from a
+    /// present None which means explicit SQL NULL.
+    draft_cells: std::collections::HashMap<(usize, usize), Option<SharedString>>,
+    /// Placeholder for an untouched draft cell: REQUIRED, DEFAULT, NULL,
+    /// or GENERATED. Derived once from catalog metadata.
+    draft_hints: Vec<SharedString>,
     /// Rows staged for DELETE — ghosted with strikethrough until commit.
     deleted: std::collections::HashSet<usize>,
     /// The cell whose editor is open, and the editor to render there.
@@ -270,7 +292,7 @@ impl Grid {
     pub(crate) fn last_visible_row(&self, cx: &App) -> u64 {
         let d = self.table.read(cx).delegate();
         if d.gutter {
-            (d.base + d.rows.len()) as u64
+            (d.base + d.fetched_count()) as u64
         } else {
             0
         }
@@ -383,6 +405,9 @@ impl Grid {
             identities: Vec::new(),
             row_of: std::collections::HashMap::new(),
             staged: std::collections::HashMap::new(),
+            draft_keys: Vec::new(),
+            draft_cells: std::collections::HashMap::new(),
+            draft_hints: Vec::new(),
             deleted: std::collections::HashSet::new(),
             editing: None,
             tab_anchor: None,
@@ -415,16 +440,9 @@ impl Grid {
                 delegate.names.iter().map(|n| n.to_string()).collect(),
             )
         });
-        let not_null = delegate
-            .names
-            .iter()
-            .map(|n| {
-                structure
-                    .as_ref()
-                    .and_then(|s| s.cols.iter().find(|c| c.name == n.as_ref()))
-                    .is_some_and(|c| c.notnull)
-            })
-            .collect();
+        let (not_null, defaults, generated, hints) =
+            insert_metadata(&delegate.names, structure.as_ref());
+        delegate.draft_hints = hints;
         // Header dragging stays off until move_column permutes the
         // visible map for real — the library default half-enables it
         // (widths reorder, contents don't).
@@ -642,6 +660,8 @@ impl Grid {
             rowid,
             pk_cols,
             not_null,
+            defaults,
+            generated,
             committing: false,
             needs_focus: false,
             ring_keep: None,
@@ -802,6 +822,20 @@ impl Grid {
                         ));
                     }
                 }
+                // A grid born from a failed first fetch had no result
+                // columns when build() derived these arrays. Populate them
+                // alongside the first schema that eventually succeeds.
+                let names = grid.table.read(cx).delegate().names.clone();
+                if grid.not_null.len() != names.len() {
+                    let (not_null, defaults, generated, hints) =
+                        insert_metadata(&names, grid.structure.as_ref());
+                    grid.not_null = not_null;
+                    grid.defaults = defaults;
+                    grid.generated = generated;
+                    grid.table.update(cx, |state, _| {
+                        state.delegate_mut().draft_hints = hints;
+                    });
+                }
                 // Staged changes are identity-keyed; the new page gets
                 // them projected wherever (and whether) its rows match.
                 grid.sync_staged(cx);
@@ -857,7 +891,7 @@ impl Grid {
     pub(crate) fn has_next(&self, cx: &App) -> bool {
         match self.last_page() {
             Some(last) => self.page < last,
-            None => self.table.read(cx).delegate().rows.len() == self.page_size,
+            None => self.table.read(cx).delegate().fetched_count() == self.page_size,
         }
     }
 
@@ -1124,7 +1158,7 @@ impl Grid {
     /// line (footer.rs; Grid's side reads straight off the fields).
     pub(crate) fn table_facts(&self, cx: &App) -> (usize, usize, bool) {
         let d = self.table.read(cx).delegate();
-        (d.rows.len(), d.cols.len().saturating_sub(d.gutter as usize), d.loading)
+        (d.fetched_count(), d.cols.len().saturating_sub(d.gutter as usize), d.loading)
     }
 
     /// The selected row as (column, display value, is_null) pairs, for the
@@ -1134,15 +1168,29 @@ impl Grid {
     /// tints from.
     pub(crate) fn row_kv(&self, cx: &App) -> Option<Vec<(SharedString, SharedString, bool)>> {
         let d = self.table.read(cx).delegate();
-        let row = d.rows.get(d.selected?)?;
+        let row_ix = d.selected?;
+        let row = d.rows.get(row_ix)?;
+        let is_draft = d.draft_key(row_ix).is_some();
         Some(
             d.names
                 .iter()
                 .enumerate()
                 .skip(d.identity as usize)
-                .map(|(i, name)| match row.get(i) {
-                    None | Some(None) => (name.clone(), SharedString::from("NULL"), true),
-                    Some(Some(s)) => (name.clone(), s.clone(), false),
+                .map(|(i, name)| {
+                    if is_draft && !d.draft_cells.contains_key(&(row_ix, i)) {
+                        return (
+                            name.clone(),
+                            d.draft_hints
+                                .get(i)
+                                .cloned()
+                                .unwrap_or_else(|| SharedString::from("DEFAULT")),
+                            false,
+                        );
+                    }
+                    match row.get(i) {
+                        None | Some(None) => (name.clone(), SharedString::from("NULL"), true),
+                        Some(Some(s)) => (name.clone(), s.clone(), false),
+                    }
                 })
                 .collect(),
         )
@@ -1152,6 +1200,66 @@ impl Grid {
     // Editing (docs/EDITING.md). One meaning per key; Esc is lossless;
     // nothing writes until ⌘S.
     // ------------------------------------------------------------------
+
+    /// Add an intentional all-DEFAULT draft at the top of the current
+    /// page, then enter its first useful writable cell. The draft is an
+    /// ordinary staged change immediately; moving focus never writes it.
+    pub(crate) fn add_row(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.committing || self.edits.is_none() {
+            return;
+        }
+        if self.editor.is_some() && !self.confirm_and_move(0, 0, false, cx) {
+            return;
+        }
+        let key = self.edits.as_mut().expect("checked above").stage_insert();
+        self.error = None;
+        self.sync_staged(cx);
+        // sync_staged normally returns focus after a draft row appears or
+        // disappears; Add Row is the exception because its editor is the
+        // intended destination.
+        self.needs_focus = false;
+        let (row, col, reveal) = {
+            let d = self.table.read(cx).delegate();
+            let row = d.draft_keys.iter().position(|k| k == &key).unwrap_or(0);
+            let first_schema = d.identity as usize;
+            let required = (first_schema..d.names.len()).find(|&col| {
+                self.not_null.get(col).copied().unwrap_or(false)
+                    && self.defaults.get(col).and_then(Option::as_ref).is_none()
+                    && !self.generated.get(col).copied().unwrap_or(false)
+            });
+            let fallback = d
+                .visible
+                .iter()
+                .copied()
+                .find(|&col| !self.generated.get(col).copied().unwrap_or(false));
+            let col = required.or(fallback);
+            (row, col, col.is_some_and(|col| d.hidden.contains(&col)))
+        };
+        if reveal {
+            self.remap_columns(cx, |d| d.hidden.remove(&col.expect("reveal has a column")));
+        }
+        self.table.update(cx, |state, cx| {
+            if let Some(col) = col {
+                state.delegate_mut().active_cell = Some((row, col));
+            }
+            select_row(state, row, cx);
+            state.scroll_to_row(row, cx);
+            cx.notify();
+        });
+        if let Some(col) = col {
+            self.open_editor(row, col, None, window, cx);
+        } else {
+            // A generated-only table has no writable destination for an
+            // editor, but the staged DEFAULT row still needs keyboard
+            // focus so it can be committed or discarded.
+            self.needs_focus = true;
+        }
+        cx.notify();
+    }
 
     /// The grid's whole keymap, focus-scoped by construction: this
     /// listener sits on the grid wrapper, so it hears keys only when
@@ -1464,14 +1572,30 @@ impl Grid {
         if self.edits.is_none() || self.committing {
             return; // read-only says why in the footer, not with a beep
         }
-        let (original, deleted) = {
+        if self.generated.get(col).copied().unwrap_or(false) {
+            let name = self.table.read(cx).delegate().names[col].clone();
+            self.error = Some(format!("{name} is generated by DuckDB"));
+            cx.notify();
+            return;
+        }
+        let (original, deleted, draft_key, draft_explicit) = {
             let d = self.table.read(cx).delegate();
             if row >= d.rows.len() {
                 return;
             }
             let base = d.rows[row].get(col).cloned().flatten();
-            let staged = d.staged.get(&(row, col)).cloned();
-            (staged.unwrap_or(base), d.deleted.contains(&row))
+            let draft_key = d.draft_key(row).map(str::to_string);
+            let staged = if draft_key.is_some() {
+                d.draft_cells.get(&(row, col)).cloned()
+            } else {
+                d.staged.get(&(row, col)).cloned()
+            };
+            (
+                staged.unwrap_or(base),
+                d.deleted.contains(&row),
+                draft_key,
+                d.draft_cells.contains_key(&(row, col)),
+            )
         };
         if deleted {
             return; // you cannot edit a ghost; revert the delete first (⌘Z)
@@ -1509,7 +1633,14 @@ impl Grid {
             }
         })
         .detach();
-        self.editor = Some(CellEditor { row, col, input: input.clone(), replace });
+        self.editor = Some(CellEditor {
+            row,
+            col,
+            draft_key,
+            draft_explicit,
+            input: input.clone(),
+            replace,
+        });
         self.table.update(cx, |state, cx| {
             let d = state.delegate_mut();
             d.editing = Some((row, col));
@@ -1562,11 +1693,17 @@ impl Grid {
                 d.identities.get(ed.row).cloned(),
             )
         };
-        let staged = if text.is_empty() {
-            if fetched.is_none() {
+        let leave_default = ed.draft_key.is_some() && !ed.draft_explicit && text.is_empty();
+        let staged = if leave_default {
+            None
+        } else if text.is_empty() {
+            if fetched.is_none() && ed.draft_key.is_none() {
                 // NULL in, nothing typed, NULL out: confirming an empty
                 // editor over NULL is a no-op (stage_cell auto-cleans),
                 // not a NULL→'' edit.
+                Some((None, Value::Null))
+            } else if fetched.is_none() {
+                // Reconfirming an explicit NULL draft keeps it NULL.
                 Some((None, Value::Null))
             } else if edits::is_text_type(&ty) {
                 // An emptied editor: '' for text (the one honest way to
@@ -1589,19 +1726,31 @@ impl Grid {
                 }
             }
         };
-        let (staged_text, value) = match staged {
+        let staged_value = match staged {
             Some(pair) => pair,
             None => {
-                if !self.stageable_null(ed.col, cx) {
-                    self.editor = Some(ed);
-                    return false;
+                if leave_default {
+                    (None, Value::Null)
+                } else {
+                    if !self.stageable_null(ed.col, cx) {
+                        self.editor = Some(ed);
+                        return false;
+                    }
+                    (None, Value::Null)
                 }
-                (None, Value::Null)
             }
         };
-        if let (Some(edits), Some(identity)) = (&mut self.edits, identity) {
+        if let Some(edits) = &mut self.edits {
             self.error = None;
-            edits.stage_cell(identity, ed.col, fetched, staged_text, value);
+            if let Some(key) = &ed.draft_key {
+                if leave_default {
+                    edits.stage_insert_default(key, ed.col);
+                } else {
+                    edits.stage_insert_cell(key, ed.col, staged_value.0, staged_value.1);
+                }
+            } else if let Some(identity) = identity {
+                edits.stage_cell(identity, ed.col, fetched, staged_value.0, staged_value.1);
+            }
         }
         self.close_editor_cell(cx);
         self.sync_staged(cx);
@@ -1634,12 +1783,19 @@ impl Grid {
     /// Delete on a cell: clear it, type-honestly — '' for text columns,
     /// NULL for everything else. Never touches the row.
     fn stage_clear(&mut self, row: usize, col: usize, cx: &mut Context<Self>) {
-        let (ty, fetched, identity, deleted) = {
+        if self.generated.get(col).copied().unwrap_or(false) {
+            let name = self.table.read(cx).delegate().names[col].clone();
+            self.error = Some(format!("{name} is generated by DuckDB"));
+            cx.notify();
+            return;
+        }
+        let (ty, fetched, identity, draft_key, deleted) = {
             let d = self.table.read(cx).delegate();
             (
                 d.schema_cols.get(col).map(|c| c.duckdb_type.clone()).unwrap_or_default(),
                 d.rows.get(row).and_then(|r| r.get(col)).cloned().flatten(),
                 d.identities.get(row).cloned(),
+                d.draft_key(row).map(str::to_string),
                 d.deleted.contains(&row),
             )
         };
@@ -1654,9 +1810,13 @@ impl Grid {
             }
             (None, Value::Null)
         };
-        if let (Some(edits), Some(identity)) = (&mut self.edits, identity) {
+        if let Some(edits) = &mut self.edits {
             self.error = None;
-            edits.stage_cell(identity, col, fetched, text, value);
+            if let Some(key) = draft_key {
+                edits.stage_insert_cell(&key, col, text, value);
+            } else if let Some(identity) = identity {
+                edits.stage_cell(identity, col, fetched, text, value);
+            }
             self.sync_staged(cx);
         }
     }
@@ -1664,18 +1824,29 @@ impl Grid {
     /// ⌃⇧N: SQL NULL, deliberately, any column type.
     fn stage_null(&mut self, cx: &mut Context<Self>) {
         let Some((row, col)) = self.table.read(cx).delegate().active_cell else { return };
-        let (fetched, identity) = {
+        if self.generated.get(col).copied().unwrap_or(false) {
+            let name = self.table.read(cx).delegate().names[col].clone();
+            self.error = Some(format!("{name} is generated by DuckDB"));
+            cx.notify();
+            return;
+        }
+        let (fetched, identity, draft_key) = {
             let d = self.table.read(cx).delegate();
             (
                 d.rows.get(row).and_then(|r| r.get(col)).cloned().flatten(),
                 d.identities.get(row).cloned(),
+                d.draft_key(row).map(str::to_string),
             )
         };
         if !self.stageable_null(col, cx) {
             return;
         }
-        if let (Some(edits), Some(identity)) = (&mut self.edits, identity) {
-            edits.stage_cell(identity, col, fetched, None, Value::Null);
+        if let Some(edits) = &mut self.edits {
+            if let Some(key) = draft_key {
+                edits.stage_insert_cell(&key, col, None, Value::Null);
+            } else if let Some(identity) = identity {
+                edits.stage_cell(identity, col, fetched, None, Value::Null);
+            }
             self.sync_staged(cx);
         }
     }
@@ -1684,14 +1855,19 @@ impl Grid {
     /// reversible until commit. No dialog, ever: reversibility replaces
     /// confirmation.
     fn stage_delete_row(&mut self, cx: &mut Context<Self>) {
-        let identity = {
+        let (identity, draft_key) = {
             let d = self.table.read(cx).delegate();
-            d.selected
+            let row = d.selected
                 .or(d.active_cell.map(|(r, _)| r))
-                .and_then(|r| d.identities.get(r).cloned())
+                .unwrap_or(usize::MAX);
+            (d.identities.get(row).cloned(), d.draft_key(row).map(str::to_string))
         };
-        if let (Some(edits), Some(identity)) = (&mut self.edits, identity) {
-            edits.stage_delete(identity);
+        if let Some(edits) = &mut self.edits {
+            if let Some(key) = draft_key {
+                edits.discard(&key);
+            } else if let Some(identity) = identity {
+                edits.stage_delete(identity);
+            }
             self.sync_staged(cx);
         }
     }
@@ -1848,34 +2024,94 @@ impl Grid {
         cx.notify();
     }
 
-    /// Project the staged layer onto the current page: identity-keyed
-    /// changes land wherever (and whether) their rows appear.
+    /// Project the staging model into the grid. INSERT drafts are
+    /// synthetic rows before the fetched page; existing-row changes land
+    /// by identity wherever (and whether) their rows currently appear.
     fn sync_staged(&mut self, cx: &mut Context<Self>) {
-        let (staged, deleted) = {
-            let d = self.table.read(cx).delegate();
-            let mut staged = std::collections::HashMap::new();
-            let mut deleted = std::collections::HashSet::new();
-            if let Some(e) = &self.edits {
-                for (key, _, change) in e.entries() {
-                    let Some(&row) = d.row_of.get(key) else { continue };
-                    match change {
-                        edits::RowChange::Delete => {
-                            deleted.insert(row);
-                        }
-                        edits::RowChange::Update(cells) => {
-                            for (col, cell) in cells {
-                                staged.insert((row, *col), cell.text.clone());
-                            }
-                        }
-                    }
-                }
-            }
-            (staged, deleted)
-        };
+        let changes: Vec<(String, Vec<Value>, edits::RowChange)> = self
+            .edits
+            .as_ref()
+            .map(|e| {
+                e.entries()
+                    .into_iter()
+                    .map(|(key, identity, change)| {
+                        (key.to_string(), identity.to_vec(), change.clone())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let next_drafts: Vec<String> = changes
+            .iter()
+            .filter(|(_, _, change)| matches!(change, edits::RowChange::Insert(_)))
+            .map(|(key, _, _)| key.clone())
+            .collect();
+        let draft_shape_changed =
+            self.table.read(cx).delegate().draft_keys.as_slice() != next_drafts.as_slice();
+        if draft_shape_changed {
+            self.editor = None;
+            self.needs_focus = true;
+        }
         self.table.update(cx, |state, cx| {
             let d = state.delegate_mut();
-            d.staged = staged;
-            d.deleted = deleted;
+            d.remove_drafts();
+            d.staged.clear();
+            d.deleted.clear();
+
+            let width = d.schema_cols.len();
+            let mut draft_rows = Vec::new();
+            for (key, _, change) in &changes {
+                let edits::RowChange::Insert(cells) = change else { continue };
+                let row = draft_rows.len();
+                let mut values = vec![None; width];
+                for (col, cell) in cells {
+                    if *col < width {
+                        values[*col] = cell.text.clone();
+                        d.draft_cells.insert((row, *col), cell.text.clone());
+                    }
+                }
+                d.draft_keys.push(key.clone());
+                draft_rows.push(values);
+            }
+            let draft_count = draft_rows.len();
+            draft_rows.append(&mut d.rows);
+            d.rows = draft_rows;
+            let mut identities = vec![Vec::new(); draft_count];
+            identities.append(&mut d.identities);
+            d.identities = identities;
+            let mut labels = vec![SharedString::from("+"); draft_count];
+            labels.append(&mut d.row_labels);
+            d.row_labels = labels;
+
+            // Fetched identities shifted down by the inserted drafts.
+            d.row_of = d
+                .identities
+                .iter()
+                .enumerate()
+                .skip(draft_count)
+                .map(|(ix, id)| (edits::key_of(id), ix))
+                .collect();
+            for (key, _, change) in &changes {
+                let Some(&row) = d.row_of.get(key) else { continue };
+                match change {
+                    edits::RowChange::Update(cells) => {
+                        for (col, cell) in cells {
+                            d.staged.insert((row, *col), cell.text.clone());
+                        }
+                    }
+                    edits::RowChange::Delete => {
+                        d.deleted.insert(row);
+                    }
+                    edits::RowChange::Insert(_) => {}
+                }
+            }
+            if draft_shape_changed {
+                d.selected = None;
+                d.active_cell = None;
+                d.editing = None;
+                d.editor_input = None;
+                d.tab_anchor = None;
+                state.clear_selection(cx);
+            }
             // Dirtiness just changed under the selection: re-decide the
             // wash (undoing a row's last edit gives its wash back).
             if let Some(row) = state.delegate().selected {
@@ -1891,8 +2127,8 @@ impl Grid {
     /// only if there is actually something staged to carry.
     pub(crate) fn take_edits(&mut self) -> Option<Edits> {
         let e = self.edits.take()?;
-        let (updates, deletes) = e.counts();
-        if updates + deletes == 0 {
+        let (inserts, updates, deletes) = e.counts();
+        if inserts + updates + deletes == 0 {
             self.edits = Some(e);
             return None;
         }
@@ -1941,6 +2177,33 @@ impl Grid {
             return;
         }
         let Some(edits) = &self.edits else { return };
+        let missing = edits.first_missing_required(
+            &self.not_null,
+            &self.defaults,
+            &self.generated,
+        );
+        if let Some((key, col)) = missing {
+            let name = self
+                .table
+                .read(cx)
+                .delegate()
+                .names
+                .get(col)
+                .cloned()
+                .unwrap_or_else(|| SharedString::from("column"));
+            self.error = Some(format!("{name} is required for the new row · edits kept"));
+            self.remap_columns(cx, |d| d.hidden.remove(&col));
+            self.table.update(cx, |state, cx| {
+                let d = state.delegate_mut();
+                if let Some(row) = d.draft_keys.iter().position(|k| k == &key) {
+                    d.active_cell = Some((row, col));
+                    select_row(state, row, cx);
+                }
+                cx.notify();
+            });
+            cx.notify();
+            return;
+        }
         let stmts = edits.statements();
         if stmts.is_empty() {
             return;
@@ -1956,22 +2219,34 @@ impl Grid {
                     let sid = harbor_client::session_new(&conn)?;
                     let run = || -> Result<usize, String> {
                         harbor_client::exec(&conn, "BEGIN", None, Some(&sid))?;
-                        for (sql, params) in &stmts {
+                        for stmt in &stmts {
                             let r = harbor_client::exec(
                                 &conn,
-                                sql,
-                                Some(params.clone()),
+                                &stmt.sql,
+                                Some(stmt.params.clone()),
                                 Some(&sid),
                             )?;
-                            // The engine answers UPDATE/DELETE with one
-                            // count row; anything but exactly 1 means the
-                            // row is not what we fetched. Nothing lands.
-                            let affected = crate::sql::count_of(&r).unwrap_or(0);
-                            if affected != 1 {
-                                return Err(format!(
-                                    "a row changed since you read it \
-                                     ({affected} rows matched) — refresh and retry"
-                                ));
+                            match stmt.expectation {
+                                edits::StatementExpectation::AffectedOne => {
+                                    // The engine answers UPDATE/DELETE with one
+                                    // count row; anything but exactly 1 means the
+                                    // row is not what we fetched. Nothing lands.
+                                    let affected = crate::sql::count_of(&r).unwrap_or(0);
+                                    if affected != 1 {
+                                        return Err(format!(
+                                            "a row changed since you read it \
+                                             ({affected} rows matched) — refresh and retry"
+                                        ));
+                                    }
+                                }
+                                edits::StatementExpectation::ReturnedOne => {
+                                    if r.rows.len() != 1 {
+                                        return Err(format!(
+                                            "insert returned {} rows instead of 1",
+                                            r.rows.len()
+                                        ));
+                                    }
+                                }
                             }
                         }
                         harbor_client::exec(&conn, "COMMIT", None, Some(&sid))?;
@@ -2012,6 +2287,19 @@ impl Grid {
                         if let Some(e) = &mut grid.edits {
                             e.clear();
                         }
+                        // INSERT drafts have no fetched identity to fold
+                        // into the existing page. Remove their synthetic
+                        // rows now; the refetch below decides whether each
+                        // committed row belongs on this page/filter.
+                        grid.table.update(cx, |state, cx| {
+                            state.delegate_mut().remove_drafts();
+                            state.clear_selection(cx);
+                            let d = state.delegate_mut();
+                            d.selected = None;
+                            d.active_cell = None;
+                            state.refresh(cx);
+                            cx.notify();
+                        });
                         // No sync_staged here: it would also clear the
                         // delete ghosts. The refetch's own sync does.
                         // Fetch-first still holds: the page refetches so
@@ -2076,10 +2364,54 @@ fn select_row(
 }
 
 impl GridDelegate {
+    fn draft_count(&self) -> usize {
+        self.draft_keys.len()
+    }
+
+    fn fetched_count(&self) -> usize {
+        self.rows.len().saturating_sub(self.draft_count())
+    }
+
+    fn draft_key(&self, row: usize) -> Option<&str> {
+        self.draft_keys.get(row).map(String::as_str)
+    }
+
+    fn remove_drafts(&mut self) {
+        let count = self.draft_count();
+        if count == 0 {
+            return;
+        }
+        self.rows.drain(..count.min(self.rows.len()));
+        self.identities.drain(..count.min(self.identities.len()));
+        self.row_labels.drain(..count.min(self.row_labels.len()));
+        self.draft_keys.clear();
+        self.draft_cells.clear();
+        self.staged = self
+            .staged
+            .drain()
+            .filter_map(|((row, col), value)| {
+                (row >= count).then_some(((row - count, col), value))
+            })
+            .collect();
+        self.deleted = self
+            .deleted
+            .drain()
+            .filter_map(|row| (row >= count).then_some(row - count))
+            .collect();
+        self.row_of = self
+            .identities
+            .iter()
+            .enumerate()
+            .map(|(ix, id)| (edits::key_of(id), ix))
+            .collect();
+    }
+
     /// A row carrying any staged change — the rows whose color already
     /// tells a story, so the selection wash stays off them.
     fn row_dirty(&self, row: usize) -> bool {
-        self.deleted.contains(&row) || self.staged.keys().any(|(r, _)| *r == row)
+        row < self.draft_count()
+            || self.deleted.contains(&row)
+            || self.staged.keys().any(|(r, _)| *r == row)
     }
 
     /// Adopt a page's schema and rows — the one birth, shared by Grid::new
@@ -2122,6 +2454,10 @@ impl GridDelegate {
     /// raw values) before display conversion, then derive the render-side
     /// strings and labels. The one door rows enter the delegate through.
     fn adopt_rows(&mut self, rows: Vec<Vec<Value>>, base: usize) {
+        self.draft_keys.clear();
+        self.draft_cells.clear();
+        self.staged.clear();
+        self.deleted.clear();
         self.identities = if self.pk_ix.is_empty() {
             Vec::new()
         } else {
@@ -2231,7 +2567,7 @@ impl GridDelegate {
             }
         }
         if self.gutter {
-            let last = (self.base + self.rows.len()) as u64;
+            let last = (self.base + self.fetched_count()) as u64;
             self.cols[0].width = px(gutter_width(last));
         }
     }
@@ -2268,8 +2604,10 @@ impl TableDelegate for GridDelegate {
         // Column 0 is the row-number gutter: raised, muted, and a firmer
         // divider than the data cells (design.css `.grid td.num`).
         if self.gutter && col_ix == 0 {
+            let is_draft = row_ix < self.draft_count();
             let row_deleted = self.deleted.contains(&row_ix);
-            let row_dirty = !row_deleted && self.staged.keys().any(|(r, _)| *r == row_ix);
+            let row_dirty = is_draft
+                || (!row_deleted && self.staged.keys().any(|(r, _)| *r == row_ix));
             return div()
                 .h_flex()
                 .relative()
@@ -2301,7 +2639,7 @@ impl TableDelegate for GridDelegate {
                         .text_right()
                         .text_size(px(GUTTER_TEXT))
                         .font_family(value_font())
-                        .text_color(t.muted)
+                        .text_color(if is_draft { t.warn } else { t.muted })
                         // Absolute position: page 2 starts at 5,001, and
                         // the number says so (plain digits, like Sheets).
                         .child(self.row_labels.get(row_ix).cloned().unwrap_or_default()),
@@ -2374,8 +2712,10 @@ impl TableDelegate for GridDelegate {
         // The staged layer overrides the fetched value: a confirmed edit
         // shows its new text (or NULL) under a soft accent tint until ⌘S
         // makes it the database's truth.
-        let staged = self.staged.get(&(row_ix, data_col)).cloned();
-        let is_staged = staged.is_some();
+        let is_draft = row_ix < self.draft_count();
+        let draft_explicit = is_draft && self.draft_cells.contains_key(&(row_ix, data_col));
+        let staged = (!is_draft).then(|| self.staged.get(&(row_ix, data_col)).cloned()).flatten();
+        let is_staged = is_draft || staged.is_some();
         let value = match staged {
             Some(v) => Some(v),
             None => self.rows.get(row_ix).and_then(|r| r.get(data_col)).cloned(),
@@ -2482,6 +2822,32 @@ impl TableDelegate for GridDelegate {
                         .border_color(t.accent),
                 )
             });
+        if is_draft && !draft_explicit {
+            let hint = self
+                .draft_hints
+                .get(data_col)
+                .cloned()
+                .unwrap_or_else(|| SharedString::from("DEFAULT"));
+            let required = hint.as_ref() == "REQUIRED";
+            return cell
+                .when(right, |d| d.justify_end())
+                .child(
+                    div()
+                        .flex_none()
+                        .px(px(5.))
+                        .rounded(px(4.))
+                        .bg(if required {
+                            t.warn.opacity(0.18)
+                        } else {
+                            t.pill.opacity(0.45)
+                        })
+                        .text_size(px(TAG_TEXT * p.zoom_factor()))
+                        .font_family(ui_font())
+                        .text_color(if required { t.warn } else { t.muted.opacity(0.7) })
+                        .child(hint),
+                )
+                .into_any_element();
+        }
         match value {
             None | Some(None) => {
                 if !p.null_tags {
@@ -3094,6 +3460,46 @@ impl Render for Grid {
             .child(self.footer(cx))
             .into_any_element()
     }
+}
+
+type InsertMetadata = (
+    Vec<bool>,
+    Vec<Option<String>>,
+    Vec<bool>,
+    Vec<SharedString>,
+);
+
+/// Align catalog insert capabilities to the result schema. The hidden
+/// rowid has no catalog column and therefore receives the harmless NULL
+/// defaults; users never see or insert it.
+fn insert_metadata(
+    names: &[SharedString],
+    structure: Option<&crate::structure::TableStructure>,
+) -> InsertMetadata {
+    let cols: Vec<_> = names
+        .iter()
+        .map(|name| {
+            structure.and_then(|s| s.cols.iter().find(|c| c.name == name.as_ref()))
+        })
+        .collect();
+    let not_null: Vec<bool> = cols.iter().map(|c| c.is_some_and(|c| c.notnull)).collect();
+    let defaults: Vec<Option<String>> =
+        cols.iter().map(|c| c.and_then(|c| c.dflt.clone())).collect();
+    let generated: Vec<bool> = cols.iter().map(|c| c.is_some_and(|c| c.generated)).collect();
+    let hints = (0..names.len())
+        .map(|col| {
+            SharedString::from(if generated[col] {
+                "GENERATED"
+            } else if defaults[col].is_some() {
+                "DEFAULT"
+            } else if not_null[col] {
+                "REQUIRED"
+            } else {
+                "NULL"
+            })
+        })
+        .collect();
+    (not_null, defaults, generated, hints)
 }
 
 /// Wire values -> render-ready cell text (None = NULL), once per page.

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -242,7 +242,7 @@ macro_rules! icon {
     };
 }
 
-const ICONS: [(&str, &[u8]); 12] = [
+const ICONS: [(&str, &[u8]); 13] = [
     icon!("shapes"),
     icon!("panel-right"),
     icon!("search"),
@@ -255,6 +255,7 @@ const ICONS: [(&str, &[u8]); 12] = [
     icon!("check"),
     icon!("copy"),
     icon!("funnel"),
+    icon!("plus"),
 ];
 
 impl AssetSource for Assets {

--- a/ducktable/crates/ducktable/src/structure.rs
+++ b/ducktable/crates/ducktable/src/structure.rs
@@ -20,6 +20,8 @@ pub(crate) struct StructCol {
     pub(crate) ty: String,
     pub(crate) notnull: bool,
     pub(crate) dflt: Option<String>,
+    pub(crate) generated: bool,
+    pub(crate) generation_expression: Option<String>,
     pub(crate) pk: bool,
 }
 
@@ -40,6 +42,8 @@ pub(crate) fn table_structure(table: &harbor_client::Table) -> TableStructure {
             ty: c.duck_type.clone(),
             notnull: c.not_null,
             dflt: c.default.clone(),
+            generated: c.generated,
+            generation_expression: c.generation_expression.clone(),
             pk: c.primary,
         })
         .collect();
@@ -201,17 +205,25 @@ pub(crate) fn columns_grid(
         .cols
         .iter()
         .map(|c| {
-            let attrs = match (c.pk, c.notnull) {
-                (true, true) => "PK \u{00b7} NOT NULL",
-                (true, false) => "PK",
-                (false, true) => "NOT NULL",
-                (false, false) => "",
-            };
+            let mut attrs = Vec::new();
+            if c.pk {
+                attrs.push("PK");
+            }
+            if c.notnull {
+                attrs.push("NOT NULL");
+            }
+            if c.generated {
+                attrs.push("GENERATED");
+            }
             vec![
                 c.name.clone().into(),
                 c.ty.clone().into(),
-                attrs.into(),
-                c.dflt.clone().unwrap_or_default().into(),
+                attrs.join(" \u{00b7} ").into(),
+                c.generation_expression
+                    .clone()
+                    .or_else(|| c.dflt.clone())
+                    .unwrap_or_default()
+                    .into(),
             ]
         })
         .collect();

--- a/ducktable/crates/harbor-client/src/catalog.rs
+++ b/ducktable/crates/harbor-client/src/catalog.rs
@@ -58,6 +58,10 @@ pub struct Column {
     #[serde(default)]
     pub default: Option<String>,
     #[serde(default)]
+    pub generated: bool,
+    #[serde(default)]
+    pub generation_expression: Option<String>,
+    #[serde(default)]
     pub primary: bool,
 }
 
@@ -132,7 +136,8 @@ mod tests {
             "walSizeBytes": 0,
             "tables": [
                 {"name": "events", "schema": "main", "rowCount": 42,
-                 "columns": [{"name": "id", "type": "INTEGER", "notNull": true, "default": "nextval('id')", "primary": true}],
+                 "columns": [{"name": "id", "type": "INTEGER", "notNull": true, "default": "nextval('id')", "generated": false, "generationExpression": null, "primary": true},
+                              {"name": "slug", "type": "VARCHAR", "notNull": false, "default": "lower(name)", "generated": true, "generationExpression": "lower(name)", "primary": false}],
                  "primaryKey": ["id"], "uniqueConstraints": [], "indexes": [], "foreignKeys": [],
                  "ddl": "CREATE TABLE events(id INTEGER PRIMARY KEY DEFAULT(nextval('id')));"},
                 {"name": "zeta", "schema": "audit", "rowCount": 7, "columns": [], "primaryKey": []}
@@ -144,6 +149,12 @@ mod tests {
         assert_eq!(c.schemas(), vec!["main", "audit"]);
         assert_eq!(c.tables_in("main")[0].columns[0].duck_type, "INTEGER");
         assert!(c.tables_in("main")[0].columns[0].primary);
+        assert!(!c.tables_in("main")[0].columns[0].generated);
+        assert!(c.tables_in("main")[0].columns[1].generated);
+        assert_eq!(
+            c.tables_in("main")[0].columns[1].generation_expression.as_deref(),
+            Some("lower(name)")
+        );
         assert_eq!(c.tables_in("main")[0].row_count, Some(42));
         assert!(c.tables_in("main")[0].ddl.as_deref().unwrap().starts_with("CREATE TABLE"));
         assert_eq!(c.tables_in("audit")[0].row_count, Some(7));

--- a/ducktable/crates/harbor-client/tests/live.rs
+++ b/ducktable/crates/harbor-client/tests/live.rs
@@ -118,8 +118,12 @@ fn a_session_carries_a_transaction_with_bound_params() {
     let run = |sql: &str, params: Option<Vec<serde_json::Value>>| {
         harbor_client::exec(&conn, sql, params, Some(&sid)).expect(sql)
     };
-    // A TEMP table lives on the pinned connection and dies with it —
-    // the probe never touches the database's real schema.
+    // TEMP tables stay on the pinned worker rather than entering the
+    // database's real schema. A released session returns that connection
+    // to Harbor's pool, so clean up names explicitly for repeatability.
+    run("DROP TABLE IF EXISTS _dt_edit_probe", None);
+    run("DROP TABLE IF EXISTS _dt_insert_probe", None);
+    run("DROP TABLE IF EXISTS _dt_default_probe", None);
     run("CREATE TEMP TABLE _dt_edit_probe(id INTEGER PRIMARY KEY, name VARCHAR)", None);
     run("INSERT INTO _dt_edit_probe VALUES (?, ?), (?, ?)",
         Some(vec![json!(1), json!("a"), json!(2), json!("b")]));
@@ -143,6 +147,29 @@ fn a_session_carries_a_transaction_with_bound_params() {
     run("ROLLBACK", None);
     let intact = run("SELECT name FROM _dt_edit_probe WHERE id = 2", None);
     assert_eq!(intact.rows[0][0], json!("b"), "rollback left the row untouched");
+
+    // The staged-INSERT shape: omitted columns keep DEFAULT semantics,
+    // values bind, and RETURNING exposes the engine-computed truth.
+    run(
+        "CREATE TEMP TABLE _dt_insert_probe(\
+         id INTEGER PRIMARY KEY DEFAULT 41, \
+         name VARCHAR NOT NULL, \
+         doubled INTEGER GENERATED ALWAYS AS (id * 2))",
+        None,
+    );
+    run("BEGIN", None);
+    let inserted = run(
+        "INSERT INTO _dt_insert_probe (name) VALUES (?) RETURNING *",
+        Some(vec![json!("Ada")]),
+    );
+    assert_eq!(inserted.rows, vec![vec![json!(41), json!("Ada"), json!(82)]]);
+    run("COMMIT", None);
+    run("CREATE TEMP TABLE _dt_default_probe(answer INTEGER DEFAULT 42)", None);
+    let defaults = run("INSERT INTO _dt_default_probe DEFAULT VALUES RETURNING *", None);
+    assert_eq!(defaults.rows, vec![vec![json!(42)]]);
+    run("DROP TABLE _dt_edit_probe", None);
+    run("DROP TABLE _dt_insert_probe", None);
+    run("DROP TABLE _dt_default_probe", None);
     harbor_client::session_release(&conn, &sid);
     println!("session {sid}: transaction, params, counts — all as the spec assumes");
 }

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -24,6 +24,27 @@ disagree, this document wins.
    ease. After commit the grid refetches, so every row shows the
    database's truth — defaults filled, triggers applied.
 
+## Inserting rows
+
+The `+` button in the Data footer creates a draft row at the top of the
+current grid and opens its first required writable cell. The `+` in its row
+number rail is its identity: it is staged, not yet a database row. Additional
+clicks create additional drafts. Drafts stay above the fetched page through
+filter and page changes because hiding an uncommitted insert would be data
+loss disguised as navigation.
+
+An untouched draft cell means SQL `DEFAULT`, not NULL. DuckTable omits it from
+the INSERT so DuckDB can apply declared defaults, sequences, and generated
+expressions. The placeholder says what will happen: `REQUIRED`, `DEFAULT`,
+`NULL`, or `GENERATED`. Generated cells are read-only. Delete/Backspace keeps
+the grid's type-honest meaning — empty string for text, explicit NULL for
+other nullable types — and ⌃⇧N is always explicit NULL.
+
+Moving out of a draft never writes it. The row joins the same staged set as
+updates and deletes immediately, including undo, review, discard, table
+switches, and the all-or-nothing commit. Discarding/deleting a draft removes
+the pending INSERT; it never emits a DELETE.
+
 ## The grammar
 
 One meaning per key. No contextual double-agents.
@@ -109,14 +130,15 @@ not change, and printable exotica (AltGr, IME) already land on rung 6.
 
 ## Staging
 
-- A staged cell shows a soft accent tint. A staged delete shows the row
-  ghosted with strikethrough. While an editor is open there is no tint —
-  the editor surface is the state; staging happens when the editor
-  confirms.
+- A staged cell shows a soft accent tint. A draft insert shows the same tint
+  across its synthetic row; a staged delete shows the row ghosted with
+  strikethrough. While an editor is open there is no tint — the editor surface
+  is the state; staging happens when the editor confirms.
 - One entry per cell, last wins. A cell edited back to its original
   value auto-cleans: "3 changes" always means three real diffs.
 - The status line counts, verb-split when destruction is pending:
-  `3 changes · ⌘S to commit`, or `2 updates · 1 delete · ⌘S to commit`
+  `3 changes · ⌘S to commit`, or
+  `1 insert · 2 updates · 1 delete · ⌘S to commit`
   with the delete in the danger color. Clicking the count opens a
   popover listing every staged change (`column: old → new`, per-change
   discard) — audit is pull-based, never pushed.
@@ -142,14 +164,19 @@ not change, and printable exotica (AltGr, IME) already land on rung 6.
   someday.)
 - Primary-key cells are editable like any other — the WHERE holds the
   original, so `SET id = 7 WHERE id = 5` is just an update.
+- Draft inserts need no fetched identity. Each carries a private local key
+  until commit; `INSERT … RETURNING *` verifies that exactly one row landed,
+  and the post-commit refetch acquires its real primary key or rowid.
 - Statements are parameterized (`?` + bound params), never assembled
   from strings. Identifiers are quoted.
 
 ## Commit
 
 ⌘S opens a Harbor session (a pinned connection), then:
-`BEGIN` → each staged statement in order, each verified to have affected
-**exactly one row** → `COMMIT` → release. Any failure — SQL error,
+`BEGIN` → parameterized inserts, updates, and deletes, each verified to have
+affected or returned **exactly one row** → `COMMIT` → release. Before opening
+the session, DuckTable refuses a draft missing a `NOT NULL` column with no
+default. Any failure — SQL error,
 constraint, or a row that no longer matches its original values — rolls
 the whole transaction back: nothing landed, every staged change is kept
 and still visible, the offender is marked, and the status line says why,
@@ -170,6 +197,6 @@ only at ⌘S. Reversibility replaces confirmation.
 - **Live mode** (write-per-edit): designed in UI.md, deferred until it
   re-clears an adversarial review. If it ships, type-to-edit turns off
   in it — the two are certified only as a pair with staging.
-- Ghost insert row, duplicate-row (menu, blanking key/unique columns),
-  value popout editor for long/nested values, range selection and
+- Duplicate-row (menu, blanking key/unique columns), value popout editor for
+  long/nested values, range selection and
   TSV paste-spread, crash-recovery journal for staged edits.

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -179,7 +179,8 @@ appear.
 
 Bottom bar per table: the Data | Structure view switcher (JSON view
 later), the raw-SQL filter toggle, the Columns popover (search past 10
-columns, Show all / Hide all, full-row click targets), and the
+columns, Show all / Hide all, full-row click targets), the Data view's
+Add Row button (a staged draft appears above the fetched page), and the
 right-anchored status line: `1 ms · 1–500 of 5,410 rows · 9 columns ·
 |< < 500 per > >|`. The ordering is the anti-jump rule: in a
 right-justified cluster an element only moves when something to its

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.31.1"
+version = "0.32.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -253,15 +253,19 @@ you.
 
 `GET /catalog` answers what a client would otherwise ask in a dozen queries:
 every table with its columns, primary key, unique constraints, foreign keys,
-indexes and sequences — plus its exact row count and the engine's own `CREATE
+indexes and sequences — including whether a column is generated and its
+generation expression — plus its exact row count and the engine's own `CREATE
 TABLE` rendering per table, and the database and WAL file sizes in exact bytes
 at the top:
 
 ```json
-{"harborVersion":"0.31.1","duckdbVersion":"v2.0.0-dev83323",
+{"harborVersion":"0.32.0","duckdbVersion":"v2.0.0-dev83323",
  "databaseSizeBytes":12582912,"walSizeBytes":0,
  "tables":[{"name":"orders","schema":"main","rowCount":300000,
-            "columns":[…],"primaryKey":["id"],
+            "columns":[{"name":"id","type":"BIGINT","notNull":true,
+                        "default":null,"generated":false,
+                        "generationExpression":null,"primary":true},…],
+            "primaryKey":["id"],
             "ddl":"CREATE TABLE orders(id BIGINT PRIMARY KEY, …);"}, …],
  …}
 ```
@@ -326,7 +330,7 @@ with `sudo` in front of the whole command — the installer never escalates on
 its own. On Windows the binary lands in `%LOCALAPPDATA%\Programs\harbor\bin`,
 which the installer adds to your user `PATH`.
 
-Pin a version with `... | bash -s v0.31.1` (or `-Tag v0.31.1` on Windows). Each
+Pin a version with `... | bash -s v0.32.0` (or `-Tag v0.32.0` on Windows). Each
 [release](https://github.com/shreeve/duckdb-harbor/releases)
 ships one self-contained archive per
 platform (osx-arm64, linux-amd64, linux-arm64, windows-amd64, windows-arm64):

--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -2625,6 +2625,8 @@ struct CatalogColumn {
     ty: String,
     not_null: bool,
     default: Option<String>,
+    generated: bool,
+    generation_expression: Option<String>,
     primary: bool,
 }
 
@@ -2888,7 +2890,8 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
 
     let column_rows = match catalog_rows(
         jobs,
-        "SELECT schema_name, table_name, column_name, data_type, is_nullable, column_default \
+        "SELECT schema_name, table_name, column_name, data_type, is_nullable, column_default, \
+                is_generated, generation_expression \
          FROM duckdb_columns() \
          WHERE database_name = current_database() AND NOT internal \
          ORDER BY schema_name, table_name, column_index",
@@ -2960,6 +2963,8 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
             ty: cell_str(row, 3),
             not_null: !cell_bool(row, 4),
             default: cell_opt_str(row, 5),
+            generated: cell_bool(row, 6),
+            generation_expression: cell_opt_str(row, 7),
             primary: false,
         });
     }
@@ -3042,6 +3047,13 @@ fn run_catalog(req: Request, jobs: &mpsc::SyncSender<Job>) -> (bool, u16) {
             out.push_str(if column.not_null { "true" } else { "false" });
             out.push_str(",\"default\":");
             match &column.default {
+                Some(expression) => push_json_string(&mut out, expression),
+                None => out.push_str("null"),
+            }
+            out.push_str(",\"generated\":");
+            out.push_str(if column.generated { "true" } else { "false" });
+            out.push_str(",\"generationExpression\":");
+            match &column.generation_expression {
                 Some(expression) => push_json_string(&mut out, expression),
                 None => out.push_str("null"),
             }

--- a/harbor/test/scripts/catalog.py
+++ b/harbor/test/scripts/catalog.py
@@ -137,7 +137,8 @@ CREATE SEQUENCE users_seq START 1;
 CREATE TABLE users (
   id INTEGER PRIMARY KEY DEFAULT nextval('users_seq'),
   email VARCHAR NOT NULL,
-  name VARCHAR
+  name VARCHAR,
+  slug VARCHAR GENERATED ALWAYS AS (lower(name))
 );
 CREATE UNIQUE INDEX idx_users_email ON users(email);
 CREATE TABLE posts (
@@ -237,8 +238,20 @@ def run_fixture(base):
     users = next((t for t in doc["tables"] if t["name"] == "users"), {})
     default = (users.get("columns") or [{}])[0].get("default") or ""
     eq("the sequence-backed pk keeps its default", True, default.startswith("nextval("))
+    generated = next((c for c in users.get("columns", []) if c["name"] == "slug"), {})
+    eq("generated columns are identified structurally", True, generated.get("generated"))
+    expression = generated.get("generationExpression") or ""
+    eq("their engine-rendered expression is carried separately", True,
+       "lower" in expression and "name" in expression)
+    eq("every column declares whether DuckDB generates it", [],
+       [c["name"] for t in doc["tables"] for c in t.get("columns", [])
+        if not isinstance(c.get("generated"), bool)])
     for column in users.get("columns", []):
         column.pop("default", None)
+    for table in doc["tables"]:
+        for column in table.get("columns", []):
+            column.pop("generated", None)
+            column.pop("generationExpression", None)
 
     # The DDL is likewise the engine's own rendering — asserted for presence
     # and shape, then set aside so the structural expectations below stay
@@ -305,6 +318,7 @@ def run_fixture(base):
              {"name": "id", "type": "INTEGER", "notNull": True, "primary": True},
              {"name": "email", "type": "VARCHAR", "notNull": True, "primary": False},
              {"name": "name", "type": "VARCHAR", "notNull": False, "primary": False},
+             {"name": "slug", "type": "VARCHAR", "notNull": False, "primary": False},
          ],
          "primaryKey": ["id"],
          "uniqueConstraints": [],


### PR DESCRIPTION
## Summary

- add staged draft-row insertion to DuckTable's Data view
- preserve DuckDB `DEFAULT`, explicit `NULL`, and generated-column semantics
- commit inserts, updates, and deletes together with bound parameters and exact row verification
- expose generated-column metadata through Harbor `/catalog`
- release as Harbor 0.32.0 and DuckTable 0.19.0

## Verification

- `cargo test --workspace --all-targets` (Harbor)
- `cargo test --workspace --all-targets` (DuckTable)
- `SUITES='unit catalog sessions' test/scripts/check.sh`
- live Harbor session probe for bound inserts, defaults, generated values, and `RETURNING *`
- `scripts/macos-app.sh release`
- Harbor binary reports 0.32.0; DuckTable bundle reports 0.19.0
