### PR TITLE
Keep cell editing active across Tab navigation

### DIFF
--- a/ducktable/CHANGELOG.md
+++ b/ducktable/CHANGELOG.md
@@ -3,6 +3,12 @@
 DuckTable release tags use `ducktable-vX.Y.Z`. Entries are ordered by signed
 tag date, newest first.
 
+## 0.20.3 — 2026-09-05
+
+- Keeps cell editing continuous across Tab and Shift-Tab: DuckTable confirms
+  the current value, moves with row-local wraparound, and immediately opens
+  the destination cell for editing.
+
 ## 0.20.2 — 2026-09-05
 
 - Fixes Tab and Shift-Tab while a cell editor is active: the edited value is

--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "ducktable"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "duckdb-lang",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-client"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "harbor-common",
  "serde",

--- a/ducktable/Cargo.toml
+++ b/ducktable/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/ducktable", "crates/duckdb-lang", "crates/harbor-client"]
 exclude = ["vendor/gpui-component"]
 
 [workspace.package]
-version = "0.20.2"
+version = "0.20.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/shreeve/duckdb-harbor"

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -1387,7 +1387,7 @@ impl Grid {
                     self.confirm_and_move(1, 0, false, cx);
                 }
                 "tab" => {
-                    self.confirm_and_move(0, if m.shift { -1 } else { 1 }, true, cx);
+                    self.confirm_and_tab(if m.shift { -1 } else { 1 }, window, cx);
                 }
                 "up" if replace => {
                     self.confirm_and_move(-1, 0, false, cx);
@@ -1621,7 +1621,7 @@ impl Grid {
         cx: &mut Context<Self>,
     ) {
         if self.editor.as_ref().is_some_and(|ed| ed.input.focus_handle(cx).is_focused(window)) {
-            self.confirm_and_move(0, 1, true, cx);
+            self.confirm_and_tab(1, window, cx);
         } else {
             cx.propagate();
         }
@@ -1634,7 +1634,7 @@ impl Grid {
         cx: &mut Context<Self>,
     ) {
         if self.editor.as_ref().is_some_and(|ed| ed.input.focus_handle(cx).is_focused(window)) {
-            self.confirm_and_move(0, -1, true, cx);
+            self.confirm_and_tab(-1, window, cx);
         } else {
             cx.propagate();
         }
@@ -1718,6 +1718,10 @@ impl Grid {
         if deleted {
             return; // you cannot edit a ghost; revert the delete first (⌘Z)
         }
+        // Closing the preceding editor schedules table focus for the next
+        // frame. A Tab run opens its neighbor immediately, so cancel that
+        // handoff before it can steal focus back from the new input.
+        self.needs_focus = false;
         let replace = seed.is_some();
         let text = seed
             .unwrap_or_else(|| original.as_ref().map(|s| s.to_string()).unwrap_or_default());
@@ -1768,6 +1772,18 @@ impl Grid {
             cx.notify();
         });
         cx.notify();
+    }
+
+    /// Tab while editing is a continuous entry gesture: confirm the current
+    /// cell, wrap the ring to its neighbor, then immediately open that cell's
+    /// editor. Validation failure leaves the original editor in place.
+    fn confirm_and_tab(&mut self, dc: i32, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.confirm_and_move(0, dc, true, cx) {
+            return;
+        }
+        if let Some((row, col)) = self.table.read(cx).delegate().active_cell {
+            self.open_editor(row, col, None, window, cx);
+        }
     }
 
     /// Esc: the in-progress text never happened; what was there before —

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -66,7 +66,7 @@ One meaning per key. No contextual double-agents.
 | typing | opens the editor **replacing** the value, seeded with the keystroke | inserts text |
 | Enter | opens the editor **keeping** the value, caret at end — but during a Tab run, sweeps to the run's anchor column one row down (the carriage return) | confirms the cell, ring moves down — or sweeps, if a Tab run is going |
 | ⇧Enter | (same as Enter, sweeping/moving up) | inserts a line break — the chat-composer convention (Slack, every message box); confirm-and-move-up retired in its favor |
-| Tab / ⇧Tab | moves the ring right / left with row-local wraparound, arming the typewriter anchor | confirms, moves right / left with row-local wraparound, anchor kept |
+| Tab / ⇧Tab | moves the ring right / left with row-local wraparound, arming the typewriter anchor | confirms, moves right / left with row-local wraparound, and immediately edits the destination cell; anchor kept |
 | arrows | move the ring | *replace entry:* confirm + move the ring · *kept-value entry:* move the caret |
 | double-click | opens the editor keeping the value, caret at the click | — |
 | Esc | clears the selection | cancels the edit, restores what was there, ring stays |


### PR DESCRIPTION
## Summary

- confirm the active cell and immediately open the destination editor on Tab and Shift-Tab
- preserve row-local wraparound in both directions
- prevent the closed editor's deferred table-focus handoff from stealing focus from the new input
- bump DuckTable to 0.20.3 and update the changelog and editing guide

## Verification

- `cargo test -p ducktable`
- `cargo check --workspace --all-targets`
- `./scripts/macos-app.sh release`
- built app reports version 0.20.3