### PR TITLE
Add DuckTable table commands

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -1261,6 +1261,18 @@ impl Grid {
         cx.notify();
     }
 
+    /// Native Edit-menu actions arrive at App scope, so they need one
+    /// explicit gate before reaching the grid. Row commands belong only
+    /// to the focused Data table, never to text inputs or embedded grids.
+    pub(crate) fn accepts_row_commands(&self, window: &Window, cx: &App) -> bool {
+        !self.embedded
+            && prefs::get(cx).view == ViewMode::Data
+            && self.editor.is_none()
+            && self.edits.is_some()
+            && !self.committing
+            && self.table.focus_handle(cx).contains_focused(window, cx)
+    }
+
     /// The grid's whole keymap, focus-scoped by construction: this
     /// listener sits on the grid wrapper, so it hears keys only when
     /// focus is inside — the table or an open cell editor.
@@ -1851,9 +1863,14 @@ impl Grid {
         }
     }
 
-    /// ⌘⌫: stage the selected row's DELETE — visible, ghosted,
-    /// reversible until commit. No dialog, ever: reversibility replaces
-    /// confirmation.
+    /// Edit-menu entry point; the window argument keeps its signature
+    /// parallel with New Row for the shared App-level dispatcher.
+    pub(crate) fn delete_row(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        self.stage_delete_row(cx);
+    }
+
+    /// Stage the selected row's DELETE — visible, ghosted, reversible
+    /// until commit. No dialog: reversibility is the confirmation model.
     fn stage_delete_row(&mut self, cx: &mut Context<Self>) {
         let (identity, draft_key) = {
             let d = self.table.read(cx).delegate();

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -26,9 +26,9 @@ use gpui_component::{Root, StyledExt as _};
 actions!(
     ducktable,
     [
-        ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, TablePrev,
-        TableNext, View1, View2, View3, ToggleFullScreen, ToggleRowNumbers, ToggleRightAlign,
-        ToggleNullTags, OpenDatabase, OpenDatabaseUrl
+        ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, RefreshTables,
+        AddRow, DeleteRow, TablePrev, TableNext, View1, View2, View3, ToggleFullScreen,
+        ToggleRowNumbers, ToggleRightAlign, ToggleNullTags, OpenDatabase, OpenDatabaseUrl
     ]
 );
 
@@ -111,6 +111,32 @@ fn step_table(delta: i32, cx: &mut App) {
     });
 }
 
+/// Run an Edit-menu row command only when the Data table itself owns
+/// focus. App-level registration makes native menu items work; the grid
+/// gate keeps the same shortcuts inert in Query, Structure, filters, and
+/// cell editors.
+fn run_row_action(
+    action: fn(&mut grid::Grid, &mut Window, &mut Context<grid::Grid>),
+    cx: &mut App,
+) {
+    let Some(view) = cx.try_global::<AppView>().and_then(|v| v.0.upgrade()) else {
+        return;
+    };
+    cx.defer(move |cx| {
+        let Some(active) = cx.active_window() else { return };
+        active
+            .update(cx, |_, window, cx| {
+                view.update(cx, |this, cx| {
+                    let Some(grid) = this.grid.clone() else { return };
+                    if grid.read(cx).accepts_row_commands(window, cx) {
+                        grid.update(cx, |grid, cx| action(grid, window, cx));
+                    }
+                });
+            })
+            .ok();
+    });
+}
+
 /// The switcher's one ordering — the footer renders it and ⌘1/⌘2/⌘3
 /// address it (Finder's ⌘1–4 idiom; these keys migrate to the tab
 /// strip when tabs ship, the ⌥↑/↓ pattern).
@@ -172,6 +198,13 @@ fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Open Database URL…", OpenDatabaseUrl),
             ],
         },
+        Menu {
+            name: "Edit".into(),
+            items: vec![
+                MenuItem::action("New Row", AddRow),
+                MenuItem::action("Delete Row", DeleteRow),
+            ],
+        },
         // macOS shows each item's key equivalent from the keymap, so this
         // menu is also where the zoom shortcuts advertise themselves.
         Menu {
@@ -182,6 +215,8 @@ fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Structure", View1),
                 MenuItem::action("Data", View2),
                 MenuItem::action("Query", View3),
+                MenuItem::separator(),
+                MenuItem::action("Refresh Tables", RefreshTables),
                 MenuItem::separator(),
                 MenuItem::action("Previous Table", TablePrev),
                 MenuItem::action("Next Table", TableNext),
@@ -366,6 +401,9 @@ fn main() {
             KeyBinding::new("cmd-i", ToggleInspector, None),
             KeyBinding::new("cmd-o", OpenDatabase, None),
             KeyBinding::new("cmd-q", Quit, None),
+            KeyBinding::new("cmd-r", RefreshTables, None),
+            KeyBinding::new("cmd-n", AddRow, None),
+            KeyBinding::new("cmd-d", DeleteRow, None),
             // Cmd-Plus arrives as cmd-= (unshifted) or cmd-shift-= — bind
             // both, the way browsers treat the pair.
             KeyBinding::new("cmd-=", ZoomIn, None),
@@ -486,6 +524,21 @@ fn main() {
         });
         cx.on_action(|_: &TablePrev, cx| step_table(-1, cx));
         cx.on_action(|_: &TableNext, cx| step_table(1, cx));
+        cx.on_action(|_: &AddRow, cx| run_row_action(grid::Grid::add_row, cx));
+        cx.on_action(|_: &DeleteRow, cx| {
+            run_row_action(grid::Grid::delete_row, cx)
+        });
+        // One command behind both the View menu and Cmd+R. The sidebar
+        // glyph calls the same refresh_catalog method directly from its
+        // DuckTable context, so every entrance has identical semantics.
+        cx.on_action(|_: &RefreshTables, cx| {
+            let Some(view) = cx.try_global::<AppView>().and_then(|v| v.0.upgrade()) else {
+                return;
+            };
+            cx.defer(move |cx| {
+                view.update(cx, |this, cx| this.refresh_catalog(cx));
+            });
+        });
         cx.on_action(|_: &ToggleFullScreen, cx| {
             cx.defer(|cx| {
                 if let Some(w) = cx.active_window() {

--- a/ducktable/crates/ducktable/src/sidebar.rs
+++ b/ducktable/crates/ducktable/src/sidebar.rs
@@ -424,7 +424,7 @@ impl DuckTable {
                         // sets it explicitly); without this it's invisible.
                         .child(svg().path("icons/refresh-cw.svg").size_3p5().text_color(t.muted))
                         .tooltip(move |window, cx| {
-                            gpui_component::tooltip::Tooltip::new("Refresh tables")
+                            gpui_component::tooltip::Tooltip::new("Refresh Tables (⌘R)")
                                 .build(window, cx)
                         })
                         .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -60,7 +60,8 @@ One meaning per key. No contextual double-agents.
 | Esc | clears the selection | cancels the edit, restores what was there, ring stays |
 | Delete / ⌫ | clears the cell: text → `''`, everything else → NULL (NOT NULL columns refuse, with the reason in the status line) | deletes text |
 | ⌃⇧N | stages NULL explicitly, any type | — |
-| ⌘⌫ | stages a row DELETE (ghost strikethrough; reversible until commit) | — |
+| ⌘N | creates a new all-DEFAULT row and opens its first useful writable cell | — |
+| ⌘D / ⌘⌫ | stages a row DELETE (ghost strikethrough; reversible until commit) | — |
 | ⌘Z / ⌘⇧Z | un-stages / re-stages the most recent change | text undo / redo |
 | ⌘S | commits all staged changes — one transaction, all or nothing | confirms the cell, then commits (⌘Enter is its equal) |
 | ⌥Enter | — | newline (the Sheets-hand twin of ⇧Enter) |

--- a/ducktable/docs/QUERY.md
+++ b/ducktable/docs/QUERY.md
@@ -134,9 +134,9 @@ Harbor; responses are fenced, so a stale result can never replace a
 newer one. Closing the connection cancels the run.
 
 **⌘S** flushes the scratch to disk immediately; the status line
-flashes `saved`. It never runs anything. **⌘R** runs again: it repeats
-the previous run's captured text exactly — refresh means "what I last
-looked at," even if the scratch has moved on.
+flashes `saved`. It never runs anything. **⌘R** is the app-level
+**Refresh Tables** command: it refreshes the sidebar's catalog snapshot
+from either pane without changing or running the scratch.
 
 ⌘Enter works from **either pane**: with focus in the results grid it
 still sends the marked statement. Results have no staged powers, so
@@ -293,7 +293,7 @@ a rung:
 | ⌘Enter | send: the selection if any, else the marked statement — from either pane |
 | ⌘⇧Enter | run all, top to bottom, stop at first error |
 | ⌘. | cancel the running query |
-| ⌘R | run again — repeat the previous run exactly |
+| ⌘R | Refresh Tables — refresh the sidebar catalog without running the scratch |
 | ⌘S | flush the scratch to disk (`saved` flashes; it was already safe) |
 | ⌘L | from anywhere in the window: switch to Query, focus the editor — the address-bar reflex |
 | Enter / ⇧Enter / ⌥Enter | newline, always; Enter never accepts a completion |
@@ -424,7 +424,8 @@ DuckTable.
 
 **v1 — one phase, shippable:** the Query segment with focus handoff;
 per-berth scratch, autosave, restore; the split; statement spans and
-the send mark; ⌘Enter / ⌘⇧Enter / ⌘. / ⌘R / ⌘S / ⌘L; the
+the send mark; ⌘Enter / ⌘⇧Enter / ⌘. / ⌘S / ⌘L; app-level ⌘R
+Refresh Tables; the
 session-holding runner; read-only results grid, chips, acknowledgment
 cards, error strip with caret jump; status-line timing; local
 completion (keywords, functions, schema, dot-members, ⌃Space,

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -59,6 +59,11 @@ Harbor loopback port. A tunneled row remains a normal DATABASES row and says
 Database**, which forgets the saved route and closes its tunnel without sending
 a shutdown request to the database server.
 
+The Edit menu owns Data-grid row operations. **New Row** (Cmd+N) creates an
+all-DEFAULT draft and enters its first useful writable cell. **Delete Row**
+(Cmd+D) stages the selected row for deletion. The row remains visibly ghosted
+and undoable until the final Cmd+S commit boundary.
+
 ## Sizing
 
 Rigidity is part of feeling native: content pushes back instead of
@@ -119,7 +124,8 @@ the tree when the catalog endpoint carries them. Each section header
 has its own filter glyph — a filter field only appears once a section
 exceeds 10 items — and a refresh glyph. Refresh refetches then swaps in
 one frame; it never blanks the tree while loading, and a failed refresh
-keeps the old tree unchanged.
+keeps the old tree unchanged. **Refresh Tables** is also available from
+the View menu and with Cmd+R; all three entrances perform the same action.
 
 Single click selects; Enter or double-click opens a table in a new tab
 (or focuses the already-open tab for that table).
@@ -304,6 +310,9 @@ Every surface defines empty, loading, and failed:
 
 - Cmd+K: berth switcher (fuzzy)
 - Cmd+P: table switcher (fuzzy, within connected berth)
+- Cmd+R: Refresh Tables
+- Cmd+N: New Row (Data grid)
+- Cmd+D: stage Delete Row (Data grid)
 - Cmd+T / Cmd+W: new query tab / close tab
 - Cmd+Enter / Cmd+Shift+Enter: run statement / run all
 - Cmd+. : cancel running query


### PR DESCRIPTION
## Summary

- add View → Refresh Tables bound to Cmd+R and route it to the same catalog refresh as the TABLES sidebar icon
- add Edit → New Row bound to Cmd+N
- add Edit → Delete Row bound to Cmd+D, using the existing reversible staged-delete behavior
- scope row commands to the focused editable Data grid and leave Cmd+A unbound
- update the shortcut documentation and bump DuckTable to 0.19.1

## Verification

- `cargo test --workspace --all-targets`
- `cargo check --workspace --all-targets`
- `scripts/macos-app.sh release`
- release bundle version verified as 0.19.1
