### PR TITLE
Make autostart a service under launchd and systemd

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/ducktable/crates/harbor-client/src/fleet.rs
+++ b/ducktable/crates/harbor-client/src/fleet.rs
@@ -541,7 +541,7 @@ pub fn set_autostart(db: &Path, on: bool) -> Result<(), String> {
     let name = harbor_common::membership::name_of(db)?;
     if on {
         harbor_common::membership::attach(db)?;
-        harbor_common::autostart::install(db, &name)
+        harbor_common::autostart::arm(db, &name)
     } else {
         harbor_common::autostart::remove(&name).map(|_| ())
     }

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,21 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.33.0 — 2026-09-06
+
+- Makes `autostart` a service: the login item is loaded the moment it is
+  installed, so the server starts now under launchd or systemd, at every
+  login, and again after a crash (`KeepAlive` on failure only; systemd
+  `Restart=on-failure`). A clean `stop` stays stopped until the next login.
+- Adds `restart`, which bounces a database under its login item with a fresh
+  read of config.toml, and `autostart off`, which drops the login item and
+  leaves a running server alone (`autostart off stop` takes both down).
+- Stops a plain `start` or `stop` from removing the login item; only
+  `autostart off` and `detach` do.
+- Refuses start options on `autostart` and on a login item's `restart`,
+  pointing at the `[connection.<name>]` entry a login item actually reads.
+- Sends the login item's output to the berth's log under `runtime/log/`.
+
 ## 0.32.1 — 2026-09-05
 
 - Shows the installed Harbor CLI version as a caption joined to the fleet

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.32.1"
+version = "0.33.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -354,9 +354,30 @@ same path — joins the same server instead of reporting "database is locked".
 refcount: it lives until you leave. On a terminal you get the same prompt,
 dialled at the server's own socket, and `.quit` ends the server; headless it
 runs until `SIGTERM`. Either exit is clean — drain, `CHECKPOINT` so the next
-open never replays a WAL, socket swept. Boot persistence belongs to launchd
-or a systemd user unit running exactly this command; harbor never becomes a
-supervisor.
+open never replays a WAL, socket swept.
+
+**`harbor <db.duckdb> autostart` — the server is the session manager's.**
+harbor never becomes a supervisor; it hands exactly this `start` to one that
+already exists. On macOS it writes a LaunchAgent and loads it, on Linux a
+systemd user unit, enabled and started. The server comes up now, at every
+login, and again after a crash — never after a clean exit, so `stop` stays
+stopped until the next login and `restart` bounces it with a fresh read of
+its config. `autostart off` drops the login item and leaves a running server
+alone; `autostart off stop` takes both down. A login item runs a bare
+`start`, so its options are the `[connection.<name>]` entry in config.toml
+(`statement-timeout`, `memory-limit`, `workers`, `threads`, `init`), never
+flags. The verbs move two independent facts, the way `brew services` and
+`systemctl` do:
+
+| You type             | Registered at login | Running now       |
+| -------------------- | ------------------- | ----------------- |
+| `autostart`          | yes                 | yes               |
+| `autostart stop`     | yes                 | no                |
+| `stop`               | unchanged           | no                |
+| `restart`            | unchanged           | yes               |
+| `autostart off`      | no                  | unchanged         |
+| `autostart off stop` | no                  | no                |
+| `detach`             | no                  | no, and forgotten |
 
 There is no registry. The socket **is** the runtime registration: its name is
 derived from the database's canonical path

--- a/harbor/crates/common/src/autostart.rs
+++ b/harbor/crates/common/src/autostart.rs
@@ -1,48 +1,131 @@
-//! autostart — the login item that runs `harbor <db> start` when you log in.
+//! autostart — the login item that keeps `harbor <db> start` running for you.
 //!
-//! Installing it is just placing a file the platform's session manager already
-//! reads at login: a launchd LaunchAgent on macOS, a systemd user unit on
-//! Linux. It arms the NEXT login and leaves "now" to whoever asked — the CLI's
-//! running axis, or nobody (a GUI checkbox arms login without starting).
+//! The platform's session manager is the supervisor: a launchd LaunchAgent on
+//! macOS, a systemd user unit on Linux. Both run the same bare `start`, which
+//! takes its standing options from the database's config.toml entry, so the
+//! server launched at login is the fully configured one.
 //!
-//! RunAtLoad / WantedBy, never KeepAlive: it starts the server once when you
-//! log in, and does not resurrect one you stop. The server it launches is a
-//! plain `start`, so it is persistent — up until you stop it or log out.
+//! The item has two independent facts, and the verbs map onto them the way
+//! `brew services` and `systemctl` users expect:
 //!
-//! Shared so the CLI and DuckTable arm and disarm it through the same code and
+//!   registered — the file exists and the manager knows it (arm / remove)
+//!   loaded     — the manager holds the job now (install / unload)
+//!
+//! `install` registers AND loads: the server starts now, under the manager,
+//! and again at every login. `arm` registers only. `remove` unregisters and
+//! leaves any running server alone; `unload` takes the job out of the current
+//! session. The manager restarts the server after a crash and never after a
+//! clean exit, so `harbor <db> stop` stays stopped until the next login.
+//!
+//! Shared so the CLI and DuckTable arm and disarm through the same code and
 //! read the same `installed` truth for a menu checkmark.
 
 use crate::paths;
 use std::path::Path;
 
+/// What `install` found when it went to load the job.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Installed {
+    /// The manager loaded the item and the server is starting under it.
+    Started,
+    /// The manager already held the item; nothing to start.
+    AlreadyLoaded,
+    /// Something else is serving the database, so the item was registered
+    /// but not loaded — a load would only fail against the file lock and
+    /// then retry. `restart` hands the server over.
+    Deferred,
+}
+
 // ---------------------------------------------------------------------------
-// macOS — a ~/Library/LaunchAgents plist. Placing the file arms the next
-// login; we deliberately do not `launchctl load` it, so "run now" is never a
-// side effect of arming — there is no double-start to reconcile.
+// macOS — a ~/Library/LaunchAgents plist, loaded with `launchctl bootstrap`.
 // ---------------------------------------------------------------------------
 
 #[cfg(target_os = "macos")]
-pub fn install(db: &Path, name: &str) -> Result<(), String> {
+fn domain() -> String {
+    // SAFETY: getuid has no preconditions and cannot fail.
+    format!("gui/{}", unsafe { libc::getuid() })
+}
+
+#[cfg(target_os = "macos")]
+fn label(name: &str) -> String {
+    format!("harbor.{name}")
+}
+
+#[cfg(target_os = "macos")]
+fn launchctl(args: &[&str]) -> bool {
+    std::process::Command::new("launchctl")
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Register the item: write the plist and clear any disable launchd may hold
+/// for the label from an earlier life. Does not load it.
+#[cfg(target_os = "macos")]
+pub fn arm(db: &Path, name: &str) -> Result<(), String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let canon = paths::canonical_db(db)?;
+    let log = paths::log_file(&paths::runtime_dir()?, name);
+    if let Some(dir) = log.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
     let plist = agent_path(name)?;
     if let Some(dir) = plist.parent() {
         std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
     }
-    std::fs::write(&plist, plist_body(name, &exe.display().to_string(), &canon.display().to_string()))
-        .map_err(|e| format!("writing {}: {e}", plist.display()))?;
+    std::fs::write(
+        &plist,
+        plist_body(name, &exe.display().to_string(), &canon.display().to_string(), &log.display().to_string()),
+    )
+    .map_err(|e| format!("writing {}: {e}", plist.display()))?;
+    launchctl(&["enable", &format!("{}/{}", domain(), label(name))]);
     Ok(())
 }
 
+/// Register and load: the server starts now under launchd and at every login.
+/// `serving` says whether something already answers for this database; when
+/// it does, the item is registered but not loaded.
+#[cfg(target_os = "macos")]
+pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String> {
+    arm(db, name)?;
+    if loaded(name) {
+        return Ok(Installed::AlreadyLoaded);
+    }
+    if serving {
+        return Ok(Installed::Deferred);
+    }
+    let plist = agent_path(name)?;
+    let out = std::process::Command::new("launchctl")
+        .args(["bootstrap", &domain()])
+        .arg(&plist)
+        .output()
+        .map_err(|e| format!("launchctl bootstrap: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "launchctl bootstrap {}: {}",
+            plist.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(Installed::Started)
+}
+
+/// Take the job out of this session. The server, if launchd is running one,
+/// receives SIGTERM and exits cleanly. Registration is untouched.
+#[cfg(target_os = "macos")]
+pub fn unload(name: &str) {
+    launchctl(&["bootout", &format!("{}/{}", domain(), label(name))]);
+}
+
+/// Unregister: delete the plist. A running server is left alone; it ends
+/// with `stop` or at logout. Returns whether there was an item to remove.
 #[cfg(target_os = "macos")]
 pub fn remove(name: &str) -> Result<bool, String> {
     let plist = agent_path(name)?;
     if !plist.exists() {
         return Ok(false);
     }
-    // Best-effort unload if it happens to be loaded this session; unload reads
-    // the plist by path, so it needs no uid. A not-loaded item just no-ops.
-    let _ = std::process::Command::new("launchctl").arg("unload").arg(&plist).output();
     std::fs::remove_file(&plist).map_err(|e| format!("removing {}: {e}", plist.display()))?;
     Ok(true)
 }
@@ -53,35 +136,49 @@ pub fn installed(name: &str) -> bool {
     agent_path(name).map(|p| p.exists()).unwrap_or(false)
 }
 
+/// Whether launchd holds the job in this session.
+#[cfg(target_os = "macos")]
+fn loaded(name: &str) -> bool {
+    launchctl(&["print", &format!("{}/{}", domain(), label(name))])
+}
+
 #[cfg(target_os = "macos")]
 fn agent_path(name: &str) -> Result<std::path::PathBuf, String> {
     let home = std::env::var_os("HOME").ok_or("no HOME to place the login item under")?;
     Ok(std::path::PathBuf::from(home)
         .join("Library/LaunchAgents")
-        .join(format!("harbor.{name}.plist")))
+        .join(format!("{}.plist", label(name))))
 }
 
+// KeepAlive on failure only: a crash or a kill comes back after the throttle,
+// a clean exit — `stop`, `.quit`, the refcount departure — stays down. The
+// server's stdout and stderr land in the berth's log, which is where a crash
+// explains itself.
 #[cfg(target_os = "macos")]
-fn plist_body(name: &str, exe: &str, db: &str) -> String {
+fn plist_body(name: &str, exe: &str, db: &str, log: &str) -> String {
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
          <plist version=\"1.0\">\n\
          <dict>\n\
-         \t<key>Label</key>\n\t<string>harbor.{name}</string>\n\
+         \t<key>Label</key>\n\t<string>{label}</string>\n\
          \t<key>ProgramArguments</key>\n\t<array>\n\
          \t\t<string>{exe}</string>\n\t\t<string>{db}</string>\n\t\t<string>start</string>\n\
          \t</array>\n\
-         \t<key>EnvironmentVariables</key>\n\t<dict>\n\
-         \t\t<key>HARBOR_AUTOSTART</key>\n\t\t<string>1</string>\n\
-         \t</dict>\n\
          \t<key>RunAtLoad</key>\n\t<true/>\n\
+         \t<key>KeepAlive</key>\n\t<dict>\n\
+         \t\t<key>SuccessfulExit</key>\n\t\t<false/>\n\
+         \t</dict>\n\
+         \t<key>ThrottleInterval</key>\n\t<integer>10</integer>\n\
+         \t<key>StandardOutPath</key>\n\t<string>{log}</string>\n\
+         \t<key>StandardErrorPath</key>\n\t<string>{log}</string>\n\
          \t<key>ProcessType</key>\n\t<string>Background</string>\n\
          </dict>\n\
          </plist>\n",
-        name = xml(name),
+        label = xml(&label(name)),
         exe = xml(exe),
         db = xml(db),
+        log = xml(log),
     )
 }
 
@@ -91,40 +188,81 @@ fn xml(s: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Linux — a ~/.config/systemd/user unit, enabled so default.target pulls it in
-// at login. `enable` (not `enable --now`) arms the next login without starting
-// one now.
+// Linux — a ~/.config/systemd/user unit. `enable` registers it with
+// default.target; `start` loads it now.
 // ---------------------------------------------------------------------------
 
 #[cfg(target_os = "linux")]
-pub fn install(db: &Path, name: &str) -> Result<(), String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let canon = paths::canonical_db(db)?;
-    let unit = unit_path(name)?;
-    if let Some(dir) = unit.parent() {
-        std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
-    }
-    std::fs::write(&unit, unit_body(name, &exe.display().to_string(), &canon.display().to_string()))
-        .map_err(|e| format!("writing {}: {e}", unit.display()))?;
-    // Arm the next login (creates the default.target.wants symlink). Best
-    // effort: a build box without a user session bus should still write the
-    // unit rather than fail the whole command.
-    let _ = std::process::Command::new("systemctl")
-        .args(["--user", "enable", &format!("harbor-{name}.service")])
-        .output();
-    Ok(())
+fn unit(name: &str) -> String {
+    format!("harbor-{name}.service")
 }
 
 #[cfg(target_os = "linux")]
+fn systemctl(args: &[&str]) -> Result<(), String> {
+    let out = std::process::Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .output()
+        .map_err(|e| format!("systemctl --user {}: {e}", args.join(" ")))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "systemctl --user {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
+/// Register the unit and enable it for login. Does not start it. Enabling is
+/// best effort: a build box without a user session bus still gets the file.
+#[cfg(target_os = "linux")]
+pub fn arm(db: &Path, name: &str) -> Result<(), String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let canon = paths::canonical_db(db)?;
+    let path = unit_path(name)?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
+    std::fs::write(&path, unit_body(name, &exe.display().to_string(), &canon.display().to_string()))
+        .map_err(|e| format!("writing {}: {e}", path.display()))?;
+    let _ = systemctl(&["daemon-reload"]);
+    let _ = systemctl(&["enable", &unit(name)]);
+    Ok(())
+}
+
+/// Register, enable, and start now. A unit already active is left running.
+#[cfg(target_os = "linux")]
+pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String> {
+    arm(db, name)?;
+    if systemctl(&["is-active", "--quiet", &unit(name)]).is_ok() {
+        return Ok(Installed::AlreadyLoaded);
+    }
+    if serving {
+        return Ok(Installed::Deferred);
+    }
+    systemctl(&["start", &unit(name)])?;
+    Ok(Installed::Started)
+}
+
+/// Stop the unit's server, if systemd is running one. Registration stays.
+#[cfg(target_os = "linux")]
+pub fn unload(name: &str) {
+    let _ = systemctl(&["stop", &unit(name)]);
+}
+
+/// Unregister: disable the unit and delete its file. A running server is
+/// left alone. Returns whether there was a unit to remove.
+#[cfg(target_os = "linux")]
 pub fn remove(name: &str) -> Result<bool, String> {
-    let unit = unit_path(name)?;
-    if !unit.exists() {
+    let path = unit_path(name)?;
+    if !path.exists() {
         return Ok(false);
     }
-    let _ = std::process::Command::new("systemctl")
-        .args(["--user", "disable", &format!("harbor-{name}.service")])
-        .output();
-    std::fs::remove_file(&unit).map_err(|e| format!("removing {}: {e}", unit.display()))?;
+    let _ = systemctl(&["disable", &unit(name)]);
+    std::fs::remove_file(&path).map_err(|e| format!("removing {}: {e}", path.display()))?;
+    let _ = systemctl(&["daemon-reload"]);
     Ok(true)
 }
 
@@ -140,20 +278,23 @@ fn unit_path(name: &str) -> Result<std::path::PathBuf, String> {
         .map(std::path::PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".config")))
         .ok_or("no HOME to place the login item under")?;
-    Ok(base.join("systemd/user").join(format!("harbor-{name}.service")))
+    Ok(base.join("systemd/user").join(unit(name)))
 }
 
+// Restart=on-failure is KeepAlive's SuccessfulExit=false: back after a crash,
+// down after a clean exit. Quote the two paths so a space in either survives
+// systemd's word split.
 #[cfg(target_os = "linux")]
 fn unit_body(name: &str, exe: &str, db: &str) -> String {
-    // Quote the two paths so a space in either survives systemd's word split.
     format!(
         "[Unit]\n\
          Description=harbor: {name}\n\
          After=default.target\n\n\
          [Service]\n\
          Type=simple\n\
-         Environment=HARBOR_AUTOSTART=1\n\
-         ExecStart=\"{exe}\" \"{db}\" start\n\n\
+         ExecStart=\"{exe}\" \"{db}\" start\n\
+         Restart=on-failure\n\
+         RestartSec=10\n\n\
          [Install]\n\
          WantedBy=default.target\n",
         exe = exe.replace('"', "\\\""),
@@ -166,9 +307,17 @@ fn unit_body(name: &str, exe: &str, db: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub fn install(_db: &Path, _name: &str) -> Result<(), String> {
+pub fn arm(_db: &Path, _name: &str) -> Result<(), String> {
     Err("autostart is only supported on macOS and Linux".into())
 }
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn install(_db: &Path, _name: &str, _serving: bool) -> Result<Installed, String> {
+    Err("autostart is only supported on macOS and Linux".into())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn unload(_name: &str) {}
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 pub fn remove(_name: &str) -> Result<bool, String> {
@@ -184,27 +333,55 @@ pub fn installed(_name: &str) -> bool {
 mod tests {
     #[cfg(target_os = "macos")]
     #[test]
-    fn plist_names_the_verb_and_escapes_paths() {
-        let body = super::plist_body("my-db", "/opt/harbor & co/harbor", "/data/my-db.duckdb");
+    fn plist_runs_start_and_escapes_paths() {
+        let body = super::plist_body("my-db", "/opt/harbor & co/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
         assert!(body.contains("<string>harbor.my-db</string>"));
-        assert!(body.contains("<string>start</string>"));
-        assert!(body.contains("<key>RunAtLoad</key>"));
-        assert!(!body.contains("<key>KeepAlive</key>"), "RunAtLoad, never KeepAlive");
-        // The login item's own start must not reconcile autostart — without
-        // this marker the agent deletes its plist at every login.
-        assert!(body.contains("<key>HARBOR_AUTOSTART</key>"));
+        assert!(body.contains("<string>/data/my-db.duckdb</string>\n\t\t<string>start</string>"));
+        assert!(body.contains("<key>RunAtLoad</key>\n\t<true/>"));
         assert!(body.contains("/opt/harbor &amp; co/harbor"), "the & must be XML-escaped");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn plist_restarts_on_failure_only() {
+        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        assert!(body.contains("<key>KeepAlive</key>\n\t<dict>\n\t\t<key>SuccessfulExit</key>\n\t\t<false/>"));
+        assert!(body.contains("<key>ThrottleInterval</key>\n\t<integer>10</integer>"));
+        assert!(!body.contains("<key>KeepAlive</key>\n\t<true/>"), "a clean stop must stay stopped");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn plist_sends_output_to_the_berth_log() {
+        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        assert!(body.contains("<key>StandardOutPath</key>\n\t<string>/tmp/log/my-db.log</string>"));
+        assert!(body.contains("<key>StandardErrorPath</key>\n\t<string>/tmp/log/my-db.log</string>"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn plist_carries_no_environment() {
+        // The login item's start is a plain start: options come from
+        // config.toml, and nothing about it is signalled through env.
+        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        assert!(!body.contains("EnvironmentVariables"));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn unit_names_the_verb_and_quotes_paths() {
+    fn unit_runs_start_and_quotes_paths() {
         let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my db.duckdb");
         assert!(body.contains("ExecStart=\"/opt/harbor/harbor\" \"/data/my db.duckdb\" start"));
         assert!(body.contains("WantedBy=default.target"));
-        assert!(!body.contains("Restart="), "no KeepAlive equivalent");
-        // The unit's own start must not reconcile autostart — without this
-        // marker the service deletes its unit file every time it starts.
-        assert!(body.contains("Environment=HARBOR_AUTOSTART=1"));
+        assert!(!body.contains("Environment="));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unit_restarts_on_failure_only() {
+        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my-db.duckdb");
+        assert!(body.contains("Restart=on-failure"));
+        assert!(body.contains("RestartSec=10"));
+        assert!(!body.contains("Restart=always"), "a clean stop must stay stopped");
     }
 }

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, Instant};
 
 use harbor_common::duration::parse_duration;
 use harbor_common::autostart;
+use verbs::Running;
 use harbor_common::membership::{self, Attached};
 use harbor_common::perms::chmod;
 
@@ -86,14 +87,24 @@ fn main() -> ExitCode {
     };
     let flags = args; // whatever followed the verbs — start's, and only start's
 
-    if plan.run != Some(true) && !flags.is_empty() {
+    // Only a hand start takes options. The login item runs a bare `start`
+    // that reads the database's config.toml entry, so options given to
+    // `autostart` would be honored once and silently dropped at every login.
+    if plan.autostart == Some(true) && !flags.is_empty() {
+        eprintln!(
+            "harbor: a login item starts from config.toml, not flags — put {} under [connection.<name>]",
+            flags.join(" ")
+        );
+        return ExitCode::FAILURE;
+    }
+    if !matches!(plan.run, Some(Running::Start | Running::Restart)) && !flags.is_empty() {
         eprintln!("harbor: only `start` takes options — got: {}", flags.join(" "));
         return ExitCode::FAILURE;
     }
 
     // Membership first — durable and quick, and it is what a start's lifetime
     // keys off: a listed database is persistent, an unlisted one ephemeral.
-    // Detach also tears down any login item, since one for a database you no
+    // Detach also removes any login item, since one for a database you no
     // longer keep makes no sense.
     match plan.attach {
         Some(true) => match membership::attach(&db) {
@@ -118,49 +129,118 @@ fn main() -> ExitCode {
         None => {}
     }
 
-    // autostart is declarative and defaults off: any lifetime change re-applies
-    // it — an explicit `autostart` installs the login item, its absence removes
-    // one — and a detach tears it down too. We act before the running axis,
-    // since a persistent start blocks at the helm and would defer the install.
-    // The one exempt caller is the login item itself: its `start` is the boot
-    // machinery running what the user armed, not the user declaring a new
-    // lifetime — reconciling there would delete the unit at every boot. Like
-    // ephemerality, that rides an env channel, never a flag.
-    let booted = std::env::var_os("HARBOR_AUTOSTART").is_some();
-    if !booted && (plan.run.is_some() || plan.attach == Some(false)) {
-        let name = match membership::name_of(&db) {
-            Ok(n) => n,
+    let name = match membership::name_of(&db) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("harbor: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // The login item. Installing it loads it too, so the session manager
+    // starts the server now and at every login; the running axis is carried
+    // out by the manager, never by a start in this process. Removing it
+    // leaves whatever is running alone unless a stop was asked for. A plain
+    // start or stop never touches it: stopped stays stopped until the next
+    // login, which is what a login item means.
+    if let Some(install) = plan.autostart {
+        if install {
+            let stopped = match plan.run {
+                Some(Running::Stop | Running::Restart) => match harbor::repl::shutdown(&db) {
+                    Ok(stopped) => stopped,
+                    Err(e) => {
+                        eprintln!("harbor: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                },
+                _ => false,
+            };
+            if stopped {
+                eprintln!("harbor: {} stopped", db.display());
+            }
+            if plan.run == Some(Running::Stop) {
+                return match autostart::arm(&db, &name) {
+                    Ok(()) => {
+                        eprintln!("harbor: {name} will start at login");
+                        ExitCode::SUCCESS
+                    }
+                    Err(e) => {
+                        eprintln!("harbor: {e}");
+                        ExitCode::FAILURE
+                    }
+                };
+            }
+            if plan.run == Some(Running::Restart) {
+                autostart::unload(&name);
+            }
+            return match autostart::install(&db, &name, serving(&db)) {
+                Ok(autostart::Installed::Started) => {
+                    eprintln!("harbor: {name} started; it will start at every login");
+                    ExitCode::SUCCESS
+                }
+                Ok(autostart::Installed::AlreadyLoaded) => {
+                    eprintln!("harbor: {name} is already running at login — `restart` applies a changed config");
+                    ExitCode::SUCCESS
+                }
+                Ok(autostart::Installed::Deferred) => {
+                    eprintln!(
+                        "harbor: {name} is already being served; it will start at login — `harbor {} restart` hands it over now",
+                        db.display()
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("harbor: {e}");
+                    ExitCode::FAILURE
+                }
+            };
+        }
+        if plan.run == Some(Running::Stop) {
+            match harbor::repl::shutdown(&db) {
+                Ok(true) => eprintln!("harbor: {} stopped", db.display()),
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("harbor: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+            autostart::unload(&name);
+        }
+        match autostart::remove(&name) {
+            Ok(true) => eprintln!("harbor: {name} will no longer start at login"),
+            Ok(false) => eprintln!("harbor: {name} was not set to start at login"),
             Err(e) => {
                 eprintln!("harbor: {e}");
                 return ExitCode::FAILURE;
             }
-        };
-        let synced = if plan.autostart {
-            autostart::install(&db, &name).inspect(|()| eprintln!("harbor: {name} will start at login"))
-        } else {
-            autostart::remove(&name).map(|removed| {
-                if removed {
-                    eprintln!("harbor: {name} will no longer start at login");
-                }
-            })
-        };
-        if let Err(e) = synced {
-            eprintln!("harbor: {e}");
-            return ExitCode::FAILURE;
+        }
+        if plan.run != Some(Running::Start) {
+            return ExitCode::SUCCESS;
+        }
+    } else if plan.attach == Some(false) {
+        match autostart::remove(&name) {
+            Ok(true) => eprintln!("harbor: {name} will no longer start at login"),
+            Ok(false) => {}
+            Err(e) => {
+                eprintln!("harbor: {e}");
+                return ExitCode::FAILURE;
+            }
         }
     }
 
     // Running. The grammar owns the lifetime — a detached start is ephemeral —
-    // so start takes that as a plain fact, not a flag.
+    // so start takes that as a plain fact, not a flag. A restart of a database
+    // with a login item is the manager's to do: the server comes back under
+    // launchd or systemd with a fresh read of its config, not in this process.
     match plan.run {
-        Some(true) => match start(db, flags, plan.ephemeral()) {
+        Some(Running::Start) => match start(db, flags, plan.ephemeral()) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("harbor: {e}");
                 ExitCode::FAILURE
             }
         },
-        Some(false) => match harbor::repl::shutdown(&db) {
+        Some(Running::Stop) => match harbor::repl::shutdown(&db) {
             Ok(true) => {
                 eprintln!("harbor: {} stopped", db.display());
                 ExitCode::SUCCESS
@@ -174,7 +254,61 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Some(Running::Restart) => {
+            if autostart::installed(&name) && !flags.is_empty() {
+                eprintln!(
+                    "harbor: {name} starts at login from config.toml, not flags — put {} under [connection.{name}]",
+                    flags.join(" ")
+                );
+                return ExitCode::FAILURE;
+            }
+            match harbor::repl::shutdown(&db) {
+                Ok(true) => eprintln!("harbor: {} stopped", db.display()),
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("harbor: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+            if autostart::installed(&name) {
+                autostart::unload(&name);
+                return match autostart::install(&db, &name, false) {
+                    Ok(_) => {
+                        eprintln!("harbor: {name} restarted; it will start at every login");
+                        ExitCode::SUCCESS
+                    }
+                    Err(e) => {
+                        eprintln!("harbor: {e}");
+                        ExitCode::FAILURE
+                    }
+                };
+            }
+            match start(db, flags, plan.ephemeral()) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("harbor: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
         None => ExitCode::SUCCESS, // a bare attach/detach: membership done
+    }
+}
+
+/// Is anything answering for this database right now — a hand start, a
+/// summon, or the login item's own server?
+fn serving(db: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        let Ok(runtime) = harbor_common::runtime_dir() else { return false };
+        let Ok(canon) = harbor_common::paths::canonical_db(db) else { return false };
+        let Ok(sock) = harbor_common::socket_for(&runtime, &canon) else { return false };
+        sock.exists() && harbor::repl::sock_ready(&sock)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = db;
+        false
     }
 }
 
@@ -194,17 +328,27 @@ usage:
                                you get the prompt and .quit ends the server;
                                headless it runs until SIGTERM
   harbor <db.duckdb> stop      stop the server for this database, if one is
-                               running (a quiet no-op if nothing is)
+                               running (a quiet no-op if nothing is); a login
+                               item brings it back at the next login
+  harbor <db.duckdb> restart   stop and start again — under the login item
+                               when there is one, re-reading config.toml
   harbor <db.duckdb> attach    add this database to your list (config.toml) —
                                a listed database is persistent when started
   harbor <db.duckdb> detach    remove it from your list (and its login item)
-  harbor <db.duckdb> autostart start it at every login (implies attach + start;
-                               `autostart stop` arms login but leaves it off now)
+  harbor <db.duckdb> autostart keep it running: starts now under launchd or
+                               systemd, at every login, and again after a
+                               crash (implies attach; `autostart stop` arms
+                               login but leaves it off now)
+  harbor <db.duckdb> autostart off
+                               drop the login item; a running server is left
+                               alone (`autostart off stop` takes both down)
   harbor version               print this binary's version (also -V)
 
 Verbs combine, in any order: `attach start` remembers it and starts it
 persistent; `detach start` starts an ephemeral one; `attach` alone just
-lists it. At most one of attach/detach and one of start/stop.
+lists it. At most one of attach/detach and one of start/stop/restart.
+A login item runs a bare `start`, so its options live in config.toml under
+[connection.<name>] — statement-timeout, memory-limit, workers, threads, init.
 
 The two lifetimes, in one breath — bare: the server is everyone's, it lives
 while anyone is connected. start: the server is yours, it lives until you

--- a/harbor/crates/harbor/src/verbs.rs
+++ b/harbor/crates/harbor/src/verbs.rs
@@ -1,15 +1,20 @@
-//! The verb grammar: `harbor <db> [attach|detach] [start|stop] [autostart]`.
+//! The verb grammar: `harbor <db> [attach|detach] [start|stop|restart] [autostart [off]]`.
 //!
 //! A bag of BARE verbs — no `--options` — in any order, at most one per axis.
 //! The bag is validated as a whole (nothing half-applies) and resolved into a
-//! [`Plan`] the caller enacts. Two axes:
+//! [`Plan`] the caller enacts. Two axes and one property:
 //!
-//!   membership — attach / detach   (on your list; persisted in config)
-//!   running    — start / stop      (green now)
+//!   membership — attach / detach          (on your list; persisted in config)
+//!   running    — start / stop / restart   (green now)
+//!   autostart  — autostart / autostart off (the login item: the session
+//!                manager runs `start` at every login and after a crash)
 //!
-//! and one property, `autostart` (launch at login), which HARD-implies attach
-//! and SOFT-defaults start (an explicit `stop` overrides the start, giving
-//! "armed for login but off right now").
+//! `autostart` HARD-implies attach and SOFT-defaults start: the login item is
+//! loaded now, so the server comes up under the manager. An explicit `stop`
+//! overrides the start, giving "armed for login but off right now". `off` is
+//! a modifier and stands only directly after `autostart`; it takes the login
+//! item away and implies nothing else, so `autostart off` leaves a running
+//! server alone and `autostart off stop` takes both down.
 //!
 //! Membership carries the lifetime: a running server that is attached is
 //! persistent; one that is detached is ephemeral — it lives while anyone is
@@ -24,7 +29,10 @@ pub enum Verb {
     Detach,
     Start,
     Stop,
+    Restart,
     Autostart,
+    /// The modifier after `autostart`; never a verb on its own.
+    Off,
 }
 
 impl Verb {
@@ -34,7 +42,9 @@ impl Verb {
             "detach" => Verb::Detach,
             "start" => Verb::Start,
             "stop" => Verb::Stop,
+            "restart" => Verb::Restart,
             "autostart" => Verb::Autostart,
+            "off" => Verb::Off,
             _ => return None,
         })
     }
@@ -51,21 +61,31 @@ impl Verb {
             Verb::Detach => "detach",
             Verb::Start => "start",
             Verb::Stop => "stop",
+            Verb::Restart => "restart",
             Verb::Autostart => "autostart",
+            Verb::Off => "off",
         }
     }
 }
 
+/// The running axis's three directions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Running {
+    Start,
+    Stop,
+    Restart,
+}
+
 /// What a validated verb bag resolves to. `None` on an axis means "leave it
-/// unchanged"; `Some(true)`/`Some(false)` are the two directions.
+/// unchanged".
 #[derive(Debug, PartialEq, Eq)]
 pub struct Plan {
     /// membership: Some(true)=attach, Some(false)=detach, None=unchanged.
     pub attach: Option<bool>,
-    /// running: Some(true)=start, Some(false)=stop, None=unchanged.
-    pub run: Option<bool>,
-    /// install the login item (implies attach + start-unless-stop).
-    pub autostart: bool,
+    /// running: start, stop, restart, or unchanged.
+    pub run: Option<Running>,
+    /// the login item: Some(true)=install, Some(false)=remove, None=unchanged.
+    pub autostart: Option<bool>,
 }
 
 impl Plan {
@@ -74,7 +94,7 @@ impl Plan {
     /// `start` are persistent; only `detach start` is ephemeral.) The dispatch
     /// hands this to `start` as the server's refcounted-lifetime fact.
     pub fn ephemeral(&self) -> bool {
-        self.run == Some(true) && self.attach == Some(false)
+        self.run == Some(Running::Start) && self.attach == Some(false)
     }
 }
 
@@ -87,12 +107,20 @@ impl Plan {
 ///
 /// On any error nothing is applied (the caller only acts on `Ok`).
 pub fn plan(words: &[String]) -> Result<Plan, String> {
-    // 1-3) parse each word, rejecting unknowns; 2) count on the way.
+    // 1-3) parse each word, rejecting unknowns; 2) count on the way. `off` is
+    // position-bound: it modifies the `autostart` immediately before it.
     let mut counts: HashMap<Verb, u32> = HashMap::new();
-    for w in words {
+    let mut off = false;
+    for (i, w) in words.iter().enumerate() {
         let v = Verb::parse(w).ok_or_else(|| {
-            format!("unknown verb '{w}' — verbs are: attach, detach, start, stop, autostart")
+            format!("unknown verb '{w}' — verbs are: attach, detach, start, stop, restart, autostart [off]")
         })?;
+        if v == Verb::Off {
+            if i == 0 || Verb::parse(&words[i - 1]) != Some(Verb::Autostart) {
+                return Err("'off' goes right after autostart — `autostart off`".into());
+            }
+            off = true;
+        }
         *counts.entry(v).or_insert(0) += 1;
     }
 
@@ -105,26 +133,29 @@ pub fn plan(words: &[String]) -> Result<Plan, String> {
 
     let has = |v: Verb| counts.contains_key(&v);
 
-    // 5) the three conflicts: the two same-axis opposites, plus autostart's
-    // hard-attach against detach. (autostart + stop is NOT a conflict — stop
-    // is a soft override of autostart's default start.)
+    // 5) conflicts: the same-axis opposites, and installing the login item
+    // for a database being detached. (autostart + stop is NOT a conflict —
+    // stop is a soft override of autostart's default start.)
     if has(Verb::Attach) && has(Verb::Detach) {
         return Err("can't attach and detach at once — pick one".into());
     }
-    if has(Verb::Start) && has(Verb::Stop) {
-        return Err("can't start and stop at once — pick one".into());
+    let running = [Verb::Start, Verb::Stop, Verb::Restart].iter().filter(|v| has(**v)).count();
+    if running > 1 {
+        return Err("start, stop and restart are one axis — pick one".into());
     }
-    if has(Verb::Autostart) && has(Verb::Detach) {
+    let install = has(Verb::Autostart) && !off;
+    if install && has(Verb::Detach) {
         return Err(
             "autostart keeps the database (it implies attach); drop detach or drop autostart"
                 .into(),
         );
     }
 
-    // 6) resolve. autostart pre-fills attach (hard) and start (default), then
-    // any explicit verb wins — except detach, ruled out above.
-    let autostart = has(Verb::Autostart);
-    let attach = if has(Verb::Attach) || autostart {
+    // 6) resolve. An installing autostart pre-fills attach (hard) and start
+    // (default), then any explicit verb wins — except detach, ruled out above.
+    // `autostart off` implies nothing.
+    let autostart = if has(Verb::Autostart) { Some(!off) } else { None };
+    let attach = if has(Verb::Attach) || install {
         Some(true)
     } else if has(Verb::Detach) {
         Some(false)
@@ -132,11 +163,13 @@ pub fn plan(words: &[String]) -> Result<Plan, String> {
         None
     };
     let run = if has(Verb::Start) {
-        Some(true)
+        Some(Running::Start)
     } else if has(Verb::Stop) {
-        Some(false)
-    } else if autostart {
-        Some(true) // autostart's soft default, no explicit stop overrode it
+        Some(Running::Stop)
+    } else if has(Verb::Restart) {
+        Some(Running::Restart)
+    } else if install {
+        Some(Running::Start) // autostart's soft default, no explicit verb overrode it
     } else {
         None
     };
@@ -160,21 +193,23 @@ mod tests {
 
     #[test]
     fn singles() {
-        assert_eq!(ok("attach"), Plan { attach: Some(true), run: None, autostart: false });
-        assert_eq!(ok("detach"), Plan { attach: Some(false), run: None, autostart: false });
-        assert_eq!(ok("start"), Plan { attach: None, run: Some(true), autostart: false });
-        assert_eq!(ok("stop"), Plan { attach: None, run: Some(false), autostart: false });
+        assert_eq!(ok("attach"), Plan { attach: Some(true), run: None, autostart: None });
+        assert_eq!(ok("detach"), Plan { attach: Some(false), run: None, autostart: None });
+        assert_eq!(ok("start"), Plan { attach: None, run: Some(Running::Start), autostart: None });
+        assert_eq!(ok("stop"), Plan { attach: None, run: Some(Running::Stop), autostart: None });
+        assert_eq!(ok("restart"), Plan { attach: None, run: Some(Running::Restart), autostart: None });
     }
 
     #[test]
     fn empty_bag_is_a_noop_plan() {
-        assert_eq!(ok(""), Plan { attach: None, run: None, autostart: false });
+        assert_eq!(ok(""), Plan { attach: None, run: None, autostart: None });
     }
 
     #[test]
     fn order_does_not_matter() {
         assert_eq!(ok("attach start"), ok("start attach"));
         assert_eq!(ok("detach stop"), ok("stop detach"));
+        assert_eq!(ok("stop autostart off"), ok("autostart off stop"));
     }
 
     #[test]
@@ -186,8 +221,18 @@ mod tests {
     }
 
     #[test]
+    fn start_and_stop_leave_the_login_item_alone() {
+        assert_eq!(ok("start").autostart, None);
+        assert_eq!(ok("stop").autostart, None);
+        assert_eq!(ok("restart").autostart, None);
+    }
+
+    #[test]
     fn autostart_implies_attach_and_start() {
-        assert_eq!(ok("autostart"), Plan { attach: Some(true), run: Some(true), autostart: true });
+        assert_eq!(
+            ok("autostart"),
+            Plan { attach: Some(true), run: Some(Running::Start), autostart: Some(true) }
+        );
     }
 
     #[test]
@@ -195,8 +240,37 @@ mod tests {
         // The soft start yields to an explicit stop; the hard attach stays.
         assert_eq!(
             ok("autostart stop"),
-            Plan { attach: Some(true), run: Some(false), autostart: true }
+            Plan { attach: Some(true), run: Some(Running::Stop), autostart: Some(true) }
         );
+    }
+
+    #[test]
+    fn autostart_restart_hands_the_server_to_the_manager() {
+        assert_eq!(
+            ok("autostart restart"),
+            Plan { attach: Some(true), run: Some(Running::Restart), autostart: Some(true) }
+        );
+    }
+
+    #[test]
+    fn autostart_off_implies_nothing_else() {
+        assert_eq!(ok("autostart off"), Plan { attach: None, run: None, autostart: Some(false) });
+        assert_eq!(
+            ok("autostart off stop"),
+            Plan { attach: None, run: Some(Running::Stop), autostart: Some(false) }
+        );
+        // Detaching a database whose login item is being removed is fine.
+        assert_eq!(
+            ok("autostart off detach"),
+            Plan { attach: Some(false), run: None, autostart: Some(false) }
+        );
+    }
+
+    #[test]
+    fn off_must_follow_autostart() {
+        assert!(err("off").contains("right after autostart"));
+        assert!(err("off autostart").contains("right after autostart"));
+        assert!(err("autostart stop off").contains("right after autostart"));
     }
 
     #[test]
@@ -212,12 +286,15 @@ mod tests {
     #[test]
     fn duplicates_are_rejected() {
         assert!(err("start start").contains("more than once"));
+        assert!(err("autostart off autostart off").contains("more than once"));
     }
 
     #[test]
     fn same_axis_opposites_conflict() {
         assert!(err("attach detach").contains("attach and detach"));
-        assert!(err("start stop").contains("start and stop"));
+        assert!(err("start stop").contains("one axis"));
+        assert!(err("restart stop").contains("one axis"));
+        assert!(err("start restart").contains("one axis"));
     }
 
     #[test]


### PR DESCRIPTION
`autostart` becomes what `brew services start` and `systemctl enable --now` are: the login item is loaded the moment it is installed, so the server starts now under the session manager, at every login, and again after a crash. KeepAlive fires on failure only, so a clean `stop` stays stopped until the next login.

**New verbs**
- `restart` bounces a database under its login item with a fresh read of config.toml.
- `autostart off` drops the login item and leaves a running server alone; `autostart off stop` takes both down.

**Behavior changes**
- A plain `start` or `stop` no longer removes the login item. Only `autostart off` and `detach` do.
- Start options are refused on `autostart` and on a login item's `restart`. A login item runs a bare `start`, so its settings live in `[connection.<name>]`.
- The login item's stdout and stderr go to the berth's log under `runtime/log/`.
- DuckTable's autostart checkbox arms the item without loading it; running stays its own axis there.

| You type             | Registered at login | Running now       |
| -------------------- | ------------------- | ----------------- |
| `autostart`          | yes                 | yes               |
| `autostart stop`     | yes                 | no                |
| `stop`               | unchanged           | no                |
| `restart`            | unchanged           | yes               |
| `autostart off`      | no                  | unchanged         |
| `autostart off stop` | no                  | no                |
| `detach`             | no                  | no, and forgotten |

**Verification**
- Unit tests: 119 passed across harbor-common and harbor; clippy clean; DuckTable's harbor-client checks.
- Full suite: 11 of 12 green in one run, catalog flaked and passed alone (51/51).
- Walked every row of the table on a scratch database on macOS: bootstrap, `kill -9` recovered in 8 s, `stop` stayed down with the plist intact, `restart` came back under launchd, `autostart off stop` left no job and no plist, `detach` left no config entry.

Bumps the workspace to 0.33.0 with a CHANGELOG entry.
