### PR TITLE
Show CLI and server versions in fleet view

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,13 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.32.1 — 2026-09-05
+
+- Shows the installed Harbor CLI version as a caption joined to the fleet
+  table printed by bare `harbor`.
+- Adds a `VERSION` column with the version reported by each running database
+  server, making processes that still need a restart immediately visible.
+
 ## 0.32.0 — 2026-09-04
 
 - Adds generated-column metadata to `/catalog` through `generated` and

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.32.0"
+version = "0.32.1"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -103,11 +103,12 @@ while the whole path stays under `sun_path` (the basename yields bytes when
 the runtime dir runs deep).
 
 Discovery is therefore `readdir` + `GET /info` per socket — which is exactly
-what bare `harbor` prints: database path, pid, live client count, uptime,
-address. A socket that refuses the connection is a leftover from a `kill -9`
-and is unlinked on sight; any other failure proves nothing and removes
-nothing. The listening socket is the only runtime registration; `/info` is
-the identity document, with uptime and the client refcount spliced in live.
+what bare `harbor` prints: the installed CLI version, then each database's
+path, serving Harbor version, pid, live client count, uptime, and address. A
+socket that refuses the connection is a leftover from a `kill -9` and is
+unlinked on sight; any other failure proves nothing and removes nothing. The
+listening socket is the only runtime registration; `/info` is the identity
+document, with uptime and the client refcount spliced in live.
 
 ## The refcounted lifetime (bare) and the owned lifetime (start)
 

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -259,7 +259,7 @@ TABLE` rendering per table, and the database and WAL file sizes in exact bytes
 at the top:
 
 ```json
-{"harborVersion":"0.32.0","duckdbVersion":"v2.0.0-dev83323",
+{"harborVersion":"0.32.1","duckdbVersion":"v2.0.0-dev83323",
  "databaseSizeBytes":12582912,"walSizeBytes":0,
  "tables":[{"name":"orders","schema":"main","rowCount":300000,
             "columns":[{"name":"id","type":"BIGINT","notNull":true,
@@ -330,7 +330,7 @@ with `sudo` in front of the whole command — the installer never escalates on
 its own. On Windows the binary lands in `%LOCALAPPDATA%\Programs\harbor\bin`,
 which the installer adds to your user `PATH`.
 
-Pin a version with `... | bash -s v0.32.0` (or `-Tag v0.32.0` on Windows). Each
+Pin a version with `... | bash -s v0.32.1` (or `-Tag v0.32.1` on Windows). Each
 [release](https://github.com/shreeve/duckdb-harbor/releases)
 ships one self-contained archive per
 platform (osx-arm64, linux-amd64, linux-arm64, windows-amd64, windows-arm64):
@@ -366,17 +366,21 @@ derived from the database's canonical path
 
 ```console
 $ harbor
-╭────────────────────┬───────────────────────┬───────┬─────────┬────────╮
-│ DATABASE           │ URL                   │ PID   │ CLIENTS │ UPTIME │
-├────────────────────┼───────────────────────┼───────┼─────────┼────────┤
-│ ~/Data/labs.duckdb │ http://127.0.0.1:9495 │ 72840 │       2 │     3d │ ¹
-╰────────────────────┴───────────────────────┴───────┴─────────┴────────╯
+╭───────────────╮
+│ harbor 0.32.1 │
+├───────────────┴────┬───────────────────────┬─────────┬───────┬─────────┬────────╮
+│ DATABASE           │ URL                   │ VERSION │ PID   │ CLIENTS │ UPTIME │
+├────────────────────┼───────────────────────┼─────────┼───────┼─────────┼────────┤
+│ ~/Data/labs.duckdb │ http://127.0.0.1:9495 │ 0.32.1  │ 72840 │       2 │     3d │ ¹
+╰────────────────────┴───────────────────────┴─────────┴───────┴─────────┴────────╯
 ¹ ~/.local/state/harbor/runtime/labs.duckdb-1a2b3c4d.sock
 ```
 
-The socket path hangs below the grid under the row's footnote, and the URL
-column exists only while some server has a TCP door — an all-socket fleet
-keeps the four-column shape.
+The caption is the installed CLI version. Each row's version comes from that
+running server, so an installation update is visible immediately and servers
+that still need a restart stand out. The socket path hangs below the grid
+under the row's footnote, and the URL column exists only while some server has
+a TCP door — an all-socket fleet keeps the five-column shape.
 
 A running database answers to four spellings, and the last two come straight
 off this list:

--- a/harbor/crates/common/src/ui.rs
+++ b/harbor/crates/common/src/ui.rs
@@ -202,6 +202,7 @@ impl Cell {
 /// they need the answer is the only moment they will read anything.
 #[derive(Default)]
 pub struct Table {
+    caption: Option<String>,
     head: Vec<String>,
     rows: Vec<Vec<Cell>>,
     notes: Vec<(usize, Tone, String)>,
@@ -213,6 +214,14 @@ impl Table {
             head: head.into_iter().map(|h| sanitize(h.as_ref())).collect(),
             ..Default::default()
         }
+    }
+
+    /// Give the table a title. On a terminal it becomes a small tab joined
+    /// to the table's top border; through a pipe it is a plain line before
+    /// the TSV header.
+    pub fn caption(&mut self, text: impl AsRef<str>) -> &mut Self {
+        self.caption = Some(sanitize(text.as_ref()));
+        self
     }
 
     pub fn row(&mut self, cells: impl IntoIterator<Item = Cell>) -> &mut Self {
@@ -235,9 +244,13 @@ impl Table {
         }
     }
 
-    /// Tab-separated, no notes, no color. What a pipe wants.
+    /// Plain caption, then tab-separated data; no notes or color. What a pipe wants.
     fn render_plain(&self) -> String {
         let mut out = String::new();
+        if let Some(caption) = &self.caption {
+            out.push_str(caption);
+            out.push('\n');
+        }
         if !self.head.is_empty() {
             out.push_str(&self.head.join("\t"));
             out.push('\n');
@@ -261,6 +274,12 @@ impl Table {
                 w[i] = w[i].max(cells(&c.text));
             }
         }
+        // Keep the caption's right edge inside the first cell rather than
+        // colliding with its first column joint. Usually DATABASE is already
+        // much wider; this matters for an empty fleet.
+        if let (Some(caption), Some(first)) = (&self.caption, w.first_mut()) {
+            *first = (*first).max(cells(caption) + 1);
+        }
         w
     }
 
@@ -277,8 +296,29 @@ impl Table {
         };
 
         let mut out = String::new();
-        out.push_str(&rule(c.tl, c.tm, c.tr));
-        out.push('\n');
+        if let Some(caption) = &self.caption {
+            let caption_width = cells(caption);
+            out.push_str(&format!("{}{}{}\n", c.tl, c.h.repeat(caption_width + 2), c.tr));
+            out.push_str(&format!(
+                "{} {} {}\n",
+                c.v,
+                st.paint(Tone::Bold, caption),
+                c.v
+            ));
+
+            // The caption's lower border is also the table's top border.
+            // Because widths() keeps its endpoint inside column zero, the
+            // join is a T pointing up, followed later by the normal column
+            // joints pointing down.
+            let mut top: Vec<char> = rule(c.tl, c.tm, c.tr).chars().collect();
+            top[0] = c.ml.chars().next().unwrap();
+            top[caption_width + 3] = c.bm.chars().next().unwrap();
+            out.extend(top);
+            out.push('\n');
+        } else {
+            out.push_str(&rule(c.tl, c.tm, c.tr));
+            out.push('\n');
+        }
 
         if !self.head.is_empty() {
             let hs: Vec<String> = (0..w.len())
@@ -365,6 +405,29 @@ mod tests {
         assert!(out.starts_with("╭─"), "{out}");
         assert!(out.contains('┬') && out.contains('┼') && out.contains('┴'));
         assert!(out.trim_end().ends_with('╯'), "{out}");
+    }
+
+    #[test]
+    fn a_caption_is_a_tab_joined_to_the_top_border() {
+        let mut t = Table::new(["DATABASE", "VERSION"]);
+        t.caption("fleet");
+        t.row([Cell::new("~/labs.duckdb"), Cell::new("old")]);
+        let out = t.render(&boxed());
+        let mut lines = out.lines();
+        assert_eq!(lines.next(), Some("╭───────╮"));
+        assert_eq!(lines.next(), Some("│ fleet │"));
+        assert_eq!(lines.next(), Some("├───────┴───────┬─────────╮"));
+    }
+
+    #[test]
+    fn a_caption_stays_a_plain_line_in_tsv() {
+        let mut t = Table::new(["DATABASE", "VERSION"]);
+        t.caption("fleet");
+        t.row([Cell::new("db.duckdb"), Cell::new("old")]);
+        assert_eq!(
+            t.render(&Style::plain()),
+            "fleet\nDATABASE\tVERSION\ndb.duckdb\told\n"
+        );
     }
 
     #[test]

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -482,6 +482,7 @@ fn is_socket(p: &Path) -> bool {
 struct ListRow {
     database: String,
     url: String,
+    version: String,
     pid: String,
     clients: String,
     uptime: String,
@@ -578,6 +579,9 @@ fn list() -> Result<(), String> {
                             .map(|d| harbor_common::paths::shorten(Path::new(d)))
                             .unwrap_or_else(|| "?".into()),
                         url: url_of(&v).unwrap_or_default(),
+                        version: v["harborVersion"]
+                            .as_str()
+                            .map_or_else(|| "?".into(), Into::into),
                         pid: v["pid"].as_u64().map_or_else(|| "?".into(), |p| p.to_string()),
                         clients: v["clients"]
                             .as_u64()
@@ -589,6 +593,7 @@ fn list() -> Result<(), String> {
                 None => ListRow {
                     database: "?".into(),
                     url: String::new(),
+                    version: "?".into(),
                     pid: "?".into(),
                     clients: "?".into(),
                     uptime: "?".into(),
@@ -604,7 +609,8 @@ fn list() -> Result<(), String> {
     // it holds 0 rows or 30, so the eye (and a script) meets one shape. The
     // tally line below carries the words.
     if rows.is_empty() {
-        let t = Table::new(["DATABASE", "PID", "CLIENTS", "UPTIME"]);
+        let mut t = Table::new(["DATABASE", "VERSION", "PID", "CLIENTS", "UPTIME"]);
+        t.caption(format!("harbor {}", env!("CARGO_PKG_VERSION")));
         println!("{}", t.render(&Style::stdout()));
         println!("  Nothing running\n");
         println!("  harbor <db.duckdb>   open a database — served while anyone is connected");
@@ -622,7 +628,7 @@ fn list() -> Result<(), String> {
     // stay tight and the address is still one glance away. A tally closes it,
     // live rows first. Piped output degrades to plain text (Style::stdout).
     // The URL column exists only when some server has a TCP door — an
-    // all-socket fleet keeps the four-column shape, no empty column earning
+    // all-socket fleet keeps the five-column shape, no empty column earning
     // its keep. The URL is the bare base (no /ready, no /info): it is a
     // client target as it stands — `harbor <url>` — and any route suffix
     // would narrow it to one verb.
@@ -631,14 +637,19 @@ fn list() -> Result<(), String> {
     if tcp {
         head.push("URL");
     }
-    head.extend(["PID", "CLIENTS", "UPTIME"]);
+    head.extend(["VERSION", "PID", "CLIENTS", "UPTIME"]);
     let mut t = Table::new(head);
+    // The caption identifies this CLI binary; the VERSION column identifies
+    // each independently running server binary. They can differ after an
+    // installation replaces harbor but existing servers keep running.
+    t.caption(format!("harbor {}", env!("CARGO_PKG_VERSION")));
     for r in &rows {
         let running = r.pid != "?";
         let mut cells = vec![Cell::new(&r.database).tone(if running { Tone::Green } else { Tone::Dim })];
         if tcp {
             cells.push(Cell::new(&r.url));
         }
+        cells.push(Cell::new(&r.version));
         cells.extend([
             Cell::new(&r.pid).right(),
             Cell::new(&r.clients).right(),


### PR DESCRIPTION
## Summary

- render the installed Harbor CLI version as a caption joined to the fleet table
- show each running database server's reported Harbor version in its own column
- release the change as Harbor 0.32.1 and document the two version levels

## Validation

- `cargo test -p harbor-common -p harbor`
- `cargo check --workspace --all-targets` in DuckTable
- `make test SUITES="unit lifecycle types spec catalog sessions cancel"`
- release-binary smoke test with an isolated live server