### PR TITLE
Refresh data grids and duplicate rows

### DIFF
--- a/ducktable/CHANGELOG.md
+++ b/ducktable/CHANGELOG.md
@@ -3,6 +3,16 @@
 DuckTable release tags use `ducktable-vX.Y.Z`. Entries are ordered by signed
 tag date, newest first.
 
+## 0.20.0 — 2026-09-05
+
+- Adds **Duplicate Row** with Cmd+D as a staged insert that copies exact source
+  values while leaving primary-key and generated columns to DuckDB.
+- Keeps **Delete Row** on Cmd+Delete and preserves staged, reversible deletion.
+- Makes **Refresh Tables** update both the catalog and the currently open Data
+  grid while leaving Query results unchanged.
+- Refreshes the current Data grid after every completed Query run so external
+  mutations become visible immediately.
+
 ## 0.19.3 — 2026-09-04
 
 - Refreshes `/catalog` and all sidebar row counts after a successful staged

--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.19.3"
+version = "0.20.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/ducktable/src/app.rs
+++ b/ducktable/crates/ducktable/src/app.rs
@@ -308,7 +308,7 @@ impl DuckTable {
                     let query =
                         cx.new(|cx| crate::query::QueryView::new(qconn, &berth, window, cx));
                     cx.subscribe(&query, |state, _, _: &CatalogRefreshRequested, cx| {
-                        state.refresh_catalog(cx)
+                        state.refresh_tables(cx)
                     })
                     .detach();
                     state.query = Some(query);
@@ -441,6 +441,16 @@ impl DuckTable {
             .ok();
         })
         .detach();
+    }
+
+    /// Refresh every table-facing snapshot: exact catalog counts in the
+    /// sidebar and the currently open Data page. Query results are an
+    /// explicit SQL snapshot and are intentionally left unchanged.
+    pub(crate) fn refresh_tables(&mut self, cx: &mut Context<Self>) {
+        self.refresh_catalog(cx);
+        if let Some(grid) = self.grid.clone() {
+            grid.update(cx, |grid, cx| grid.refresh_current(cx));
+        }
     }
 
     pub(crate) fn refresh(&mut self, cx: &mut Context<Self>) {

--- a/ducktable/crates/ducktable/src/edits.rs
+++ b/ducktable/crates/ducktable/src/edits.rs
@@ -192,13 +192,29 @@ impl Edits {
     /// Add an intentional all-DEFAULT draft. It is staged immediately:
     /// DEFAULT VALUES can itself be a valid insert, and one undo removes it.
     pub fn stage_insert(&mut self) -> String {
+        self.stage_insert_values(Vec::new())
+    }
+
+    /// Add a draft whose supplied cells are already known. This is the
+    /// duplicate-row path: the whole copied row is one undo step, just as
+    /// an empty New Row is one undo step.
+    pub fn stage_insert_values(
+        &mut self,
+        values: Vec<(usize, Option<SharedString>, Value)>,
+    ) -> String {
         let key = format!("draft:{:020}", self.next_draft);
         self.next_draft += 1;
+        let cells = values
+            .into_iter()
+            .map(|(col, text, value)| {
+                (col, CellEdit { original: None, text, value })
+            })
+            .collect();
         self.apply(Op {
             key: key.clone(),
             identity: Vec::new(),
             prev: None,
-            next: Some(RowChange::Insert(BTreeMap::new())),
+            next: Some(RowChange::Insert(cells)),
         });
         key
     }
@@ -585,6 +601,23 @@ mod tests {
         assert_eq!(e.counts(), (1, 0, 0));
         assert!(e.undo());
         assert_eq!(e.counts(), (2, 0, 0));
+    }
+
+    #[test]
+    fn a_prefilled_duplicate_is_one_insert_and_one_undo_step() {
+        let mut e = edits();
+        let key = e.stage_insert_values(vec![
+            (1, txt("Ada"), json!("Ada")),
+            (2, None, Value::Null),
+        ]);
+        assert_eq!(e.counts(), (1, 0, 0));
+        assert_eq!(e.staged_text(&key, 1), Some(txt("Ada")));
+        assert_eq!(
+            e.statements()[0].sql,
+            "INSERT INTO \"main\".\"t\" (\"name\", \"qty\") VALUES (?, ?) RETURNING *"
+        );
+        assert!(e.undo());
+        assert!(e.is_empty(), "the whole duplicate must undo at once");
     }
 
     #[test]

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -273,6 +273,10 @@ pub(crate) struct GridDelegate {
     /// commit — render_td runs per visible cell per frame and must not
     /// allocate, so it only bumps these SharedStrings.
     rows: Vec<Vec<Option<SharedString>>>,
+    /// Raw wire values aligned with `rows`. INSERT drafts carry empty
+    /// placeholders; fetched rows retain exact values so Duplicate Row
+    /// never round-trips through display formatting.
+    raw_rows: Vec<Vec<Value>>,
     /// Mirror of the table's selected row (synced from TableEvent), so
     /// render_tr can tint the selection — the delegate cannot read the
     /// TableState it is rendering inside.
@@ -426,6 +430,7 @@ impl Grid {
             visible: Vec::new(),
             gutter,
             rows: Vec::new(),
+            raw_rows: Vec::new(),
             selected: None,
             all_selected: false,
             active_cell: None,
@@ -1231,13 +1236,74 @@ impl Grid {
         let key = self.edits.as_mut().expect("checked above").stage_insert();
         self.error = None;
         self.sync_staged(cx);
+        self.focus_draft(&key, window, cx);
+    }
+
+    /// Stage a new INSERT copied from the selected fetched row. Generated
+    /// columns and primary-key columns are omitted so DuckDB can compute
+    /// them; a natural key without a default therefore appears REQUIRED.
+    /// Exact raw values are copied, with any staged updates overlaid.
+    pub(crate) fn duplicate_row(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.committing || self.edits.is_none() {
+            return;
+        }
+        if self.editor.is_some() && !self.confirm_and_move(0, 0, false, cx) {
+            return;
+        }
+        let (identity, mut raw, first_schema, pk_ix) = {
+            let d = self.table.read(cx).delegate();
+            let row = d.selected.or(d.active_cell.map(|(row, _)| row));
+            let Some(row) = row else { return };
+            // A draft is already an INSERT. Duplicate Row deliberately
+            // targets persisted rows so it always has exact source values.
+            if d.draft_key(row).is_some() || d.deleted.contains(&row) {
+                return;
+            }
+            let Some(raw) = d.raw_rows.get(row).cloned() else { return };
+            let Some(identity) = d.identities.get(row).cloned() else { return };
+            (identity, raw, d.identity as usize, d.pk_ix.clone())
+        };
+
+        let source_key = edits::key_of(&identity);
+        if let Some(edits::RowChange::Update(cells)) = self.edits.as_ref().and_then(|edits| {
+            edits
+                .entries()
+                .into_iter()
+                .find(|(key, _, _)| *key == source_key)
+                .map(|(_, _, change)| change)
+        }) {
+            for (col, cell) in cells {
+                if let Some(value) = raw.get_mut(*col) {
+                    *value = cell.value.clone();
+                }
+            }
+        }
+
+        let values = duplicate_values(raw, first_schema, &pk_ix, &self.generated);
+        let key = self
+            .edits
+            .as_mut()
+            .expect("checked above")
+            .stage_insert_values(values);
+        self.error = None;
+        self.sync_staged(cx);
+        self.focus_draft(&key, window, cx);
+    }
+
+    /// Select a staged INSERT and enter the first field that needs or can
+    /// accept input. Shared by New Row and Duplicate Row.
+    fn focus_draft(&mut self, key: &str, window: &mut Window, cx: &mut Context<Self>) {
         // sync_staged normally returns focus after a draft row appears or
-        // disappears; Add Row is the exception because its editor is the
-        // intended destination.
+        // disappears; row creation is the exception because its editor is
+        // the intended destination.
         self.needs_focus = false;
         let (row, col, reveal) = {
             let d = self.table.read(cx).delegate();
-            let row = d.draft_keys.iter().position(|k| k == &key).unwrap_or(0);
+            let row = d.draft_keys.iter().position(|k| k == key).unwrap_or(0);
             let first_schema = d.identity as usize;
             let required = (first_schema..d.names.len()).find(|&col| {
                 self.not_null.get(col).copied().unwrap_or(false)
@@ -2105,6 +2171,9 @@ impl Grid {
             let draft_count = draft_rows.len();
             draft_rows.append(&mut d.rows);
             d.rows = draft_rows;
+            let mut raw_drafts = vec![Vec::new(); draft_count];
+            raw_drafts.append(&mut d.raw_rows);
+            d.raw_rows = raw_drafts;
             let mut identities = vec![Vec::new(); draft_count];
             identities.append(&mut d.identities);
             d.identities = identities;
@@ -2361,6 +2430,16 @@ impl Grid {
         );
     }
 
+    /// Refresh the current Data page in place. A provisional editor value
+    /// is first staged (or the refresh stops on validation failure), so a
+    /// refresh can never silently discard what the user was typing.
+    pub(crate) fn refresh_current(&mut self, cx: &mut Context<Self>) {
+        if self.editor.is_some() && !self.confirm_and_move(0, 0, false, cx) {
+            return;
+        }
+        self.fetch_page_now(self.page, cx);
+    }
+
     /// Rebuild the column list after the row-number preference flips.
     fn sync_columns(&mut self, cx: &mut Context<Self>) {
         let want = prefs::get(cx).row_numbers;
@@ -2413,6 +2492,7 @@ impl GridDelegate {
             return;
         }
         self.rows.drain(..count.min(self.rows.len()));
+        self.raw_rows.drain(..count.min(self.raw_rows.len()));
         self.identities.drain(..count.min(self.identities.len()));
         self.row_labels.drain(..count.min(self.row_labels.len()));
         self.draft_keys.clear();
@@ -2507,7 +2587,10 @@ impl GridDelegate {
             .enumerate()
             .map(|(ix, id)| (edits::key_of(id), ix))
             .collect();
-        self.rows = display_rows(rows);
+        self.rows = display_rows(&rows);
+        // Read-only result grids never offer Duplicate Row, so retaining a
+        // second copy of a potentially large query page would buy nothing.
+        self.raw_rows = if self.pk_ix.is_empty() { Vec::new() } else { rows };
         self.relabel(base);
     }
 
@@ -3555,19 +3638,42 @@ fn insert_metadata(
 }
 
 /// Wire values -> render-ready cell text (None = NULL), once per page.
-/// The String arm moves the buffer instead of cloning; everything else
-/// pays its Display cost here so render never does.
-fn display_rows(rows: Vec<Vec<Value>>) -> Vec<Vec<Option<SharedString>>> {
-    rows.into_iter()
+/// Raw values remain beside these strings for exact duplication; render
+/// never performs conversion or allocation.
+fn display_rows(rows: &[Vec<Value>]) -> Vec<Vec<Option<SharedString>>> {
+    rows.iter()
         .map(|row| {
-            row.into_iter()
-                .map(|v| match v {
-                    Value::Null => None,
-                    Value::String(s) => Some(SharedString::from(s)),
-                    other => Some(SharedString::from(other.to_string())),
-                })
+            row.iter()
+                .map(display_value)
                 .collect()
         })
+        .collect()
+}
+
+fn display_value(value: &Value) -> Option<SharedString> {
+    match value {
+        Value::Null => None,
+        Value::String(s) => Some(SharedString::from(s.clone())),
+        other => Some(SharedString::from(other.to_string())),
+    }
+}
+
+/// Build one duplicate-row INSERT payload from exact fetched values.
+/// Hidden rowid, declared primary keys, and generated expressions stay
+/// absent so DuckDB supplies the new row's identity and derived values.
+fn duplicate_values(
+    raw: Vec<Value>,
+    first_schema: usize,
+    pk_ix: &[usize],
+    generated: &[bool],
+) -> Vec<(usize, Option<SharedString>, Value)> {
+    raw.into_iter()
+        .enumerate()
+        .skip(first_schema)
+        .filter(|(col, _)| {
+            !pk_ix.contains(col) && !generated.get(*col).copied().unwrap_or(false)
+        })
+        .map(|(col, value)| (col, display_value(&value), value))
         .collect()
 }
 
@@ -3632,7 +3738,8 @@ fn numeric(ty: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::draft_hint_min_width;
+    use super::{draft_hint_min_width, duplicate_values};
+    use serde_json::{Value, json};
 
     #[test]
     fn draft_hint_floors_fit_each_pill_and_scale_with_zoom() {
@@ -3641,5 +3748,35 @@ mod tests {
         assert_eq!(f32::from(draft_hint_min_width("REQUIRED", 1.)), 86.);
         assert_eq!(f32::from(draft_hint_min_width("GENERATED", 1.)), 93.);
         assert_eq!(f32::from(draft_hint_min_width("DEFAULT", 2.)), 128.);
+    }
+
+    #[test]
+    fn duplicate_uses_raw_values_and_omits_identity_and_generated_columns() {
+        let values = duplicate_values(
+            vec![json!(99), json!(7), json!("00123"), Value::Null, json!(14)],
+            0,
+            &[0],
+            &[false, false, false, false, true],
+        );
+        assert_eq!(
+            values.iter().map(|(col, _, _)| *col).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(values[1].1.as_ref().map(ToString::to_string), Some("00123".into()));
+        assert_eq!(values[1].2, json!("00123"));
+        assert_eq!(values[2].1, None);
+        assert_eq!(values[2].2, Value::Null);
+
+        // A keyless table's hidden rowid occupies schema column zero.
+        let values = duplicate_values(
+            vec![json!(99), json!(7), json!("Ada")],
+            1,
+            &[0],
+            &[false, false, false],
+        );
+        assert_eq!(
+            values.iter().map(|(col, _, _)| *col).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 }

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -27,7 +27,7 @@ actions!(
     ducktable,
     [
         ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, RefreshTables,
-        AddRow, DeleteRow, TablePrev, TableNext, View1, View2, View3, ToggleFullScreen,
+        AddRow, DuplicateRow, DeleteRow, TablePrev, TableNext, View1, View2, View3, ToggleFullScreen,
         ToggleRowNumbers, ToggleRightAlign, ToggleNullTags, OpenDatabase, OpenDatabaseUrl
     ]
 );
@@ -202,6 +202,7 @@ fn app_menus() -> Vec<Menu> {
             name: "Edit".into(),
             items: vec![
                 MenuItem::action("New Row", AddRow),
+                MenuItem::action("Duplicate Row", DuplicateRow),
                 MenuItem::action("Delete Row", DeleteRow),
             ],
         },
@@ -403,7 +404,7 @@ fn main() {
             KeyBinding::new("cmd-q", Quit, None),
             KeyBinding::new("cmd-r", RefreshTables, None),
             KeyBinding::new("cmd-n", AddRow, None),
-            KeyBinding::new("cmd-d", DeleteRow, None),
+            KeyBinding::new("cmd-d", DuplicateRow, None),
             // Cmd-Plus arrives as cmd-= (unshifted) or cmd-shift-= — bind
             // both, the way browsers treat the pair.
             KeyBinding::new("cmd-=", ZoomIn, None),
@@ -525,18 +526,21 @@ fn main() {
         cx.on_action(|_: &TablePrev, cx| step_table(-1, cx));
         cx.on_action(|_: &TableNext, cx| step_table(1, cx));
         cx.on_action(|_: &AddRow, cx| run_row_action(grid::Grid::add_row, cx));
+        cx.on_action(|_: &DuplicateRow, cx| {
+            run_row_action(grid::Grid::duplicate_row, cx)
+        });
         cx.on_action(|_: &DeleteRow, cx| {
             run_row_action(grid::Grid::delete_row, cx)
         });
         // One command behind both the View menu and Cmd+R. The sidebar
-        // glyph calls the same refresh_catalog method directly from its
+        // glyph calls the same refresh_tables method directly from its
         // DuckTable context, so every entrance has identical semantics.
         cx.on_action(|_: &RefreshTables, cx| {
             let Some(view) = cx.try_global::<AppView>().and_then(|v| v.0.upgrade()) else {
                 return;
             };
             cx.defer(move |cx| {
-                view.update(cx, |this, cx| this.refresh_catalog(cx));
+                view.update(cx, |this, cx| this.refresh_tables(cx));
             });
         });
         cx.on_action(|_: &ToggleFullScreen, cx| {

--- a/ducktable/crates/ducktable/src/sidebar.rs
+++ b/ducktable/crates/ducktable/src/sidebar.rs
@@ -428,7 +428,7 @@ impl DuckTable {
                                 .build(window, cx)
                         })
                         .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
-                            this.refresh_catalog(cx);
+                            this.refresh_tables(cx);
                         })),
                 ),
         );

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -45,6 +45,13 @@ updates and deletes immediately, including undo, review, discard, table
 switches, and the all-or-nothing commit. Discarding/deleting a draft removes
 the pending INSERT; it never emits a DELETE.
 
+**Duplicate Row** (⌘D) copies the selected persisted row into a new staged
+INSERT. It copies exact wire values rather than formatted cell text, includes
+any staged updates already visible on the source row, and omits primary-key and
+generated columns so DuckDB can supply the new identity and derived values. A
+natural key without a default therefore remains `REQUIRED`. The entire copied
+row is one undo step and is not written until ⌘S.
+
 ## The grammar
 
 One meaning per key. No contextual double-agents.
@@ -61,7 +68,8 @@ One meaning per key. No contextual double-agents.
 | Delete / ⌫ | clears the cell: text → `''`, everything else → NULL (NOT NULL columns refuse, with the reason in the status line) | deletes text |
 | ⌃⇧N | stages NULL explicitly, any type | — |
 | ⌘N | creates a new all-DEFAULT row and opens its first useful writable cell | — |
-| ⌘D / ⌘⌫ | stages a row DELETE (ghost strikethrough; reversible until commit) | — |
+| ⌘D | duplicates the selected persisted row as one staged INSERT | — |
+| ⌘⌫ | stages a row DELETE (ghost strikethrough; reversible until commit) | — |
 | ⌘Z / ⌘⇧Z | un-stages / re-stages the most recent change | text undo / redo |
 | ⌘S | commits all staged changes — one transaction, all or nothing | confirms the cell, then commits (⌘Enter is its equal) |
 | ⌥Enter | — | newline (the Sheets-hand twin of ⇧Enter) |
@@ -185,8 +193,9 @@ ending with "edits kept."
 
 After a successful commit the page refetches so the grid shows the
 database's truth, and Refresh Tables refetches `/catalog` so every sidebar
-row count reflects the committed transaction. NULL renders as the NULL tag,
-visually distinct from empty, always.
+row count reflects the committed transaction. Manual Refresh Tables and a
+completed Query run also refetch the currently open Data page. NULL renders as
+the NULL tag, visually distinct from empty, always.
 
 ## Dialogs
 
@@ -199,6 +208,5 @@ only at ⌘S. Reversibility replaces confirmation.
 - **Live mode** (write-per-edit): designed in UI.md, deferred until it
   re-clears an adversarial review. If it ships, type-to-edit turns off
   in it — the two are certified only as a pair with staging.
-- Duplicate-row (menu, blanking key/unique columns), value popout editor for
-  long/nested values, range selection and
+- Value popout editor for long/nested values, range selection and
   TSV paste-spread, crash-recovery journal for staged edits.

--- a/ducktable/docs/QUERY.md
+++ b/ducktable/docs/QUERY.md
@@ -125,10 +125,12 @@ temp state is gone and the note says so.
 **No implicit transaction.** Statements auto-commit individually, like
 the duckdb CLI; write `BEGIN`/`COMMIT` yourself. A run-all stops at the
 first error; whatever completed stays completed, and the status line
-says how far it got. Every completed send refreshes the sidebar catalog
-afterward (fetch first, swap in one frame): arbitrary SQL can mutate through
-forms that cannot be classified reliably, and an earlier statement may have
-committed before a later statement reports an error.
+says how far it got. Every completed send refreshes the sidebar catalog and
+the currently open Data grid afterward (fetch first, swap in one frame):
+arbitrary SQL can mutate through forms that cannot be classified reliably, and
+an earlier statement may have committed before a later statement reports an
+error. The Query result itself remains the snapshot returned by that explicit
+send; DuckTable never silently reruns arbitrary SQL.
 
 **One run in flight** per view. ⌘Enter during a run answers
 `already running · ⌘. to cancel` — no queue. **⌘.** cancels through
@@ -137,8 +139,9 @@ newer one. Closing the connection cancels the run.
 
 **⌘S** flushes the scratch to disk immediately; the status line
 flashes `saved`. It never runs anything. **⌘R** is the app-level
-**Refresh Tables** command: it refreshes the sidebar's catalog snapshot
-from either pane without changing or running the scratch.
+**Refresh Tables** command: it refreshes the sidebar's catalog snapshot and the
+currently open Data grid from either pane without changing or running the
+scratch, and without replacing the current Query result.
 
 ⌘Enter works from **either pane**: with focus in the results grid it
 still sends the marked statement. Results have no staged powers, so
@@ -295,7 +298,7 @@ a rung:
 | ⌘Enter | send: the selection if any, else the marked statement — from either pane |
 | ⌘⇧Enter | run all, top to bottom, stop at first error |
 | ⌘. | cancel the running query |
-| ⌘R | Refresh Tables — refresh the sidebar catalog without running the scratch |
+| ⌘R | Refresh Tables — refresh the catalog and current Data grid without running the scratch or replacing Query results |
 | ⌘S | flush the scratch to disk (`saved` flashes; it was already safe) |
 | ⌘L | from anywhere in the window: switch to Query, focus the editor — the address-bar reflex |
 | Enter / ⇧Enter / ⌥Enter | newline, always; Enter never accepts a completion |

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -60,9 +60,11 @@ Database**, which forgets the saved route and closes its tunnel without sending
 a shutdown request to the database server.
 
 The Edit menu owns Data-grid row operations. **New Row** (Cmd+N) creates an
-all-DEFAULT draft and enters its first useful writable cell. **Delete Row**
-(Cmd+D) stages the selected row for deletion. The row remains visibly ghosted
-and undoable until the final Cmd+S commit boundary.
+all-DEFAULT draft and enters its first useful writable cell. **Duplicate Row**
+(Cmd+D) copies the selected persisted row into one staged insert, omitting its
+primary-key and generated columns. **Delete Row** (Cmd+Delete) stages the
+selected row for deletion. Inserts and deletes remain visible and undoable
+until the final Cmd+S commit boundary.
 
 ## Sizing
 
@@ -131,11 +133,13 @@ has its own filter glyph — a filter field only appears once a section
 exceeds 10 items — and a refresh glyph. Refresh refetches then swaps in
 one frame; it never blanks the tree while loading, and a failed refresh
 keeps the old tree unchanged. **Refresh Tables** is also available from
-the View menu and with Cmd+R; all three entrances perform the same action.
-A successful staged-edit commit and every completed Query run perform that
-same refresh automatically, so row counts and schema changes land without a
-second command. If refreshes overlap, only the newest response may replace
-the catalog snapshot.
+the View menu and with Cmd+R; all three entrances refresh both the catalog and
+the currently open Data page. A successful staged-edit commit and every
+completed Query run perform that same table-facing refresh automatically, so
+row counts, schema changes, and underlying table values land without a second
+command. Query results remain the snapshot produced by the SQL the user
+explicitly ran. If refreshes overlap, only the newest response may replace a
+snapshot.
 
 Single click selects; Enter or double-click opens a table in a new tab
 (or focuses the already-open tab for that table).
@@ -320,9 +324,10 @@ Every surface defines empty, loading, and failed:
 
 - Cmd+K: berth switcher (fuzzy)
 - Cmd+P: table switcher (fuzzy, within connected berth)
-- Cmd+R: Refresh Tables
+- Cmd+R: Refresh Tables (catalog and current Data page)
 - Cmd+N: New Row (Data grid)
-- Cmd+D: stage Delete Row (Data grid)
+- Cmd+D: Duplicate Row (Data grid)
+- Cmd+Delete: stage Delete Row (Data grid)
 - Cmd+T / Cmd+W: new query tab / close tab
 - Cmd+Enter / Cmd+Shift+Enter: run statement / run all
 - Cmd+. : cancel running query


### PR DESCRIPTION
## Summary

- make Refresh Tables refetch both `/catalog` and the current Data page
- refetch the current Data page after each completed Query run while preserving Query results
- move Cmd+D to a staged Duplicate Row operation and keep row deletion on Cmd+Delete
- copy exact raw values, omit primary-key/generated columns, and make duplication one undo step
- bump DuckTable to 0.20.0 and update its changelog and design docs

## Validation

- `cargo test --workspace` (DuckTable workspace)
- `cargo check --workspace --all-targets` (DuckTable workspace)
- `cargo test --workspace` (Harbor workspace)
- `scripts/macos-app.sh debug`; bundle version verified as 0.20.0