### PR TITLE
Refresh table counts after writes

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.19.2"
+version = "0.19.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/ducktable/src/app.rs
+++ b/ducktable/crates/ducktable/src/app.rs
@@ -9,6 +9,20 @@ use crate::util::clone_str;
 use gpui::*;
 use harbor_client::{fleet, Conn, State};
 
+fn catalog_refresh_is_current(
+    current_attempt: u64,
+    current_refresh: u64,
+    fenced_attempt: u64,
+    fenced_refresh: u64,
+) -> bool {
+    current_attempt == fenced_attempt && current_refresh == fenced_refresh
+}
+
+/// A child surface finished work that may have changed any table. The root
+/// owns the catalog snapshot, so grids and query views request a refresh
+/// instead of trying to update sidebar counts themselves.
+pub(crate) struct CatalogRefreshRequested;
+
 pub(crate) struct RowVm {
     pub(crate) name: String,
     pub(crate) state: State,
@@ -81,6 +95,9 @@ pub struct DuckTable {
     /// click racing the one connect fires) commit newest-wins instead of
     /// arbitrary order.
     refresh_seq: u64,
+    /// Fence for catalog refreshes. Writes and manual refreshes can overlap;
+    /// only the newest `/catalog` response may replace the sidebar snapshot.
+    catalog_seq: u64,
     /// The sidebar's out-loud line: a refused config, or a catalog
     /// refresh that failed — a GUI has no stderr, and both would
     /// otherwise fail silently (an unexplained empty list reads as
@@ -176,6 +193,7 @@ impl DuckTable {
             berth_filter: None,
             select_seq: 0,
             refresh_seq: 0,
+            catalog_seq: 0,
             warning: None,
             query: None,
             staged: std::collections::HashMap::new(),
@@ -266,6 +284,10 @@ impl DuckTable {
                         window, cx,
                     )
                 });
+                cx.subscribe(&grid, |state, _, _: &CatalogRefreshRequested, cx| {
+                    state.refresh_catalog(cx)
+                })
+                .detach();
                 // And returning to a table hands its parked edits back.
                 let source = crate::sql::source(&schema, &name);
                 if let Some(stash) = state.staged.remove(&source) {
@@ -277,11 +299,19 @@ impl DuckTable {
                     Phase::Connected { info, .. } => clone_str(&info.name),
                     _ => String::new(),
                 };
-                if !state.query.as_ref().is_some_and(|q| q.read(cx).is_for(&berth)) {
+                if !state
+                    .query
+                    .as_ref()
+                    .is_some_and(|q| q.read(cx).is_for(&berth))
+                {
                     let qconn = grid.read(cx).conn.clone();
-                    state.query = Some(cx.new(|cx| {
-                        crate::query::QueryView::new(qconn, &berth, window, cx)
-                    }));
+                    let query =
+                        cx.new(|cx| crate::query::QueryView::new(qconn, &berth, window, cx));
+                    cx.subscribe(&query, |state, _, _: &CatalogRefreshRequested, cx| {
+                        state.refresh_catalog(cx)
+                    })
+                    .detach();
+                    state.query = Some(query);
                 }
                 grid.update(cx, |g, cx| {
                     g.query_view = state.query.clone();
@@ -382,14 +412,16 @@ impl DuckTable {
             Phase::Connected { conn, .. } => conn.clone(),
             _ => return,
         };
-        let fence = self.attempt;
+        self.catalog_seq += 1;
+        let attempt = self.attempt;
+        let refresh = self.catalog_seq;
         cx.spawn(async move |this, cx| {
             let outcome = cx
                 .background_executor()
                 .spawn(async move { harbor_client::catalog(&conn) })
                 .await;
             this.update(cx, |state, cx| {
-                if state.attempt != fence {
+                if !catalog_refresh_is_current(state.attempt, state.catalog_seq, attempt, refresh) {
                     return;
                 }
                 match outcome {
@@ -878,5 +910,17 @@ impl DuckTable {
         if let Some(q) = &self.query {
             q.update(cx, |q, cx| q.request_focus(cx));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::catalog_refresh_is_current;
+
+    #[test]
+    fn catalog_refresh_accepts_only_the_current_connection_and_request() {
+        assert!(catalog_refresh_is_current(7, 11, 7, 11));
+        assert!(!catalog_refresh_is_current(8, 11, 7, 11));
+        assert!(!catalog_refresh_is_current(7, 12, 7, 11));
     }
 }

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -161,6 +161,8 @@ pub(crate) struct Grid {
 
 }
 
+impl EventEmitter<crate::app::CatalogRefreshRequested> for Grid {}
+
 /// Everything a fetch commits along with its rows. The delegate is not
 /// touched until the data arrives — the footer, funnel, and gutter always
 /// describe the rows actually on screen, and a failed or superseded fetch
@@ -2336,6 +2338,7 @@ impl Grid {
                         // over pixels that already match it.
                         let page = grid.page;
                         grid.fetch_page_now(page, cx);
+                        cx.emit(crate::app::CatalogRefreshRequested);
                     }
                     Err(message) => {
                         grid.error = Some(format!("{message} · edits kept"));

--- a/ducktable/crates/ducktable/src/query.rs
+++ b/ducktable/crates/ducktable/src/query.rs
@@ -54,6 +54,8 @@ pub(crate) struct QueryView {
     _intercept: Subscription,
 }
 
+impl EventEmitter<crate::app::CatalogRefreshRequested> for QueryView {}
+
 impl QueryView {
     pub(crate) fn new(
         conn: Conn,
@@ -456,6 +458,11 @@ impl QueryView {
                         this.ok_ms = None;
                     }
                 }
+                // Arbitrary SQL may change any table. Request a catalog
+                // refresh after every completed send, including an error:
+                // an earlier statement may have committed before a later
+                // statement failed.
+                cx.emit(crate::app::CatalogRefreshRequested);
                 cx.notify();
             })
             .ok();

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -184,8 +184,9 @@ and still visible, the offender is marked, and the status line says why,
 ending with "edits kept."
 
 After a successful commit the page refetches so the grid shows the
-database's truth. NULL renders as the NULL tag, visually distinct from
-empty, always.
+database's truth, and Refresh Tables refetches `/catalog` so every sidebar
+row count reflects the committed transaction. NULL renders as the NULL tag,
+visually distinct from empty, always.
 
 ## Dialogs
 

--- a/ducktable/docs/QUERY.md
+++ b/ducktable/docs/QUERY.md
@@ -125,8 +125,10 @@ temp state is gone and the note says so.
 **No implicit transaction.** Statements auto-commit individually, like
 the duckdb CLI; write `BEGIN`/`COMMIT` yourself. A run-all stops at the
 first error; whatever completed stays completed, and the status line
-says how far it got. Runs containing non-SELECT statements refresh the
-sidebar catalog afterward (fetch first, swap in one frame).
+says how far it got. Every completed send refreshes the sidebar catalog
+afterward (fetch first, swap in one frame): arbitrary SQL can mutate through
+forms that cannot be classified reliably, and an earlier statement may have
+committed before a later statement reports an error.
 
 **One run in flight** per view. ⌘Enter during a run answers
 `already running · ⌘. to cancel` — no queue. **⌘.** cancels through

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -132,6 +132,10 @@ exceeds 10 items — and a refresh glyph. Refresh refetches then swaps in
 one frame; it never blanks the tree while loading, and a failed refresh
 keeps the old tree unchanged. **Refresh Tables** is also available from
 the View menu and with Cmd+R; all three entrances perform the same action.
+A successful staged-edit commit and every completed Query run perform that
+same refresh automatically, so row counts and schema changes land without a
+second command. If refreshes overlap, only the newest response may replace
+the catalog snapshot.
 
 Single click selects; Enter or double-click opens a table in a new tab
 (or focuses the already-open tab for that table).


### PR DESCRIPTION
## Summary

- refresh `/catalog` after successful staged-edit commits
- refresh `/catalog` after every completed Query run
- fence overlapping catalog requests so only the newest response updates the sidebar
- bump DuckTable to 0.19.3

## Validation

- `cargo test --workspace --all-targets`
- `cargo check --workspace --all-targets`
- `git diff --check`