### PR TITLE
Name the attached databases when a verb comes first

### DIFF
--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "libc",
  "serde",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "wire"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,12 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.33.1 — 2026-09-06
+
+- A verb typed without a database (`harbor restart`) now names the attached
+  databases in its redirect, with the command spelled out for the first one,
+  instead of showing only the file form.
+
 ## 0.33.0 — 2026-09-06
 
 - Makes `autostart` a service: the login item is loaded the moment it is

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.33.0"
+version = "0.33.1"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/crates/common/src/config.rs
+++ b/harbor/crates/common/src/config.rs
@@ -159,9 +159,8 @@ fn sql_literal(v: &toml::Value) -> Option<String> {
 
 impl FileConfig {
     /// Configured local berths, sorted. The name is the section key — never
-    /// the database file's stem, which is how `[connection.warehouse]`
-    /// pointing at `inventory.duckdb` used to produce a berth called
-    /// `inventory` and an alias nobody could use.
+    /// the database file's stem: `[connection.warehouse]` pointing at
+    /// `inventory.duckdb` is a berth called `warehouse`.
     pub fn berths(&self) -> Vec<(&str, &Connection)> {
         let mut v: Vec<_> = self
             .connection

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -46,9 +46,14 @@ fn main() -> ExitCode {
             println!("harbor {VERSION}");
             return ExitCode::SUCCESS;
         }
-        // A verb with no database in front of it: the noun comes first.
+        // A verb with no database in front of it: the noun comes first. The
+        // attached names are the short way to say it, so name them.
         Some(v) if verbs::Verb::is_verb(v) => {
-            eprintln!("harbor: the database comes first — harbor <db.duckdb> {v}");
+            eprintln!("harbor: the database comes first — harbor <db.duckdb|name|footnote> {v}");
+            let names = attached_names();
+            if let Some(first) = names.first() {
+                eprintln!("harbor: attached: {} — harbor {first} {v}", names.join(", "));
+            }
             return ExitCode::FAILURE;
         }
         _ => {}
@@ -466,6 +471,14 @@ fn default_opts(db: PathBuf) -> Opts {
 /// start honors it: a summon (`ephemeral`) stays on the unix socket, so
 /// opening a database never silently opens its TCP door — and the summoning
 /// client is waiting on that socket anyway.
+/// The config keys of every attached database, sorted, or nothing when there
+/// is no usable config — a hint never turns into an error of its own.
+fn attached_names() -> Vec<String> {
+    harbor_common::config::load()
+        .map(|cfg| cfg.berths().into_iter().map(|(k, _)| k.to_string()).collect())
+        .unwrap_or_default()
+}
+
 fn apply_berth_config(o: &mut Opts, canon: &Path, ephemeral: bool) {
     use harbor_common::config;
     let cfg = match config::load() {


### PR DESCRIPTION
`harbor restart` typed without a database used to answer with only the file form. It now shows the full noun grammar and the attached names:

```
harbor: the database comes first — harbor <db.duckdb|name|footnote> restart
harbor: attached: ducks, labs, medlabs — harbor ducks restart
```

With no usable config the second line is simply absent. Also rewords the `berths()` doc comment to state the rule rather than narrate an old bug. Version 0.33.1, CHANGELOG entry included. Unit tests and the lifecycle suite pass locally.