### PR TITLE
Fix Tab navigation in active cell editors

### DIFF
--- a/ducktable/CHANGELOG.md
+++ b/ducktable/CHANGELOG.md
@@ -3,6 +3,14 @@
 DuckTable release tags use `ducktable-vX.Y.Z`. Entries are ordered by signed
 tag date, newest first.
 
+## 0.20.2 — 2026-09-05
+
+- Fixes Tab and Shift-Tab while a cell editor is active: the edited value is
+  confirmed and the active cell moves right or left instead of remaining in
+  the input.
+- Preserves row-local wraparound, so Tab from the final visible cell selects
+  the first and Shift-Tab from the first selects the final cell.
+
 ## 0.20.1 — 2026-09-05
 
 - Makes a sidebar table-name double-click select the table and switch directly

--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -21,6 +21,7 @@ use crate::theme::{
 };
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
+use gpui_component::input::{IndentInline, OutdentInline};
 use gpui_component::table::{Column as TableColumn, Table, TableDelegate, TableState};
 use gpui_component::tooltip::Tooltip;
 use gpui_component::resizable::{
@@ -1606,6 +1607,36 @@ impl Grid {
                     }
                 }
             }
+        }
+    }
+
+    /// A focused Input maps Tab / Shift-Tab to these actions before the
+    /// raw KeyDownEvent can bubble to `on_key`. Catch them on the cell
+    /// editor's ancestor and run the same confirm-and-wrap path as the
+    /// grid-level keyboard handler.
+    fn on_editor_tab(
+        &mut self,
+        _: &IndentInline,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.editor.as_ref().is_some_and(|ed| ed.input.focus_handle(cx).is_focused(window)) {
+            self.confirm_and_move(0, 1, true, cx);
+        } else {
+            cx.propagate();
+        }
+    }
+
+    fn on_editor_shift_tab(
+        &mut self,
+        _: &OutdentInline,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.editor.as_ref().is_some_and(|ed| ed.input.focus_handle(cx).is_focused(window)) {
+            self.confirm_and_move(0, -1, true, cx);
+        } else {
+            cx.propagate();
         }
     }
 
@@ -3302,6 +3333,7 @@ impl Render for Grid {
             self.title.clone()
         };
         let error = self.error.clone();
+        let editing_cell = self.editor.is_some();
         // Embedded (the Query view's results pane): body only. The host
         // owns the chrome — its editor above, the app footer below,
         // which reads this grid's stats and pager state through it. The
@@ -3381,6 +3413,14 @@ impl Render for Grid {
             // The whole editing keymap rides the pane, on the bubble path
             // from wherever focus is — the table or an open cell editor.
             .on_key_down(cx.listener(Self::on_key))
+            // gpui-component binds Tab inside Input to indentation
+            // actions. A single-line cell editor has nothing to indent,
+            // so intercept those actions here and give Tab its grid
+            // meaning: confirm, then move to the adjacent visible cell.
+            .when(editing_cell, |d| {
+                d.on_action(cx.listener(Self::on_editor_tab))
+                    .on_action(cx.listener(Self::on_editor_shift_tab))
+            })
             .child(
                 div()
                     .h_flex()


### PR DESCRIPTION
## Summary

- route GPUI input Tab and Shift-Tab actions into DuckTable cell navigation
- confirm the active edit before moving to the adjacent visible cell
- preserve row-local wraparound in both directions
- bump DuckTable to 0.20.2 and update its changelog

## Verification

- `cargo test -p ducktable`
- `cargo check --workspace --all-targets`
- `./scripts/macos-app.sh release`