### PR TITLE
Fix what the verb review found

### DIFF
--- a/ducktable/crates/harbor-client/src/fleet.rs
+++ b/ducktable/crates/harbor-client/src/fleet.rs
@@ -538,7 +538,7 @@ pub fn detach(db: &Path) -> Result<(), String> {
 /// needs it on your list) but never starts it — running is the Start/Stop
 /// axis's business; disarming leaves membership and the running server alone.
 pub fn set_autostart(db: &Path, on: bool) -> Result<(), String> {
-    let name = harbor_common::membership::name_of(db)?;
+    let name = harbor_common::membership::name_for(db)?;
     if on {
         harbor_common::membership::attach(db)?;
         harbor_common::autostart::arm(db, &name)

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -26,6 +26,24 @@ Harbor releases, and are not included here.
   terminal. `stop` returns once the server has actually gone quiet, so
   `stop` followed by `start` — by hand or inside `restart` — always meets a
   free database.
+- Names a database by the config key that lists it, wherever a name is
+  derived — the login item, the stopped row, `attach`, `detach` — so an entry
+  such as `[connection.warehouse]` pointing at `inventory.duckdb` never grows
+  an `inventory` twin and never boots without its settings.
+- Fixes the systemd unit, which ordered itself after the target that wants
+  it — a cycle systemd resolves by dropping a job — and sends the unit's
+  output to the berth's log like the LaunchAgent does.
+- Carries `HARBOR_HOME` and the XDG home variables into the login item when
+  the installing shell had them set, so the manager's server and the CLI
+  agree on where the socket is.
+- Makes `start` at a terminal a success when the server is already up, the
+  way `systemctl start` treats an active unit; headless it stays a refusal,
+  so a manager or a spawn never reads a clean exit as a server it did not
+  get. A running server announces the config key that lists it in `/info`,
+  so its bare name is the same word whether it is running or stopped.
+- Unloads a login item whose server fails to come up within 15s, instead of
+  letting the manager retry it every ten seconds until logout; the item stays
+  registered for the next login and the next `start`.
 - Lists attached databases that are not running as dimmed `stopped` rows in
   bare `harbor`, with the file path and whether a login item will bring them
   back. Their names and footnote numbers now resolve everywhere a running

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -79,8 +79,8 @@ came with one is gone.
 requirement, not an option.
 
 **Standing settings live in config**: a database's `[connection.*]` entry
-supplies its own memory, threads, and boot SQL, so a bare start — a summon, an
-autostart at boot — honors them without flags; explicit flags override. `init`
+supplies its own memory, threads, and boot SQL, so a bare start — a summon, the
+login item — honors them without flags; explicit flags override. `init`
 is the open door: `init = ["INSTALL httpfs", "LOAD httpfs"]` or any
 `SET`/secret runs verbatim on the control connection before serving, so harbor
 passes a berth's customizations straight to DuckDB without knowing what they

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -381,7 +381,13 @@ flags. The verbs move two independent facts, the way `brew services` and
 | `restart`            | unchanged           | yes               |
 | `autostart off`      | no                  | unchanged         |
 | `autostart off stop` | no                  | no                |
-| `detach`             | no                  | no, and forgotten |
+| `detach`             | no                  | unchanged         |
+| `detach stop`        | no                  | no, and forgotten |
+
+Removing the login item never kills a server: `autostart off` and `detach`
+take the registration away and leave whatever is running to `stop` — though
+until logout the manager still restarts that server after a crash, since it
+holds the job it loaded.
 
 There is no registry. The socket **is** the runtime registration: its name is
 derived from the database's canonical path
@@ -417,10 +423,11 @@ $ harbor labs                                                      # its name
 $ harbor 1                                                         # its footnote
 ```
 
-A name or a footnote always rides the unix socket, and reaches only what is
-already running — a bare word never becomes a file, and a name two running
-databases share is refused as ambiguous rather than guessed. The verbs take
-the same spellings: `harbor labs stop`, `harbor 1 stop`.
+A name or a footnote reaches what is listed — a running server by the name
+it declares, an attached database by its config key — and a bare word never
+becomes a file. A name two running databases share is refused as ambiguous
+rather than guessed. The verbs take the same spellings: `harbor labs stop`,
+`harbor 3 start`; opening a stopped one summons it the way its path would.
 
 A socket nothing answers on is a leftover from a `kill -9`, and the list
 unlinks it. Set `HARBOR_HOME` (absolute path) to collapse configuration and

--- a/harbor/crates/common/src/autostart.rs
+++ b/harbor/crates/common/src/autostart.rs
@@ -61,6 +61,17 @@ fn launchctl(args: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
+/// The environment a login item must carry: the variables that move harbor's
+/// home. The manager starts the server with a bare environment, so a shell
+/// that set one of these would otherwise compute one socket path and the
+/// server another, and the two would never meet.
+fn homes() -> Vec<(String, String)> {
+    ["HARBOR_HOME", "XDG_STATE_HOME", "XDG_CONFIG_HOME"]
+        .iter()
+        .filter_map(|k| std::env::var(k).ok().filter(|v| !v.is_empty()).map(|v| (k.to_string(), v)))
+        .collect()
+}
+
 /// Register the item: write the plist and clear any disable launchd may hold
 /// for the label from an earlier life. Does not load it.
 #[cfg(target_os = "macos")]
@@ -77,7 +88,7 @@ pub fn arm(db: &Path, name: &str) -> Result<(), String> {
     }
     std::fs::write(
         &plist,
-        plist_body(name, &exe.display().to_string(), &canon.display().to_string(), &log.display().to_string()),
+        plist_body(name, &exe.display().to_string(), &canon.display().to_string(), &log.display().to_string(), &homes()),
     )
     .map_err(|e| format!("writing {}: {e}", plist.display()))?;
     launchctl(&["enable", &format!("{}/{}", domain(), label(name))]);
@@ -89,12 +100,17 @@ pub fn arm(db: &Path, name: &str) -> Result<(), String> {
 /// launchd still holds with no process — what a clean `stop` leaves, since
 /// KeepAlive only revives failures — is booted out and loaded afresh: a
 /// fresh load runs at once, where a kickstart of the old job waits out
-/// launchd's throttle from its last exit.
+/// launchd's throttle from its last exit. A job whose process is already up
+/// — serving, or still opening the database — is left alone.
 #[cfg(target_os = "macos")]
 pub fn install(db: &Path, name: &str, serving: bool) -> Result<Installed, String> {
     arm(db, name)?;
+    let pid = loaded_pid(name);
     if serving {
-        return Ok(if loaded(name) { Installed::AlreadyRunning } else { Installed::Deferred });
+        return Ok(if pid.is_some() { Installed::AlreadyRunning } else { Installed::Deferred });
+    }
+    if pid.is_some() {
+        return Ok(Installed::Started);
     }
     if loaded(name) {
         unload(name);
@@ -128,8 +144,10 @@ pub fn unload(name: &str) {
     }
 }
 
-/// Unregister: delete the plist. A running server is left alone; it ends
-/// with `stop` or at logout. Returns whether there was an item to remove.
+/// Unregister: delete the plist. A running server is left alone — it ends
+/// with `stop` or at logout, and until then launchd still restarts it after a
+/// crash, since it holds the job it loaded. A job with no process is booted
+/// out, so nothing of the item lingers. Returns whether there was an item.
 #[cfg(target_os = "macos")]
 pub fn remove(name: &str) -> Result<bool, String> {
     let plist = agent_path(name)?;
@@ -137,6 +155,9 @@ pub fn remove(name: &str) -> Result<bool, String> {
         return Ok(false);
     }
     std::fs::remove_file(&plist).map_err(|e| format!("removing {}: {e}", plist.display()))?;
+    if loaded(name) && loaded_pid(name).is_none() {
+        unload(name);
+    }
     Ok(true)
 }
 
@@ -146,10 +167,22 @@ pub fn installed(name: &str) -> bool {
     agent_path(name).map(|p| p.exists()).unwrap_or(false)
 }
 
-/// Whether launchd holds the job in this session.
+/// Whether launchd holds the job in this session — running or idle.
 #[cfg(target_os = "macos")]
 fn loaded(name: &str) -> bool {
     launchctl(&["print", &format!("{}/{}", domain(), label(name))])
+}
+
+/// The pid of the job's process, while launchd has one running.
+#[cfg(target_os = "macos")]
+fn loaded_pid(name: &str) -> Option<u32> {
+    let out = std::process::Command::new("launchctl")
+        .args(["print", &format!("{}/{}", domain(), label(name))])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("pid = ").and_then(|p| p.trim().parse().ok()))
 }
 
 
@@ -162,11 +195,20 @@ fn agent_path(name: &str) -> Result<std::path::PathBuf, String> {
 }
 
 // KeepAlive on failure only: a crash or a kill comes back after the throttle,
-// a clean exit — `stop`, `.quit`, the refcount departure — stays down. The
-// server's stdout and stderr land in the berth's log, which is where a crash
-// explains itself.
+// a clean exit — `stop`, the refcount departure — stays down. The server's
+// stdout and stderr land in the berth's log, which is where a crash explains
+// itself.
 #[cfg(target_os = "macos")]
-fn plist_body(name: &str, exe: &str, db: &str, log: &str) -> String {
+fn plist_body(name: &str, exe: &str, db: &str, log: &str, env: &[(String, String)]) -> String {
+    let env = if env.is_empty() {
+        String::new()
+    } else {
+        let pairs: String = env
+            .iter()
+            .map(|(k, v)| format!("\t\t<key>{}</key>\n\t\t<string>{}</string>\n", xml(k), xml(v)))
+            .collect();
+        format!("\t<key>EnvironmentVariables</key>\n\t<dict>\n{pairs}\t</dict>\n")
+    };
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
@@ -176,6 +218,7 @@ fn plist_body(name: &str, exe: &str, db: &str, log: &str) -> String {
          \t<key>ProgramArguments</key>\n\t<array>\n\
          \t\t<string>{exe}</string>\n\t\t<string>{db}</string>\n\t\t<string>start</string>\n\
          \t</array>\n\
+         {env}\
          \t<key>RunAtLoad</key>\n\t<true/>\n\
          \t<key>KeepAlive</key>\n\t<dict>\n\
          \t\t<key>SuccessfulExit</key>\n\t\t<false/>\n\
@@ -190,6 +233,7 @@ fn plist_body(name: &str, exe: &str, db: &str, log: &str) -> String {
         exe = xml(exe),
         db = xml(db),
         log = xml(log),
+        env = env,
     )
 }
 
@@ -232,14 +276,23 @@ fn systemctl(args: &[&str]) -> Result<(), String> {
 pub fn arm(db: &Path, name: &str) -> Result<(), String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let canon = paths::canonical_db(db)?;
+    let log = paths::log_file(&paths::runtime_dir()?, name);
+    if let Some(dir) = log.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
     let path = unit_path(name)?;
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
     }
-    std::fs::write(&path, unit_body(name, &exe.display().to_string(), &canon.display().to_string()))
-        .map_err(|e| format!("writing {}: {e}", path.display()))?;
+    std::fs::write(
+        &path,
+        unit_body(name, &exe.display().to_string(), &canon.display().to_string(), &log.display().to_string(), &homes()),
+    )
+    .map_err(|e| format!("writing {}: {e}", path.display()))?;
     let _ = systemctl(&["daemon-reload"]);
-    let _ = systemctl(&["enable", &unit(name)]);
+    if let Err(e) = systemctl(&["enable", &unit(name)]) {
+        eprintln!("harbor: {e} — the unit is written, but nothing will start it at login until it is enabled");
+    }
     Ok(())
 }
 
@@ -292,23 +345,34 @@ fn unit_path(name: &str) -> Result<std::path::PathBuf, String> {
 }
 
 // Restart=on-failure is KeepAlive's SuccessfulExit=false: back after a crash,
-// down after a clean exit. Quote the two paths so a space in either survives
-// systemd's word split.
+// down after a clean exit. No After= on the target that wants this unit — a
+// target orders itself after everything it wants, so that would be a cycle
+// systemd breaks by dropping a job, usually this one. Paths are quoted so a
+// space survives systemd's word split.
 #[cfg(target_os = "linux")]
-fn unit_body(name: &str, exe: &str, db: &str) -> String {
+fn unit_body(name: &str, exe: &str, db: &str, log: &str, env: &[(String, String)]) -> String {
+    let q = |s: &str| s.replace('"', "\\\"");
+    let env: String = env
+        .iter()
+        .map(|(k, v)| format!("Environment=\"{}={}\"\n", k, q(v)))
+        .collect();
     format!(
         "[Unit]\n\
-         Description=harbor: {name}\n\
-         After=default.target\n\n\
+         Description=harbor: {name}\n\n\
          [Service]\n\
          Type=simple\n\
+         {env}\
          ExecStart=\"{exe}\" \"{db}\" start\n\
+         StandardOutput=append:{log}\n\
+         StandardError=append:{log}\n\
          Restart=on-failure\n\
          RestartSec=10\n\n\
          [Install]\n\
          WantedBy=default.target\n",
-        exe = exe.replace('"', "\\\""),
-        db = db.replace('"', "\\\""),
+        exe = q(exe),
+        db = q(db),
+        log = log,
+        env = env,
     )
 }
 
@@ -344,7 +408,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn plist_runs_start_and_escapes_paths() {
-        let body = super::plist_body("my-db", "/opt/harbor & co/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        let body = super::plist_body("my-db", "/opt/harbor & co/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
         assert!(body.contains("<string>harbor.my-db</string>"));
         assert!(body.contains("<string>/data/my-db.duckdb</string>\n\t\t<string>start</string>"));
         assert!(body.contains("<key>RunAtLoad</key>\n\t<true/>"));
@@ -354,7 +418,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn plist_restarts_on_failure_only() {
-        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
         assert!(body.contains("<key>KeepAlive</key>\n\t<dict>\n\t\t<key>SuccessfulExit</key>\n\t\t<false/>"));
         assert!(body.contains("<key>ThrottleInterval</key>\n\t<integer>10</integer>"));
         assert!(!body.contains("<key>KeepAlive</key>\n\t<true/>"), "a clean stop must stay stopped");
@@ -363,24 +427,29 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn plist_sends_output_to_the_berth_log() {
-        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
+        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
         assert!(body.contains("<key>StandardOutPath</key>\n\t<string>/tmp/log/my-db.log</string>"));
         assert!(body.contains("<key>StandardErrorPath</key>\n\t<string>/tmp/log/my-db.log</string>"));
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn plist_carries_no_environment() {
+    fn plist_carries_only_the_homes_that_were_set() {
         // The login item's start is a plain start: options come from
-        // config.toml, and nothing about it is signalled through env.
-        let body = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log");
-        assert!(!body.contains("EnvironmentVariables"));
+        // config.toml. The one thing that rides the environment is where
+        // harbor's home is, when the shell moved it — else nothing at all.
+        let bare = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
+        assert!(!bare.contains("EnvironmentVariables"));
+        let moved = super::plist_body("my-db", "/opt/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log",
+            &[("HARBOR_HOME".into(), "/srv/h & m".into())]);
+        assert!(moved.contains("<key>EnvironmentVariables</key>"));
+        assert!(moved.contains("<key>HARBOR_HOME</key>\n\t\t<string>/srv/h &amp; m</string>"));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn unit_runs_start_and_quotes_paths() {
-        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my db.duckdb");
+        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my db.duckdb", "/tmp/log/my-db.log", &[]);
         assert!(body.contains("ExecStart=\"/opt/harbor/harbor\" \"/data/my db.duckdb\" start"));
         assert!(body.contains("WantedBy=default.target"));
         assert!(!body.contains("Environment="));
@@ -389,9 +458,28 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn unit_restarts_on_failure_only() {
-        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my-db.duckdb");
+        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
         assert!(body.contains("Restart=on-failure"));
         assert!(body.contains("RestartSec=10"));
         assert!(!body.contains("Restart=always"), "a clean stop must stay stopped");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unit_never_orders_after_the_target_that_wants_it() {
+        // default.target is After= everything it Wants=; an After=default.target
+        // here would be a cycle systemd resolves by dropping a job.
+        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log", &[]);
+        assert!(!body.contains("After=default.target"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unit_logs_to_the_berth_log_and_carries_moved_homes() {
+        let body = super::unit_body("my-db", "/opt/harbor/harbor", "/data/my-db.duckdb", "/tmp/log/my-db.log",
+            &[("XDG_STATE_HOME".into(), "/srv/state".into())]);
+        assert!(body.contains("StandardOutput=append:/tmp/log/my-db.log"));
+        assert!(body.contains("StandardError=append:/tmp/log/my-db.log"));
+        assert!(body.contains("Environment=\"XDG_STATE_HOME=/srv/state\""));
     }
 }

--- a/harbor/crates/common/src/membership.rs
+++ b/harbor/crates/common/src/membership.rs
@@ -31,11 +31,14 @@ pub enum Attached {
 // ---------------------------------------------------------------------------
 
 /// Add `db` to the config under its normalized stem, or confirm it is already
-/// there. Returns the name it was filed under. Errors if that name already
-/// belongs to a different file.
+/// there — under whatever key already names this file. Returns the name it is
+/// filed under. Errors if the stem already belongs to a different file.
 pub fn attach(db: &Path) -> Result<(String, Attached), String> {
-    let name = name_of(db)?;
     let canon = paths::canonical_db(db)?;
+    if let Some(key) = listed_as(&canon) {
+        return Ok((key, Attached::AlreadyThere));
+    }
+    let name = name_of(db)?;
     let stored = paths::shorten(&canon);
     let mut doc = parse(&read()?)?;
 
@@ -60,11 +63,11 @@ pub fn attach(db: &Path) -> Result<(String, Attached), String> {
     Ok((name, Attached::Added))
 }
 
-/// Remove `db` from the config, matched by its normalized stem. Returns whether
-/// a section was actually there to remove; a missing file or absent name is a
+/// Remove `db` from the config, whatever key names it. Returns whether a
+/// section was actually there to remove; a missing file or absent name is a
 /// quiet `false`, never an error.
 pub fn detach(db: &Path) -> Result<(String, bool), String> {
-    let name = name_of(db)?;
+    let name = name_for(db)?;
     let mut doc = parse(&read()?)?;
 
     let Some((key, _)) = find(&doc, &name)? else {
@@ -110,8 +113,31 @@ pub fn remove_named(name: &str) -> Result<bool, String> {
     Ok(true)
 }
 
-/// The name a database files under: its stem, normalized to the registry
-/// alphabet — the same derivation every other harbor name goes through.
+/// The name a database answers to: the config key that already names this
+/// file, when one does, else the stem it would be filed under. A login item,
+/// a footnote row and a `stop` all go through this, so `[connection.warehouse]`
+/// pointing at `inventory.duckdb` is `warehouse` everywhere and never grows
+/// an `inventory` twin.
+pub fn name_for(db: &Path) -> Result<String, String> {
+    let canon = paths::canonical_db(db)?;
+    match listed_as(&canon) {
+        Some(key) => Ok(key),
+        None => name_of(db),
+    }
+}
+
+/// The config key whose `path` is this canonical file, if any. A config that
+/// will not load names nothing — the caller falls back to the stem.
+fn listed_as(canon: &Path) -> Option<String> {
+    let cfg = crate::config::load().ok()?;
+    cfg.berths().into_iter().find_map(|(key, c)| {
+        let p = c.database()?;
+        (paths::canonical_db(&p).ok()? == *canon).then(|| key.to_string())
+    })
+}
+
+/// The name a database files under when nothing names it yet: its stem,
+/// normalized to the registry alphabet.
 pub fn name_of(db: &Path) -> Result<String, String> {
     let stem = db
         .file_stem()

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -8,9 +8,9 @@
 //!                                 spawned that lives while anyone is connected
 //!   harbor <path/to.sock>         connect to a server by its socket
 //!   harbor http://host:port       connect to a server over TCP
-//!   harbor <name> | <footnote>    a running database, by its name or its
-//!                                 number in the list (always the socket)
-//!   harbor <db.duckdb> start      start it yourself, until you leave
+//!   harbor <name> | <footnote>    a listed database, by its name or its
+//!                                 number in the list — running or stopped
+//!   harbor <db.duckdb> start      bring it up in the background, until you stop it
 //!
 //! The socket IS the runtime registration: its name is derived from the
 //! database's canonical path (`socket_for`). Shared config supplies named
@@ -71,9 +71,10 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    // A bare word in front of a verb means a running server (`harbor medlabs
-    // stop`, `harbor 1 stop`), dereferenced to the file it actually serves —
-    // never a file made from the word (the safety law in looks_like_path).
+    // A bare word in front of a verb means a listed database (`harbor medlabs
+    // stop`, `harbor 3 start`), dereferenced to the file a running server
+    // declares or a config entry names — never a file made from the word
+    // (the safety law in looks_like_path).
     let db = if harbor_common::looks_like_path(&db) {
         PathBuf::from(db)
     } else {
@@ -98,7 +99,7 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
     if !matches!(plan.run, Some(Running::Start | Running::Restart)) && !flags.is_empty() {
-        eprintln!("harbor: only `start` takes options — got: {}", flags.join(" "));
+        eprintln!("harbor: only start and restart take options — got: {}", flags.join(" "));
         return ExitCode::FAILURE;
     }
 
@@ -119,6 +120,8 @@ fn main() -> ExitCode {
             Ok((name, removed)) => {
                 if removed {
                     eprintln!("harbor: detached {name}");
+                } else {
+                    eprintln!("harbor: {name} was not attached");
                 }
             }
             Err(e) => {
@@ -129,7 +132,7 @@ fn main() -> ExitCode {
         None => {}
     }
 
-    let name = match membership::name_of(&db) {
+    let name = match membership::name_for(&db) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("harbor: {e}");
@@ -174,7 +177,7 @@ fn main() -> ExitCode {
                 autostart::unload(&name);
             }
             return match autostart::install(&db, &name, serving(&db)) {
-                Ok(autostart::Installed::Started) => match wait_serving(&db) {
+                Ok(autostart::Installed::Started) => match wait_serving(&db, &name) {
                     Ok(sock) => {
                         eprintln!("harbor: {name} serving on {} — it will start at every login", sock.display());
                         ExitCode::SUCCESS
@@ -278,7 +281,7 @@ fn main() -> ExitCode {
             }
             if autostart::installed(&name) {
                 autostart::unload(&name);
-                return match autostart::install(&db, &name, false).and_then(|_| wait_serving(&db)) {
+                return match autostart::install(&db, &name, false).and_then(|_| wait_serving(&db, &name)) {
                     Ok(sock) => {
                         eprintln!("harbor: {name} restarted, serving on {} — it will start at every login", sock.display());
                         ExitCode::SUCCESS
@@ -303,8 +306,11 @@ fn main() -> ExitCode {
 
 /// The session manager starts a server asynchronously: block until it
 /// answers on its socket, or say why not with the log to read. The same
-/// budget a summon gives its child.
-fn wait_serving(db: &Path) -> Result<PathBuf, String> {
+/// budget a summon gives its child. A start that never comes up is taken
+/// back out of the manager, so a database that cannot open is not retried
+/// every ten seconds until logout; the item stays registered for the next
+/// login and the next `start`.
+fn wait_serving(db: &Path, name: &str) -> Result<PathBuf, String> {
     #[cfg(unix)]
     {
         let runtime = harbor_common::runtime_dir()?;
@@ -317,15 +323,16 @@ fn wait_serving(db: &Path) -> Result<PathBuf, String> {
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        let name = membership::name_of(&canon)?;
+        autostart::unload(name);
         Err(format!(
-            "{} did not come up in 15s — see {}",
+            "{} did not come up in 15s — see {}; its login item is unloaded until the next login or `start`",
             canon.display(),
-            harbor_common::paths::log_file(&runtime, &name).display()
+            harbor_common::paths::log_file(&runtime, name).display()
         ))
     }
     #[cfg(not(unix))]
     {
+        let _ = name;
         Err(format!("{}: login items need unix sockets", db.display()))
     }
 }
@@ -363,7 +370,7 @@ usage:
                                the login item when there is one — and return;
                                it runs until `stop`. Headless (no terminal) it
                                runs in place until SIGTERM, which is what a
-                               service manager wants
+                               session manager wants
   harbor <db.duckdb> stop      stop the server for this database, if one is
                                running (a quiet no-op if nothing is); a login
                                item brings it back at the next login
@@ -382,7 +389,8 @@ usage:
   harbor version               print this binary's version (also -V)
 
 Verbs combine, in any order: `attach start` remembers it and starts it
-persistent; `detach start` starts an ephemeral one; `attach` alone just
+persistent; `detach start` starts an ephemeral one (it leaves when its last
+client does); `attach` alone just
 lists it. At most one of attach/detach and one of start/stop/restart.
 A login item runs a bare `start`, so its options live in config.toml under
 [connection.<name>] — statement-timeout, memory-limit, workers, threads, init.
@@ -576,7 +584,7 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     let ephemeral = ephemeral || std::env::var_os("HARBOR_EPHEMERAL").is_some();
     // A database's config entry supplies its standing settings — memory,
     // threads, boot SQL, extensions — so a bare `harbor <db> start` (a summon,
-    // an autostart at boot) honors them without flags. Read against the
+    // the login item) honors them without flags. Read against the
     // canonical file, so any spelling of the path finds the same entry;
     // explicit flags parsed next override whatever the entry set.
     let canon = harbor_common::paths::canonical_db(&db)?;
@@ -605,10 +613,18 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     // to that.
     #[cfg(unix)]
     if sock_path.exists() && harbor::repl::sock_ready(&sock_path) {
+        let name = membership::name_for(&canon)?;
+        // At a terminal, asking for a server that is up is asking for the
+        // state you have — success, like `systemctl start` on an active unit.
+        // Headless it stays a refusal: a manager or a spawn that asked for a
+        // server and got none must not read a clean exit as one.
+        if !o.foreground && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+            eprintln!("harbor: {name} is already serving on {} — `harbor {name}` connects to it", sock_path.display());
+            return Ok(());
+        }
         return Err(format!(
-            "{} is already being served — `harbor {}` connects to it",
-            canon.display(),
-            o.db.display()
+            "{} is already being served — `harbor {name}` connects to it",
+            canon.display()
         ));
     }
 
@@ -618,22 +634,29 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     // child that runs until `stop`. Only a headless start (a service
     // manager, a spawn, a pipe) or `--foreground` serves from this process.
     #[cfg(unix)]
-    if !o.ephemeral && !o.foreground && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-        let name = membership::name_of(&canon)?;
-        if autostart::installed(&name) {
+    if !o.foreground && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        let name = membership::name_for(&canon)?;
+        if !o.ephemeral && autostart::installed(&name) {
             if !typed.is_empty() {
                 return Err(format!(
                     "{name} starts at login from config.toml, not flags — put {} under [connection.{name}]",
                     typed.join(" ")
                 ));
             }
-            autostart::install(&o.db, &name, false)?;
-            let sock = wait_serving(&o.db)?;
-            eprintln!("harbor: {name} serving on {} under its login item — `harbor {name} stop` ends it", sock.display());
-            return Ok(());
+            // The manager may be unreachable — an ssh session has no gui
+            // domain — and then the server still comes up, just not under it.
+            match autostart::install(&o.db, &name, false) {
+                Ok(_) => {
+                    let sock = wait_serving(&o.db, &name)?;
+                    eprintln!("harbor: {name} serving on {} under its login item — `harbor {name} stop` ends it", sock.display());
+                    return Ok(());
+                }
+                Err(e) => eprintln!("harbor: {e} — starting it here instead; it will not be under the login item until `restart`"),
+            }
         }
-        let sock = harbor::repl::start_detached(&o.db, &typed)?;
-        eprintln!("harbor: serving {} on {} — `harbor {} stop` ends it", canon.display(), sock.display(), name);
+        let sock = harbor::repl::start_detached(&o.db, &typed, o.ephemeral)?;
+        let lifetime = if o.ephemeral { "it leaves when its last client does" } else { &format!("`harbor {name} stop` ends it") };
+        eprintln!("harbor: serving {} on {} — {lifetime}", canon.display(), sock.display());
         return Ok(());
     }
 
@@ -701,13 +724,11 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     // by the core. This is the whole registry — the list dials it.
     harbor::set_info(serde_json::json!({
         "protocolVersion": 1,
-        // The display name clients label this server with — the wire's
-        // InfoResponse has always declared it; 0.22.1 and earlier never
-        // sent it, and clients showed blank rows for discovered servers.
-        "name": canon
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "harbor".into()),
+        // The name clients label this server with and the CLI resolves a
+        // bare word against: the config key that lists this file when one
+        // does, else its stem — the same rule the login item and the stopped
+        // row use, so `warehouse` is `warehouse` running or not.
+        "name": membership::name_for(&canon).unwrap_or_else(|_| "harbor".into()),
         "harborVersion": VERSION,
         "duckdbVersion": duckdb_version,
         "database": canon.display().to_string(),

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -10,7 +10,7 @@
 //!   harbor <db.duckdb>              the REPL (or stdin/-c on a pipe)
 //!   harbor <path/to.sock>           a harbor unix socket
 //!   harbor http://host:port         a harbor TCP listener
-//!   harbor <name> | <footnote>      a running database, by name or list number
+//!   harbor <name> | <footnote>      a listed database, by name or list number
 //!
 //! TLS is Caddy's job — the client speaks plain HTTP over UDS/TCP.
 
@@ -34,7 +34,7 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-/// Set by SIGINT while a statement streams (registered in cli_main/helm);
+/// Set by SIGINT while a statement streams (registered in cli_main);
 /// checked at every read tick. Cleared before each statement.
 static CANCEL: LazyLock<std::sync::Arc<AtomicBool>> =
     LazyLock::new(|| std::sync::Arc::new(AtomicBool::new(false)));
@@ -322,16 +322,17 @@ fn ensure_server(path: &Path) -> Result<Transport, String> {
     }
 }
 
-/// `harbor <db> start` at a terminal: the server comes up in the background,
-/// persistent — it runs until `stop` — and this returns once it answers.
-/// The same launch a summon uses, minus the ephemeral signal, plus whatever
-/// start options were typed. Returns the socket the server answers on.
+/// `harbor <db> start` at a terminal: the server comes up in the background
+/// and this returns once it answers. Persistent — it runs until `stop` —
+/// unless the grammar said `detach start`, which is the refcounted lifetime a
+/// summon gets. The same launch a summon uses, plus whatever start options
+/// were typed. Returns the socket the server answers on.
 #[cfg(unix)]
-pub fn start_detached(db: &Path, args: &[String]) -> Result<PathBuf, String> {
+pub fn start_detached(db: &Path, args: &[String], ephemeral: bool) -> Result<PathBuf, String> {
     let runtime = harbor_common::runtime_dir()?;
     let canon = harbor_common::paths::canonical_db(db)?;
     let sock = harbor_common::socket_for(&runtime, &canon)?;
-    launch(&runtime, &canon, &sock, args, false)?;
+    launch(&runtime, &canon, &sock, args, ephemeral)?;
     Ok(sock)
 }
 
@@ -418,31 +419,30 @@ pub fn sock_ready(sock: &Path) -> bool {
 /// actually there to stop. The `stop` verb's whole implementation.
 #[cfg(unix)]
 pub fn shutdown(db: &Path) -> Result<bool, String> {
-    if !db.exists() {
-        return Ok(false); // no file, nothing behind it
-    }
     let runtime = harbor_common::runtime_dir()?;
     let canon = harbor_common::paths::canonical_db(db)?;
-    let transport = Transport::Unix(harbor_common::socket_for(&runtime, &canon)?);
+    let sock = harbor_common::socket_for(&runtime, &canon)?;
+    let transport = Transport::Unix(sock.clone());
     if !ready(&transport) {
         return Ok(false); // nothing answering on its socket
     }
     // POST /shutdown drains, checkpoints, and exits. The server can close the
     // socket as it goes, so a dropped connection right after the request is
-    // success, not failure. Either way, `stop` means stopped: wait until the
-    // socket no longer answers, so `stop` followed by `start` — by hand, or
-    // inside `restart` — meets a database that is actually free.
+    // success, not failure. Either way, `stop` means stopped: the server
+    // unlinks its socket as the last thing before it exits and releases the
+    // database lock, so wait for the file to be gone — then a `start` that
+    // follows, by hand or inside `restart`, meets a database that is free.
     if let Err(e) = http::request(&transport, &endpoint::SHUTDOWN, None, Some(Duration::from_secs(30)))
         && ready(&transport)
     {
         return Err(format!("stop: {e}"));
     }
-    let deadline = Instant::now() + Duration::from_secs(30);
-    while ready(&transport) {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while sock.exists() || ready(&transport) {
         if Instant::now() > deadline {
-            return Err(format!("stop: {} is still answering after 30s", canon.display()));
+            return Err(format!("stop: {} is still shutting down after 60s", canon.display()));
         }
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(Duration::from_millis(50));
     }
     Ok(true)
 }
@@ -627,11 +627,14 @@ fn survey() -> Result<Vec<SurveyRow>, String> {
         let Some(db) = entry.database() else { continue };
         let canon = harbor_common::paths::canonical_db(&db).unwrap_or_else(|_| db.clone());
         let sock = harbor_common::socket_for(&runtime, &db).ok();
+        // Claimed by the file — its socket, or the path a server declares —
+        // never by a shared name: a server on some other `medlabs.duckdb`
+        // must not hide the attached one, or `harbor medlabs stop` would land
+        // on the wrong file.
         let claimed = rows.iter().any(|r| {
             sock.as_ref() == Some(&r.sock)
                 || r.info.as_ref().is_some_and(|v| {
-                    v["name"].as_str() == Some(name)
-                        || v["database"].as_str().map(Path::new) == Some(canon.as_path())
+                    v["database"].as_str().map(Path::new) == Some(canon.as_path())
                 })
         });
         if claimed {


### PR DESCRIPTION
Three independent reviews of the 0.33.0 verbs (grammar, lifecycle code, and an empirical walk of every combination on a scratch database) turned up the following, all fixed here.

**Identity**
- A database is named by the config key that lists it, everywhere a name is derived. `[connection.warehouse]` pointing at `inventory.duckdb` is `warehouse` running or stopped, grows no twin entry, and boots with its own settings. The server announces that name in `/info`.
- The fleet claims a config entry by socket or file only, never by a shared name.

**systemd**
- Removed `After=default.target`, an ordering cycle with the target that wants the unit.
- Unit output goes to the berth's log; `HARBOR_HOME` and XDG homes are carried into the unit and plist when the installing shell had them.

**launchd**
- `install` is pid-aware: a job with a process is left alone, an idle job is booted out and reloaded, and "already running under its login item" is only said when that is true.
- A start that does not come up in 15 s is unloaded rather than retried every ten seconds until logout.
- `remove` boots out an idle job so nothing lingers after `autostart off`.

**stop / start**
- `stop` waits for the socket file to be unlinked, which happens right before the lock is released.
- `start` at a terminal is a success when the server is already up. Headless stays a refusal.
- `detach start` detaches and carries the ephemeral lifetime. A login item that cannot be loaded over ssh falls back to a detached start.

**Docs**
- README table: `detach` forgets, it does not stop; `detach stop` row added. Stale prompt-as-lifetime sentences removed.

**Verification**
- Full suite 12/12; unit tests on both crates; clippy clean on changed files; DuckTable harbor-client checks.
- At a pty: `warehouse`-keyed entry over `inventory.duckdb` autostarts with its configured memory limit, no twin, `stop`/`autostart off`/`detach` all resolve by `warehouse`; `start` twice is exit 0; `autostart`, `stop`, `autostart off` leaves no launchd job.
