### PR TITLE
Make start bring the server up in the background and return

### DIFF
--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -18,6 +18,14 @@ Harbor releases, and are not included here.
 - Refuses start options on `autostart` and on a login item's `restart`,
   pointing at the `[connection.<name>]` entry a login item actually reads.
 - Sends the login item's output to the berth's log under `runtime/log/`.
+- Makes `start` at a terminal bring the server up in the background and
+  return — under the database's login item when it has one, otherwise as a
+  detached process that runs until `stop`. The prompt-as-server helm is
+  gone: a prompt is what bare `harbor <db>` opens. Headless `start` still
+  serves in place until SIGTERM, and `--foreground` asks for that shape at a
+  terminal. `stop` returns once the server has actually gone quiet, so
+  `stop` followed by `start` — by hand or inside `restart` — always meets a
+  free database.
 - Lists attached databases that are not running as dimmed `stopped` rows in
   bare `harbor`, with the file path and whether a login item will bring them
   back. Their names and footnote numbers now resolve everywhere a running

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -14,12 +14,12 @@ harbor <db.duckdb>              → open it: REPL / -c "SQL" / stdin;
                                   spawns a refcounted server if none exists
 harbor <path/to.sock>           → connect to a server by its socket
 harbor http://host:port         → connect to a server over TCP
-harbor <db.duckdb> start        → start it yourself, until you leave
+harbor <db.duckdb> start        → bring it up in the background, until you stop it
 ```
 
 The doctrine, in one breath: **bare, the server is everyone's — it lives
 while anyone is connected; `start`, the server is yours — it lives until you
-leave.** Everything below is the machinery that makes those two sentences
+stop it.** Everything below is the machinery that makes those two sentences
 true, and nothing else.
 
 The workspace has four first-party crates: **`harbor`** (server engine,
@@ -129,13 +129,16 @@ releases it by definition. justhttp deliberately lets an idle connection wait
 between requests forever, which is what makes presence expressible at all.
 `.open` moors at the new server before releasing the old one.
 
-`start` ignores the refcount entirely. On a terminal it puts the operator at
-the helm — the same REPL, dialled at the server's own socket, so what the
-operator sees is what any client would get — and leaving the prompt ends the
-server. Headless, it runs until `SIGTERM`. Spawn-on-use spawns exactly this
-(`current_exe() <db> start` with `HARBOR_EPHEMERAL` in its environment,
-detached, stderr to a log beside the socket), so there is one start path
-however a server comes to exist.
+`start` ignores the refcount entirely. At a terminal it brings the server up
+in the background and returns: under the database's login item when it has
+one (launchd or systemd owns the process from the first second), otherwise
+as a detached child that runs until `stop`. Headless, it serves in place
+until `SIGTERM`; `--foreground` asks for that at a terminal. Spawn-on-use
+and a terminal `start` are the same launch (`current_exe() <db> start`,
+detached, output to a log beside the socket) — the summon adds
+`HARBOR_EPHEMERAL` to its child's environment and a hand start does not —
+so there is one start path however a server comes to exist. The prompt is
+what bare `harbor <db>` is for; `start` never opens one.
 
 `curl` works iff something is listening, by design: a bare HTTP client does
 not summon a database. An application that wants spawn-on-use runs

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -16,7 +16,7 @@ DuckDB Harbor is `harbor`, one small Rust binary with one grammar:
 ```console
 $ harbor                       # what's running
 $ harbor mydata.duckdb         # open it — REPL, or -c "SQL", or stdin
-$ harbor mydata.duckdb start   # start it yourself, until you leave
+$ harbor mydata.duckdb start   # bring it up in the background, until you stop it
 ```
 
 `harbor mydata.duckdb` is the duckdb-shell muscle memory, kept: a REPL with
@@ -25,7 +25,7 @@ difference is what happens behind it — if nothing serves the file yet, a
 server is spawned for it, and every other client of the same file joins that
 server instead of hitting "database is locked". The two lifetimes, in one
 breath: **bare, the server is everyone's — it lives while anyone is
-connected; `start`, the server is yours — it lives until you leave.**
+connected; `start`, the server is yours — it lives until you stop it.**
 
 ## The Elevator Pitch
 
@@ -350,11 +350,15 @@ client leaves, the server drains, `CHECKPOINT`s, sweeps its socket, and exits
 a few seconds later. A second `harbor` on the same file — any spelling of the
 same path — joins the same server instead of reporting "database is locked".
 
-**`harbor <db.duckdb> start` — the server is yours.** Foreground, no
-refcount: it lives until you leave. On a terminal you get the same prompt,
-dialled at the server's own socket, and `.quit` ends the server; headless it
-runs until `SIGTERM`. Either exit is clean — drain, `CHECKPOINT` so the next
-open never replays a WAL, socket swept.
+**`harbor <db.duckdb> start` — the server is yours.** No refcount: it lives
+until you stop it. At a terminal the server comes up in the background and
+`start` returns — under the database's login item when it has one, so the
+session manager owns it from the first second, otherwise as a detached
+process that `harbor <db> stop` ends. Headless, meaning no terminal on
+stdin, it serves in place until `SIGTERM`, which is the shape launchd,
+systemd and a spawn want; `--foreground` asks for that shape at a terminal,
+to watch a server work. Either exit is clean — drain, `CHECKPOINT` so the
+next open never replays a WAL, socket swept.
 
 **`harbor <db.duckdb> autostart` — the server is the session manager's.**
 harbor never becomes a supervisor; it hands exactly this `start` to one that

--- a/harbor/crates/common/src/autostart.rs
+++ b/harbor/crates/common/src/autostart.rs
@@ -23,16 +23,17 @@
 use crate::paths;
 use std::path::Path;
 
-/// What `install` found when it went to load the job.
+/// What `install` found when it went to run the job.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Installed {
-    /// The manager loaded the item and the server is starting under it.
+    /// The manager is starting the server under the item now. It is not
+    /// listening yet when this returns — the caller waits on the socket.
     Started,
-    /// The manager already held the item; nothing to start.
-    AlreadyLoaded,
+    /// The manager's own server is already up; nothing to do.
+    AlreadyRunning,
     /// Something else is serving the database, so the item was registered
-    /// but not loaded — a load would only fail against the file lock and
-    /// then retry. `restart` hands the server over.
+    /// but not run — a run would only fail against the file lock and then
+    /// retry. `restart` hands the server over.
     Deferred,
 }
 
@@ -83,17 +84,20 @@ pub fn arm(db: &Path, name: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Register and load: the server starts now under launchd and at every login.
-/// `serving` says whether something already answers for this database; when
-/// it does, the item is registered but not loaded.
+/// Register and run: the server starts now under launchd and at every login.
+/// `serving` says whether something already answers for this database. A job
+/// launchd still holds with no process — what a clean `stop` leaves, since
+/// KeepAlive only revives failures — is booted out and loaded afresh: a
+/// fresh load runs at once, where a kickstart of the old job waits out
+/// launchd's throttle from its last exit.
 #[cfg(target_os = "macos")]
 pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String> {
     arm(db, name)?;
-    if loaded(name) {
-        return Ok(Installed::AlreadyLoaded);
-    }
     if serving {
-        return Ok(Installed::Deferred);
+        return Ok(if loaded(name) { Installed::AlreadyRunning } else { Installed::Deferred });
+    }
+    if loaded(name) {
+        unload(name);
     }
     let plist = agent_path(name)?;
     let out = std::process::Command::new("launchctl")
@@ -112,10 +116,16 @@ pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String
 }
 
 /// Take the job out of this session. The server, if launchd is running one,
-/// receives SIGTERM and exits cleanly. Registration is untouched.
+/// receives SIGTERM and exits cleanly; this returns once the job is gone, so
+/// a bootstrap that follows loads the plist afresh instead of finding the
+/// old job still on its way out. Registration is untouched.
 #[cfg(target_os = "macos")]
 pub fn unload(name: &str) {
     launchctl(&["bootout", &format!("{}/{}", domain(), label(name))]);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while loaded(name) && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 /// Unregister: delete the plist. A running server is left alone; it ends
@@ -141,6 +151,7 @@ pub fn installed(name: &str) -> bool {
 fn loaded(name: &str) -> bool {
     launchctl(&["print", &format!("{}/{}", domain(), label(name))])
 }
+
 
 #[cfg(target_os = "macos")]
 fn agent_path(name: &str) -> Result<std::path::PathBuf, String> {
@@ -232,15 +243,14 @@ pub fn arm(db: &Path, name: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Register, enable, and start now. A unit already active is left running.
+/// Register, enable, and start now. `serving` says whether something already
+/// answers for this database; `start` on an active unit is a no-op either way.
 #[cfg(target_os = "linux")]
 pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String> {
     arm(db, name)?;
-    if systemctl(&["is-active", "--quiet", &unit(name)]).is_ok() {
-        return Ok(Installed::AlreadyLoaded);
-    }
     if serving {
-        return Ok(Installed::Deferred);
+        let active = systemctl(&["is-active", "--quiet", &unit(name)]).is_ok();
+        return Ok(if active { Installed::AlreadyRunning } else { Installed::Deferred });
     }
     systemctl(&["start", &unit(name)])?;
     Ok(Installed::Started)

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -174,12 +174,18 @@ fn main() -> ExitCode {
                 autostart::unload(&name);
             }
             return match autostart::install(&db, &name, serving(&db)) {
-                Ok(autostart::Installed::Started) => {
-                    eprintln!("harbor: {name} started; it will start at every login");
-                    ExitCode::SUCCESS
-                }
-                Ok(autostart::Installed::AlreadyLoaded) => {
-                    eprintln!("harbor: {name} is already running at login — `restart` applies a changed config");
+                Ok(autostart::Installed::Started) => match wait_serving(&db) {
+                    Ok(sock) => {
+                        eprintln!("harbor: {name} serving on {} — it will start at every login", sock.display());
+                        ExitCode::SUCCESS
+                    }
+                    Err(e) => {
+                        eprintln!("harbor: {e}");
+                        ExitCode::FAILURE
+                    }
+                },
+                Ok(autostart::Installed::AlreadyRunning) => {
+                    eprintln!("harbor: {name} is already running under its login item — `restart` applies a changed config");
                     ExitCode::SUCCESS
                 }
                 Ok(autostart::Installed::Deferred) => {
@@ -272,9 +278,9 @@ fn main() -> ExitCode {
             }
             if autostart::installed(&name) {
                 autostart::unload(&name);
-                return match autostart::install(&db, &name, false) {
-                    Ok(_) => {
-                        eprintln!("harbor: {name} restarted; it will start at every login");
+                return match autostart::install(&db, &name, false).and_then(|_| wait_serving(&db)) {
+                    Ok(sock) => {
+                        eprintln!("harbor: {name} restarted, serving on {} — it will start at every login", sock.display());
                         ExitCode::SUCCESS
                     }
                     Err(e) => {
@@ -292,6 +298,35 @@ fn main() -> ExitCode {
             }
         }
         None => ExitCode::SUCCESS, // a bare attach/detach: membership done
+    }
+}
+
+/// The session manager starts a server asynchronously: block until it
+/// answers on its socket, or say why not with the log to read. The same
+/// budget a summon gives its child.
+fn wait_serving(db: &Path) -> Result<PathBuf, String> {
+    #[cfg(unix)]
+    {
+        let runtime = harbor_common::runtime_dir()?;
+        let canon = harbor_common::paths::canonical_db(db)?;
+        let sock = harbor_common::socket_for(&runtime, &canon)?;
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while Instant::now() < deadline {
+            if sock.exists() && harbor::repl::sock_ready(&sock) {
+                return Ok(sock);
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let name = membership::name_of(&canon)?;
+        Err(format!(
+            "{} did not come up in 15s — see {}",
+            canon.display(),
+            harbor_common::paths::log_file(&runtime, &name).display()
+        ))
+    }
+    #[cfg(not(unix))]
+    {
+        Err(format!("{}: login items need unix sockets", db.display()))
     }
 }
 
@@ -324,9 +359,11 @@ usage:
   harbor http://host:port      connect to a server over TCP
   harbor <name> | <footnote>   a database by its name (medlabs) or its number
                                in the list — running, or attached and stopped
-  harbor <db.duckdb> start     start it yourself (foreground): on a terminal
-                               you get the prompt and .quit ends the server;
-                               headless it runs until SIGTERM
+  harbor <db.duckdb> start     bring its server up in the background — under
+                               the login item when there is one — and return;
+                               it runs until `stop`. Headless (no terminal) it
+                               runs in place until SIGTERM, which is what a
+                               service manager wants
   harbor <db.duckdb> stop      stop the server for this database, if one is
                                running (a quiet no-op if nothing is); a login
                                item brings it back at the next login
@@ -352,7 +389,7 @@ A login item runs a bare `start`, so its options live in config.toml under
 
 The two lifetimes, in one breath — bare: the server is everyone's, it lives
 while anyone is connected. start: the server is yours, it lives until you
-leave.
+stop it.
 
 client options:
   -c \"SQL\"                     run statements and exit (stdin works too)
@@ -374,6 +411,8 @@ start options:
   --statement-timeout <d>  hard deadline ceiling per statement (e.g. 30s)
   --max-temp-size <s>  cap spill-to-disk (e.g. 10GB; default: DuckDB's own)
   --log                log requests to stderr
+  --foreground         run in this terminal until Ctrl-C, output here, no
+                       prompt — for watching a server work
 ";
 
 struct Opts {
@@ -389,6 +428,7 @@ struct Opts {
     sealed: bool,
     statement_timeout: Option<Duration>,
     max_temp_size: Option<String>,
+    foreground: bool,
 }
 
 /// The built-in defaults, before config or flags speak.
@@ -406,6 +446,7 @@ fn default_opts(db: PathBuf) -> Opts {
         sealed: false,
         statement_timeout: None,
         max_temp_size: None,
+        foreground: false,
     }
 }
 
@@ -491,6 +532,7 @@ fn parse_opts(mut o: Opts, rest: Vec<String>) -> Result<Opts, String> {
             "--threads" => o.threads = Some(take("threads")?.parse().map_err(|_| "bad --threads")?),
             "--init" => o.init.push(take("init")?),
             "--log" => o.log = true,
+            "--foreground" => o.foreground = true,
             "--unsigned" => o.unsigned = true,
             "--sealed" => o.sealed = true,
             "--statement-timeout" => {
@@ -540,6 +582,7 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     let canon = harbor_common::paths::canonical_db(&db)?;
     let mut o = default_opts(db);
     apply_berth_config(&mut o, &canon, ephemeral);
+    let typed = rest.clone();
     let mut o = parse_opts(o, rest)?;
     o.ephemeral = ephemeral;
     let home = ensure_runtime_dir()?;
@@ -567,6 +610,31 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
             canon.display(),
             o.db.display()
         ));
+    }
+
+    // At a terminal, `start` brings the server up in the background and
+    // returns — under the login item when the database has one, so launchd
+    // or systemd owns it from the first second; otherwise as a detached
+    // child that runs until `stop`. Only a headless start (a service
+    // manager, a spawn, a pipe) or `--foreground` serves from this process.
+    #[cfg(unix)]
+    if !o.ephemeral && !o.foreground && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        let name = membership::name_of(&canon)?;
+        if autostart::installed(&name) {
+            if !typed.is_empty() {
+                return Err(format!(
+                    "{name} starts at login from config.toml, not flags — put {} under [connection.{name}]",
+                    typed.join(" ")
+                ));
+            }
+            autostart::install(&o.db, &name, false)?;
+            let sock = wait_serving(&o.db)?;
+            eprintln!("harbor: {name} serving on {} under its login item — `harbor {name} stop` ends it", sock.display());
+            return Ok(());
+        }
+        let sock = harbor::repl::start_detached(&o.db, &typed)?;
+        eprintln!("harbor: serving {} on {} — `harbor {} stop` ends it", canon.display(), sock.display(), name);
+        return Ok(());
     }
 
     // A statement deadline ceiling, if asked. The engine reads
@@ -700,26 +768,8 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
         });
     }
 
-    // At the helm: start on a terminal gets the prompt, dialled at this
-    // server's own front door. Leaving the prompt ends the server — the
-    // start doctrine, enacted: the server is yours, it lives until you leave.
-    if !o.ephemeral && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-        let name = canon
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "harbor".into());
-        // The helm dials the home door: the unix socket is always bound (a
-        // port only adds TCP beside it).
-        #[cfg(unix)]
-        let transport = harbor::repl::Transport::Unix(sock_path.clone());
-        #[cfg(windows)]
-        let transport = harbor::repl::Transport::Tcp(format!("127.0.0.1:{}", o.port.unwrap_or(0)));
-        harbor::repl::helm(transport, &name);
-        let _ = harbor::stop();
-    }
-
-    // Blocks until SIGTERM / .quit at the helm / the refcount departure
-    // finishes drain + CHECKPOINT.
+    // Blocks until SIGTERM (Ctrl-C in the foreground) or the refcount
+    // departure finishes drain + CHECKPOINT.
     let farewell = harbor::wait()?;
     #[cfg(unix)]
     let _ = std::fs::remove_file(&sock_path);

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -165,8 +165,8 @@ usage:
   harbor http://host:port      a harbor TCP listener
   harbor <name> | <footnote>   a database by its name (medlabs) or its number
                                in the list — running, or attached and stopped
-  harbor <db.duckdb> start     start it yourself — the server is yours, and
-                               lives until you leave (harbor <db> start -h)
+  harbor <db.duckdb> start     bring its server up in the background and
+                               return; it runs until `stop` (harbor <db> start -h)
 
 options:
   -c \"SQL\"                     run statements and exit (stdin works too)
@@ -317,59 +317,80 @@ fn ensure_server(path: &Path) -> Result<Transport, String> {
         if ready(&transport) {
             return Ok(transport);
         }
-
-        // Spawn. Same binary, no PATH lookup, no environment contract —
-        // current_exe is the whole story. Detached (own process group, no
-        // tty), stderr to a log beside the socket so a failure has a face.
-        harbor_common::perms::ensure_private_dir(&runtime)?;
-        let log_path = sock.with_extension("log");
-        let log = std::fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&log_path)
-            .map_err(|e| format!("log file: {e}"))?;
-        let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-        let mut cmd = std::process::Command::new(exe);
-        cmd.arg(&canon).arg("start");
-        // The private lifetime signal: a summoned server is refcounted, so it
-        // leaves when idle. It rides an env channel, not the command line —
-        // ephemerality is something membership says (a detached start), never a
-        // flag, and a spawn is not a verb the user typed.
-        cmd.env("HARBOR_EPHEMERAL", "1");
-        // A typed path is the duckdb-cli contract: start opens it existing or
-        // not, so a summoned database that isn't there yet is simply created.
-        {
-            use std::os::unix::process::CommandExt;
-            use std::process::Stdio;
-            cmd.stdin(Stdio::null())
-                .stdout(Stdio::from(log.try_clone().map_err(|e| e.to_string())?))
-                .stderr(Stdio::from(log))
-                .process_group(0); // detached from our tty/session
-        }
-        let mut child = cmd.spawn().map_err(|e| format!("spawn: {e}"))?;
-
-        let deadline = Instant::now() + Duration::from_secs(15);
-        while Instant::now() < deadline {
-            if ready(&transport) {
-                return Ok(transport);
-            }
-            // The child dying is an answer, not a timeout — but it can be the
-            // GOOD answer: two clients raced, ours lost the database lock to
-            // the winner, and the winner's socket (same derived path) serves
-            // us fine. Only a dead child AND no listener is a failure.
-            if let Ok(Some(status)) = child.try_wait() {
-                if ready(&transport) {
-                    return Ok(transport);
-                }
-                return Err(format!(
-                    "the server did not start ({status}) — {}",
-                    log_tail(&log_path)
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        Err(format!("{} did not come up in 15s — {}", canon.display(), log_tail(&log_path)))
+        launch(&runtime, &canon, &sock, &[], true)?;
+        Ok(transport)
     }
+}
+
+/// `harbor <db> start` at a terminal: the server comes up in the background,
+/// persistent — it runs until `stop` — and this returns once it answers.
+/// The same launch a summon uses, minus the ephemeral signal, plus whatever
+/// start options were typed. Returns the socket the server answers on.
+#[cfg(unix)]
+pub fn start_detached(db: &Path, args: &[String]) -> Result<PathBuf, String> {
+    let runtime = harbor_common::runtime_dir()?;
+    let canon = harbor_common::paths::canonical_db(db)?;
+    let sock = harbor_common::socket_for(&runtime, &canon)?;
+    launch(&runtime, &canon, &sock, args, false)?;
+    Ok(sock)
+}
+
+/// Spawn a server for `canon` and wait until it answers on `sock`. Same
+/// binary, no PATH lookup, no environment contract — current_exe is the whole
+/// story. Detached (own process group, no tty), stdout and stderr to a log
+/// beside the socket so a failure has a face. `ephemeral` is the private
+/// lifetime signal: a summoned server is refcounted, so it leaves when idle.
+/// It rides an env channel, not the command line — ephemerality is something
+/// membership says, never a flag, and a spawn is not a verb the user typed.
+#[cfg(unix)]
+fn launch(runtime: &Path, canon: &Path, sock: &Path, args: &[String], ephemeral: bool) -> Result<(), String> {
+    let transport = Transport::Unix(sock.to_path_buf());
+    harbor_common::perms::ensure_private_dir(runtime)?;
+    let log_path = sock.with_extension("log");
+    let log = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&log_path)
+        .map_err(|e| format!("log file: {e}"))?;
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg(canon).arg("start").args(args);
+    if ephemeral {
+        cmd.env("HARBOR_EPHEMERAL", "1");
+    }
+    // A typed path is the duckdb-cli contract: start opens it existing or
+    // not, so a database that isn't there yet is simply created.
+    {
+        use std::os::unix::process::CommandExt;
+        use std::process::Stdio;
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::from(log.try_clone().map_err(|e| e.to_string())?))
+            .stderr(Stdio::from(log))
+            .process_group(0); // detached from our tty/session
+    }
+    let mut child = cmd.spawn().map_err(|e| format!("spawn: {e}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if ready(&transport) {
+            return Ok(());
+        }
+        // The child dying is an answer, not a timeout — but it can be the
+        // GOOD answer: two clients raced, ours lost the database lock to
+        // the winner, and the winner's socket (same derived path) serves
+        // us fine. Only a dead child AND no listener is a failure.
+        if let Ok(Some(status)) = child.try_wait() {
+            if ready(&transport) {
+                return Ok(());
+            }
+            return Err(format!(
+                "the server did not start ({status}) — {}",
+                log_tail(&log_path)
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Err(format!("{} did not come up in 15s — {}", canon.display(), log_tail(&log_path)))
 }
 
 /// The last few log lines, inlined — the operator should not have to go
@@ -408,12 +429,22 @@ pub fn shutdown(db: &Path) -> Result<bool, String> {
     }
     // POST /shutdown drains, checkpoints, and exits. The server can close the
     // socket as it goes, so a dropped connection right after the request is
-    // success, not failure — re-probe to be sure which it was.
-    match http::request(&transport, &endpoint::SHUTDOWN, None, Some(Duration::from_secs(30))) {
-        Ok(_) => Ok(true),
-        Err(_) if !ready(&transport) => Ok(true),
-        Err(e) => Err(format!("stop: {e}")),
+    // success, not failure. Either way, `stop` means stopped: wait until the
+    // socket no longer answers, so `stop` followed by `start` — by hand, or
+    // inside `restart` — meets a database that is actually free.
+    if let Err(e) = http::request(&transport, &endpoint::SHUTDOWN, None, Some(Duration::from_secs(30)))
+        && ready(&transport)
+    {
+        return Err(format!("stop: {e}"));
     }
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while ready(&transport) {
+        if Instant::now() > deadline {
+            return Err(format!("stop: {} is still answering after 30s", canon.display()));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Ok(true)
 }
 
 #[cfg(windows)]
@@ -769,24 +800,6 @@ fn list() -> Result<(), String> {
     }
     println!("  {}\n", parts.join(", "));
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// The helm — `harbor <db> start` on a terminal
-// ---------------------------------------------------------------------------
-
-/// The prompt a foreground server wears: the same REPL, dialled at the
-/// server's own front door, so what the operator types is what any client
-/// would get. Returning ends the server — the caller stops and waits — which
-/// is the foreground-start doctrine: the server is yours, it lives until you
-/// leave.
-pub fn helm(transport: Transport, name: &str) {
-    let _ = signal_hook::flag::register(signal_hook::consts::SIGINT, CANCEL.clone());
-    theme::init(None, None);
-    let conn = Conn { transport };
-    // No anchor: an owned server's lifetime is the operator's presence at
-    // this prompt, not its client count.
-    let _ = interactive::run(&conn, name, RenderOpts::default(), None);
 }
 
 fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -6,7 +6,7 @@
 #
 # The law under test is the product's one breath: bare — the server is
 # everyone's, it lives while anyone is connected; start — the server is
-# yours, it lives until you leave. Everything here is behavior no unit test
+# yours, it lives until you stop it. Everything here is behavior no unit test
 # can see: spawn-on-use across processes, two clients landing on one server,
 # an idle connection as a mooring, the last departure sweeping the socket,
 # and a start-lifetime server ignoring the refcount entirely.
@@ -145,7 +145,7 @@ else
   bad "departure left the database missing or with a wal"
 fi
 
-echo "— start: the server is yours, it lives until you leave"
+echo "— start: the server is yours, it lives until you stop it"
 "$harbor" "$work/x.duckdb" start >"$work/start.log" 2>&1 &
 srv=$!
 up=0
@@ -154,7 +154,7 @@ for _ in $(seq 1 50); do [[ -n $(live_sock) ]] && { up=1; break; }; sleep 0.1; d
 check "a client joins the started database" 0 "7" \
   "$harbor" "$work/x.duckdb" --mode csv -c "SELECT 7 AS seven"
 # Well past the linger an ephemeral server would have left on. A start
-# lifetime has no clock at all — only SIGTERM (or .quit at the helm) ends it.
+# lifetime has no clock at all — only SIGTERM or `stop` ends it.
 sleep 2
 kill -0 "$srv" 2>/dev/null && ok "no refcount: it survives its clients leaving" \
                            || bad "the start-lifetime server left on the refcount"


### PR DESCRIPTION
`harbor <db> start` at a terminal now brings the server up detached and returns, the way `start` works everywhere else. The REPL-as-server helm is gone; a prompt is what bare `harbor <db>` opens.

- With a login item, `start` loads it under launchd or systemd. Without one, it spawns a detached child that runs until `stop`.
- `start` waits until the socket answers before reporting, so `harbor` right after shows it running.
- Headless `start` still serves in place until SIGTERM. `--foreground` asks for that at a terminal.
- `stop` returns once the server has gone quiet. A clean-stopped login item is booted out and reloaded on `start` instead of kicked, avoiding launchd's ten-second throttle.

**Verification**
- Full suite green, 12 of 12.
- At a real pty on macOS: detached `start` returned in 0.1 s with the server up; `--foreground` served until Ctrl-C and closed cleanly; under a login item, `autostart`, `stop`, `start`, `stop`, `start`, and `restart` each produced a fresh pid still serving afterward, with `start` after `stop` in 0.1 s; flags on a login-item `restart` are refused with the config pointer; a stopped, unattached name is refused rather than becoming a file.

Folds into the 0.33.0 changelog entry.
