### PR TITLE
Let DuckTable update itself through Sparkle, fed from GitHub Releases

### DIFF
--- a/.github/workflows/DuckTableRelease.yml
+++ b/.github/workflows/DuckTableRelease.yml
@@ -40,9 +40,15 @@ jobs:
       - name: Smoke-test the bundle
         run: |
           test -x target/DuckTable.app/Contents/MacOS/ducktable
+          test -f target/DuckTable.app/Contents/Frameworks/Sparkle.framework/Sparkle
           ver=$(plutil -extract CFBundleShortVersionString raw target/DuckTable.app/Contents/Info.plist)
+          build=$(plutil -extract CFBundleVersion raw target/DuckTable.app/Contents/Info.plist)
           tag="${GITHUB_REF_NAME#ducktable-v}"
           [ "$ver" = "$tag" ] || { echo "bundle says $ver, tag says $tag"; exit 1; }
+          [ "$build" = "$tag" ] || { echo "CFBundleVersion is $build, tag says $tag"; exit 1; }
+          # A release without the public key would ship a bundle that can never update.
+          plutil -extract SUPublicEDKey raw target/DuckTable.app/Contents/Info.plist >/dev/null \
+            || { echo "bundle has no SUPublicEDKey: commit assets/sparkle-public-key.txt (docs/UPDATES.md)"; exit 1; }
 
       # refs/tags/ducktable-v, not refs/tags/: a workflow_dispatch aimed at
       # a harbor v* tag must not mint a DuckTable release. (Mirror of the
@@ -58,3 +64,29 @@ jobs:
             --notes "DuckTable for macOS (Apple Silicon), ad-hoc signed. \
           Install with the one-liner in the README, or unzip and clear \
           quarantine: xattr -dr com.apple.quarantine DuckTable.app"
+
+      # The Sparkle feed: one release that never changes name, holding the
+      # appcast plus every archive it points at (docs/UPDATES.md). Download
+      # what is there so generate_appcast keeps the old items and can build
+      # deltas, add this version, sign, upload back with --clobber.
+      - name: Publish the update feed
+        if: startsWith(github.ref, 'refs/tags/ducktable-v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "$SPARKLE_PRIVATE_KEY" ] || { echo "SPARKLE_PRIVATE_KEY secret is not set (docs/UPDATES.md)"; exit 1; }
+          ver="${GITHUB_REF_NAME#ducktable-v}"
+          feed=ducktable-updates
+          if ! gh release view "$feed" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$feed" --repo "$GITHUB_REPOSITORY" \
+              --title "DuckTable update feed" --prerelease --latest=false \
+              --notes "The Sparkle feed DuckTable checks for updates. Not a release: \
+          install from the newest DuckTable vX.Y.Z release or the README one-liner."
+          fi
+          mkdir -p target/updates
+          gh release download "$feed" --repo "$GITHUB_REPOSITORY" --dir target/updates --clobber || true
+          cp target/DuckTable.zip "target/updates/DuckTable-$ver.zip"
+          scripts/appcast.sh target/updates
+          gh release upload "$feed" target/updates/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /.claude/
 /misc/
+notes.txt

--- a/ducktable/.gitignore
+++ b/ducktable/.gitignore
@@ -4,3 +4,4 @@ vendor/*/target
 assets/AppIcon.iconset
 .claude/
 dist
+.ducktable-cache/

--- a/ducktable/CHANGELOG.md
+++ b/ducktable/CHANGELOG.md
@@ -3,6 +3,12 @@
 DuckTable release tags use `ducktable-vX.Y.Z`. Entries are ordered by signed
 tag date, newest first.
 
+## Unreleased
+
+- Updates itself: DuckTable → Check for Updates…, and a daily check once you
+  say yes to the first-launch prompt. Sparkle, fed from the `ducktable-updates`
+  GitHub release (docs/UPDATES.md).
+
 ## 0.20.4 — 2026-09-05
 
 - Keeps the active-cell coordinates intact when a staged row intentionally

--- a/ducktable/Cargo.lock
+++ b/ducktable/Cargo.lock
@@ -1446,7 +1446,9 @@ dependencies = [
  "gpui",
  "gpui-component",
  "harbor-client",
+ "libc",
  "objc",
+ "objc2",
  "serde_json",
  "wire",
 ]

--- a/ducktable/README.md
+++ b/ducktable/README.md
@@ -51,6 +51,10 @@ that way, allow it under System Settings → Privacy & Security → Open Anyway.
 Uninstall with `... | bash -s -- --uninstall` — the app goes; your settings
 (`~/.config/ducktable`) and your databases stay.
 
+After that, DuckTable keeps itself current: DuckTable → Check for Updates…,
+or say yes to the first-launch prompt and it checks once a day
+([docs/UPDATES.md](docs/UPDATES.md)).
+
 On Intel, or to build from source: clone the repo and run
 `ducktable/scripts/macos-app.sh release`.
 

--- a/ducktable/assets/sparkle-public-key.txt
+++ b/ducktable/assets/sparkle-public-key.txt
@@ -1,0 +1,1 @@
+7OSJnstrBxo0RCwwVjafxlVbZqYdhkjftBkoqfgWt/8=

--- a/ducktable/assets/sparkle-public-key.txt
+++ b/ducktable/assets/sparkle-public-key.txt
@@ -1,1 +1,1 @@
-7OSJnstrBxo0RCwwVjafxlVbZqYdhkjftBkoqfgWt/8=
+6xRMmsUA5QaJ3kUDkqM5gEWb6OAMCEY2T/R9pb2ETfo=

--- a/ducktable/crates/ducktable/Cargo.toml
+++ b/ducktable/crates/ducktable/Cargo.toml
@@ -17,3 +17,7 @@ serde_json = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
+# The updater talks to the embedded Sparkle framework through objc2 (the
+# generation gpui itself uses) and loads it with dlopen.
+objc2 = "0.6"
+libc = "0.2"

--- a/ducktable/crates/ducktable/src/main.rs
+++ b/ducktable/crates/ducktable/src/main.rs
@@ -17,6 +17,7 @@ mod sql;
 mod sidebar;
 mod structure;
 mod theme;
+mod updater;
 mod util;
 
 use app::DuckTable;
@@ -28,7 +29,8 @@ actions!(
     [
         ToggleInspector, About, Quit, ZoomIn, ZoomOut, ZoomReset, FitColumns, RefreshTables,
         AddRow, DuplicateRow, DeleteRow, TablePrev, TableNext, View1, View2, View3, ToggleFullScreen,
-        ToggleRowNumbers, ToggleRightAlign, ToggleNullTags, OpenDatabase, OpenDatabaseUrl
+        ToggleRowNumbers, ToggleRightAlign, ToggleNullTags, OpenDatabase, OpenDatabaseUrl,
+        CheckForUpdates
     ]
 );
 
@@ -178,16 +180,21 @@ impl Global for AppView {}
 
 /// The macOS menu bar. The first menu becomes the application menu; the
 /// About item opens the platform's standard dialog (window.prompt ->
-/// NSAlert) with the version and a GitHub link.
-fn app_menus() -> Vec<Menu> {
+/// NSAlert) with the version and a GitHub link. Check for Updates sits
+/// under it in the conventional slot, and only when this build can update
+/// itself (docs/UPDATES.md) — a dev bundle has no such item to disappoint.
+fn app_menus(can_update: bool) -> Vec<Menu> {
+    let mut app_menu = vec![MenuItem::action("About DuckTable", About)];
+    if can_update {
+        app_menu.push(MenuItem::separator());
+        app_menu.push(MenuItem::action("Check for Updates…", CheckForUpdates));
+    }
+    app_menu.push(MenuItem::separator());
+    app_menu.push(MenuItem::action("Quit DuckTable", Quit));
     vec![
         Menu {
             name: "DuckTable".into(),
-            items: vec![
-                MenuItem::action("About DuckTable", About),
-                MenuItem::separator(),
-                MenuItem::action("Quit DuckTable", Quit),
-            ],
+            items: app_menu,
         },
         Menu {
             name: "File".into(),
@@ -398,6 +405,17 @@ fn main() {
         );
         theme::init(cx);
         prefs::init(cx);
+        // Sparkle, from the framework the bundle embeds. None in debug
+        // builds and bare `cargo run` binaries, and the menu item goes
+        // with it.
+        let updater = updater::Updater::init();
+        let can_update = updater.is_some();
+        cx.set_global(updater::UpdaterState(updater));
+        cx.on_action(|_: &CheckForUpdates, cx| {
+            if let Some(updater) = &cx.global::<updater::UpdaterState>().0 {
+                updater.check_for_updates();
+            }
+        });
         cx.bind_keys([
             KeyBinding::new("cmd-i", ToggleInspector, None),
             KeyBinding::new("cmd-o", OpenDatabase, None),
@@ -617,7 +635,7 @@ fn main() {
                 }
             });
         });
-        cx.set_menus(app_menus());
+        cx.set_menus(app_menus(can_update));
 
         // The window opens where it last stood — the frame saved on
         // every move and resize below. A fresh install has no frame

--- a/ducktable/crates/ducktable/src/updater.rs
+++ b/ducktable/crates/ducktable/src/updater.rs
@@ -1,0 +1,167 @@
+//! In-app updates. macOS delegates to the Sparkle framework that
+//! `scripts/macos-app.sh` embeds in DuckTable.app; the feed it reads is the
+//! `ducktable-updates` GitHub release (docs/UPDATES.md).
+//!
+//! Every user-facing moment — the one-time "check automatically?" prompt,
+//! the checking window, the update sheet, download, install and relaunch —
+//! is Sparkle's own standard UI. DuckTable only starts the updater and
+//! forwards the Check for Updates menu item, so this file is glue, not a
+//! user driver of its own.
+//!
+//! Debug builds stay dormant so the dev bundle never offers to replace
+//! itself with a release; `DUCKTABLE_FORCE_UPDATER=1` exercises the real
+//! flow from one. A bare `cargo run` binary has no embedded framework and
+//! stays dormant too, in which case the menu item is omitted.
+
+use gpui::Global;
+
+/// App-wide handle to the updater, if this build can update itself.
+pub struct UpdaterState(pub Option<Updater>);
+
+impl Global for UpdaterState {}
+
+#[cfg(target_os = "macos")]
+pub use macos::Updater;
+
+/// Other platforms have no updater; the menu item is omitted with it.
+#[cfg(not(target_os = "macos"))]
+pub struct Updater;
+
+#[cfg(not(target_os = "macos"))]
+impl Updater {
+    pub fn init() -> Option<Self> {
+        None
+    }
+
+    pub fn check_for_updates(&self) {}
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::ffi::{CStr, CString, c_char};
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::path::PathBuf;
+    use std::ptr;
+
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject};
+    use objc2::{MainThreadMarker, msg_send};
+
+    pub struct Updater {
+        updater: Retained<AnyObject>,
+        /// Sparkle's standard user driver, kept alive for the updater's
+        /// lifetime alongside it.
+        _user_driver: Retained<AnyObject>,
+    }
+
+    impl Updater {
+        /// Load Sparkle and start its updater. `None` when this build cannot
+        /// update itself: debug builds unless forced, and binaries running
+        /// outside a bundle with an embedded framework.
+        pub fn init() -> Option<Self> {
+            let forced =
+                std::env::var_os("DUCKTABLE_FORCE_UPDATER").is_some_and(|value| value == "1");
+            if cfg!(debug_assertions) && !forced {
+                return None;
+            }
+
+            // Sparkle is AppKit code and must be started on the main thread,
+            // which is where GPUI runs `Application::run`.
+            let _mtm = MainThreadMarker::new()?;
+            let library = sparkle_library_path()?;
+            let library_c = CString::new(library.as_os_str().as_bytes()).ok()?;
+            let handle = unsafe { libc::dlopen(library_c.as_ptr(), libc::RTLD_NOW) };
+            if handle.is_null() {
+                let reason = unsafe { libc::dlerror() };
+                let reason = if reason.is_null() {
+                    "unknown dlopen failure".to_owned()
+                } else {
+                    unsafe { CStr::from_ptr(reason) }
+                        .to_string_lossy()
+                        .into_owned()
+                };
+                eprintln!("DuckTable updater: failed to load Sparkle: {reason}");
+                return None;
+            }
+
+            let bundle_class = AnyClass::get(c"NSBundle")?;
+            let updater_class = AnyClass::get(c"SPUUpdater")?;
+            let driver_class = AnyClass::get(c"SPUStandardUserDriver")?;
+            let main_bundle: *mut AnyObject = unsafe { msg_send![bundle_class, mainBundle] };
+            if main_bundle.is_null() {
+                return None;
+            }
+
+            let user_driver = unsafe {
+                let allocated: *mut AnyObject = msg_send![driver_class, alloc];
+                let initialized: *mut AnyObject = msg_send![
+                    allocated,
+                    initWithHostBundle: main_bundle,
+                    delegate: ptr::null_mut::<AnyObject>()
+                ];
+                Retained::from_raw(initialized)?
+            };
+            let updater = unsafe {
+                let allocated: *mut AnyObject = msg_send![updater_class, alloc];
+                let initialized: *mut AnyObject = msg_send![
+                    allocated,
+                    initWithHostBundle: main_bundle,
+                    applicationBundle: main_bundle,
+                    userDriver: &*user_driver,
+                    delegate: ptr::null_mut::<AnyObject>()
+                ];
+                Retained::from_raw(initialized)?
+            };
+
+            // `startUpdater:` validates the feed URL and the public key from
+            // Info.plist; a bad key here is the one misconfiguration that
+            // would otherwise fail silently at update time.
+            let mut error: *mut AnyObject = ptr::null_mut();
+            let started: bool = unsafe { msg_send![&*updater, startUpdater: &mut error] };
+            if !started {
+                eprintln!(
+                    "DuckTable updater: Sparkle refused to start: {}",
+                    error_description(error)
+                );
+                return None;
+            }
+
+            Some(Self {
+                updater,
+                _user_driver: user_driver,
+            })
+        }
+
+        /// The menu item: a user-initiated check through Sparkle's standard
+        /// windows. Sparkle's own scheduled checks run silently beside it.
+        pub fn check_for_updates(&self) {
+            let _: () = unsafe { msg_send![&*self.updater, checkForUpdates] };
+        }
+    }
+
+    fn error_description(error: *mut AnyObject) -> String {
+        if error.is_null() {
+            return "unknown error".to_owned();
+        }
+        let description: *mut AnyObject = unsafe { msg_send![error, localizedDescription] };
+        if description.is_null() {
+            return "unknown error".to_owned();
+        }
+        let utf8: *const c_char = unsafe { msg_send![description, UTF8String] };
+        if utf8.is_null() {
+            return "unknown error".to_owned();
+        }
+        unsafe { CStr::from_ptr(utf8) }
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// The embedded framework's dylib relative to the running executable
+    /// (Contents/MacOS/ducktable → Contents/Frameworks/Sparkle.framework).
+    fn sparkle_library_path() -> Option<PathBuf> {
+        let executable = std::env::current_exe().ok()?;
+        let contents = executable.parent()?.parent()?;
+        let library = contents.join("Frameworks/Sparkle.framework/Sparkle");
+        library.exists().then_some(library)
+    }
+}

--- a/ducktable/docs/UPDATES.md
+++ b/ducktable/docs/UPDATES.md
@@ -1,0 +1,97 @@
+# In-app updates
+
+DuckTable updates itself through [Sparkle](https://sparkle-project.org), the
+framework most self-updating Mac apps use, with GitHub Releases as the only
+host. Nothing else runs: no server, no bucket, no domain.
+
+## The pieces
+
+| Piece | Where | Does |
+| --- | --- | --- |
+| Framework | `scripts/sparkle.sh`, `scripts/macos-app.sh` | Fetches a pinned Sparkle by checksum into `.ducktable-cache/`, embeds it at `Contents/Frameworks`, ad-hoc signs it with the app |
+| Plist keys | `scripts/macos-app.sh` | `SUFeedURL` (the feed below) and `SUPublicEDKey` (from `assets/sparkle-public-key.txt`); `CFBundleVersion` is the workspace version, which is what Sparkle orders updates by |
+| Runtime | `crates/ducktable/src/updater.rs` | Loads the embedded framework, starts `SPUUpdater` with Sparkle's standard user driver, forwards the menu item |
+| Menu | `crates/ducktable/src/main.rs` | DuckTable → Check for Updates…, present only when the updater started |
+| Feed | `scripts/appcast.sh` | Signs the archives in a directory and writes its `appcast.xml` |
+| Publish | `.github/workflows/DuckTableRelease.yml` | After the versioned release, refreshes the feed release |
+
+## The feed release
+
+Sparkle needs one URL that always serves the current appcast, and GitHub's
+per-version release URLs contain the tag. So one extra release,
+**`ducktable-updates`**, never changes name and holds:
+
+- `appcast.xml`, the feed, rewritten every release;
+- `DuckTable-<version>.zip` for every version on the feed, since the appcast's
+  enclosure URLs are this release's download URLs;
+- `*.delta` files, binary deltas from the two previous versions.
+
+It is a prerelease and never `--latest`, so `/releases/latest` stays harbor's
+and `install.sh`, which resolves `ducktable-v*` tags by name, never sees it.
+The versioned `ducktable-v*` releases keep their `DuckTable.zip` for the
+installer and for people.
+
+Old archives can be deleted from the feed release whenever it grows tiresome;
+Sparkle only needs the newest item, plus whichever versions should still get a
+delta.
+
+## One-time setup
+
+### 1. The signing key
+
+Updates are signed with an ed25519 key. The private half lives in the login
+keychain under the account `ducktable` and, for CI, in a repository secret; the
+public half ships in the bundle. The tools land in
+`.ducktable-cache/sparkle/<version>/bin` after any `scripts/macos-app.sh` run.
+
+```sh
+bin=.ducktable-cache/sparkle/2.9.4/bin
+$bin/generate_keys --account ducktable          # creates the key, prints the public half
+$bin/generate_keys --account ducktable -p > assets/sparkle-public-key.txt
+$bin/generate_keys --account ducktable -x /tmp/ducktable-sparkle-key.txt
+gh secret set SPARKLE_PRIVATE_KEY --repo shreeve/duckdb-harbor < /tmp/ducktable-sparkle-key.txt
+rm /tmp/ducktable-sparkle-key.txt
+```
+
+Commit `assets/sparkle-public-key.txt`. Back the private key up somewhere
+durable: lose it and every installed copy is stranded on its version forever,
+because an app only trusts the key it shipped with.
+
+### 2. Nothing else
+
+No Developer ID, no notarization. The bundle is ad-hoc signed, as it was;
+Sparkle verifies that an update's signature is valid and its EdDSA signature
+matches, and both hold for an ad-hoc bundle. The installer still avoids
+Gatekeeper the same way, by never being quarantined.
+
+## Cutting a release
+
+Unchanged: bump `version` in `Cargo.toml`, note it in `CHANGELOG.md`, push a
+`ducktable-vX.Y.Z` tag. The workflow builds the bundle, creates the versioned
+release, then downloads the feed release, adds `DuckTable-X.Y.Z.zip`, runs
+`scripts/appcast.sh`, and uploads the result back with `--clobber`. Installed
+copies pick it up on their next scheduled check, once a day, or on Check for
+Updates.
+
+The workflow fails, rather than publishing a feed nobody can verify, if the
+secret is missing or does not match the public key in the bundle.
+
+## Trying it locally
+
+Debug builds keep the updater dormant so the dev bundle never offers to
+replace itself. To exercise the real flow from one:
+
+```sh
+scripts/macos-app.sh
+DUCKTABLE_FORCE_UPDATER=1 open target/DuckTable.app
+```
+
+Check for Updates then talks to the real feed. A first launch of any bundle
+also gets Sparkle's one-time prompt asking whether to check automatically;
+the answer is stored in the app's defaults under `com.shreeve.ducktable`.
+
+To rehearse an actual update without publishing, build two bundles at
+different versions, run `scripts/appcast.sh` over a directory holding the
+newer one as `DuckTable-<version>.zip`, serve that directory with any static
+server, and point the older bundle at it by editing `SUFeedURL` in its
+Info.plist before signing.

--- a/ducktable/scripts/appcast.sh
+++ b/ducktable/scripts/appcast.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# appcast.sh — sign the update archives in <updates-dir> and (re)write its
+# appcast.xml, the Sparkle feed the app reads from the `ducktable-updates`
+# GitHub release (docs/UPDATES.md).
+#
+#   scripts/appcast.sh <updates-dir>
+#
+# <updates-dir> holds DuckTable-<version>.zip for the new release plus any
+# older archives already on the feed release, so Sparkle can build binary
+# deltas against them and keep their items. Every enclosure URL is the feed
+# release's download URL for that file name.
+#
+# The private EdDSA key comes from SPARKLE_PRIVATE_KEY (CI, fed on stdin so
+# it never lands on disk), otherwise from the login keychain account
+# "ducktable" that `generate_keys --account ducktable` created.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+updates_dir="${1:?usage: scripts/appcast.sh <updates-dir>}"
+[ -d "$updates_dir" ] || { echo "error: $updates_dir is not a directory" >&2; exit 1; }
+
+. scripts/sparkle.sh
+ensure_sparkle
+generator="$sparkle_dir/bin/generate_appcast"
+
+feed_prefix="https://github.com/shreeve/duckdb-harbor/releases/download/ducktable-updates/"
+args=(
+    --download-url-prefix "$feed_prefix"
+    --link "https://github.com/shreeve/duckdb-harbor"
+    --maximum-deltas 2
+)
+
+if [ -n "${SPARKLE_PRIVATE_KEY:-}" ]; then
+    printf '%s\n' "$SPARKLE_PRIVATE_KEY" | "$generator" "${args[@]}" --ed-key-file - "$updates_dir"
+else
+    "$generator" "${args[@]}" --account ducktable "$updates_dir"
+fi
+
+# generate_appcast exits 0 after writing an *unsigned* feed when its key does
+# not match the bundle's SUPublicEDKey, and Sparkle rejects an unsigned
+# enclosure — so a silent mismatch would ship a dead update feed.
+appcast="$updates_dir/appcast.xml"
+unsigned=$(grep -o '<enclosure[^>]*>' "$appcast" | grep -v 'sparkle:edSignature=' || true)
+if [ -n "$unsigned" ]; then
+    echo "error: appcast has unsigned enclosures; the signing key does not match SUPublicEDKey:" >&2
+    echo "$unsigned" >&2
+    exit 1
+fi
+echo "Wrote $appcast"

--- a/ducktable/scripts/macos-app.sh
+++ b/ducktable/scripts/macos-app.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Assembles DuckTable.app so macOS gives the app its own icon and identity
-# instead of attributing the bare binary to whatever terminal launched it.
+# instead of attributing the bare binary to whatever terminal launched it,
+# embeds Sparkle for in-app updates (docs/UPDATES.md), and ad-hoc signs the
+# result so Sparkle can verify what it installs.
 # Usage: scripts/macos-app.sh [debug|release]   (default: debug)
 set -e
 cd "$(dirname "$0")/.."
@@ -13,14 +15,45 @@ else
 fi
 
 # The bundle says the workspace's version, not a hardcoded one — About
-# and Finder must never disagree with the binary they describe.
+# and Finder must never disagree with the binary they describe. It is also
+# the build number: Sparkle orders updates by CFBundleVersion, so that has
+# to change every release, and the dotted version already does.
 version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 
+# The public half of the update-signing key (assets/sparkle-public-key.txt,
+# from `generate_keys --account ducktable -p`). Without it Sparkle refuses
+# to start and the app simply has no Check for Updates item — a bundle that
+# runs, not one that lies about updating.
+feed_url="https://github.com/shreeve/duckdb-harbor/releases/download/ducktable-updates/appcast.xml"
+public_key=""
+if [ -f assets/sparkle-public-key.txt ]; then
+    public_key=$(tr -d '[:space:]' < assets/sparkle-public-key.txt)
+fi
+if [ -n "$public_key" ]; then
+    sparkle_keys="    <key>SUFeedURL</key><string>$feed_url</string>
+    <key>SUPublicEDKey</key><string>$public_key</string>"
+else
+    sparkle_keys=""
+    echo "note: assets/sparkle-public-key.txt is missing; the bundle will not check for updates (docs/UPDATES.md)" >&2
+fi
+
+. scripts/sparkle.sh
+ensure_sparkle
+
 app="target/DuckTable.app"
+frameworks="$app/Contents/Frameworks"
+framework="$frameworks/Sparkle.framework"
 rm -rf "$app"
-mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources" "$frameworks"
 cp "target/$profile/ducktable" "$app/Contents/MacOS/ducktable"
 cp assets/AppIcon.icns "$app/Contents/Resources/AppIcon.icns"
+cp -R "$sparkle_dir/Sparkle.framework" "$framework"
+# DuckTable is not sandboxed, so Sparkle's XPC services never run; drop them
+# with the header and module folders so the shipped framework carries no dev
+# artifacts and no unsigned nested code.
+for extra in XPCServices Headers PrivateHeaders Modules; do
+    rm -rf "$framework/$extra" "$framework/Versions/B/$extra"
+done
 
 cat > "$app/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -34,11 +67,23 @@ cat > "$app/Contents/Info.plist" <<PLIST
     <key>CFBundleIconFile</key><string>AppIcon</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>CFBundleShortVersionString</key><string>$version</string>
-    <key>CFBundleVersion</key><string>1</string>
+    <key>CFBundleVersion</key><string>$version</string>
     <key>LSMinimumSystemVersion</key><string>12.0</string>
     <key>NSHighResolutionCapable</key><true/>
+$sparkle_keys
 </dict>
 </plist>
 PLIST
+
+# Finder info and resource forks on copied files make codesign reject the
+# bundle as "detritus"; strip extended attributes before signing. Sparkle's
+# nested executables sign first, then the framework, then the app, all
+# ad-hoc: Sparkle verifies an update's signature is valid, and ad-hoc is.
+xattr -cr "$app"
+codesign --force --sign - "$framework/Versions/B/Autoupdate"
+codesign --force --sign - "$framework/Versions/B/Updater.app"
+codesign --force --sign - "$framework"
+codesign --force --sign - "$app"
+codesign --verify --deep --strict "$app"
 
 echo "$app"

--- a/ducktable/scripts/sparkle.sh
+++ b/ducktable/scripts/sparkle.sh
@@ -1,0 +1,24 @@
+# Sparkle, pinned. Sourced by macos-app.sh (which embeds the framework) and
+# appcast.sh (which signs releases with the same distribution's bin/ tools),
+# so both come from one archive cached outside target/ where `cargo clean`
+# cannot evict it. Bump the version and checksum together.
+#
+# Sourcing sets $sparkle_dir; ensure_sparkle populates it on first use.
+sparkle_version="2.9.4"
+sparkle_sha256="ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"
+sparkle_cache_root=".ducktable-cache/sparkle"
+sparkle_dir="$sparkle_cache_root/$sparkle_version"
+
+ensure_sparkle() {
+    [ -d "$sparkle_dir/Sparkle.framework" ] && return 0
+    staging="$sparkle_cache_root/.staging-$sparkle_version-$$"
+    rm -rf "$staging"
+    mkdir -p "$staging"
+    archive="$staging/Sparkle-$sparkle_version.tar.xz"
+    curl -fsSL --retry 3 -o "$archive" \
+        "https://github.com/sparkle-project/Sparkle/releases/download/$sparkle_version/Sparkle-$sparkle_version.tar.xz"
+    echo "$sparkle_sha256  $archive" | shasum -a 256 -c - >/dev/null
+    tar -xJf "$archive" -C "$staging" ./Sparkle.framework ./bin
+    rm "$archive"
+    mv "$staging" "$sparkle_dir"
+}


### PR DESCRIPTION
DuckTable → Check for Updates…, and a daily check once the user says yes to Sparkle's first-launch prompt. The Waku model, minus the parts Waku needs and DuckTable does not.

### What ships in the bundle

- `scripts/macos-app.sh` fetches a checksum-pinned Sparkle 2.9.4 into `.ducktable-cache/`, embeds it at `Contents/Frameworks`, and ad-hoc signs framework then app. Sparkle verifies what it installs, and the EdDSA signature carries the trust, so ad-hoc is enough.
- `CFBundleVersion` was a constant `1`, which would have made every release look like the same build to Sparkle. It is now the workspace version.
- `SUFeedURL` and `SUPublicEDKey` come from `assets/sparkle-public-key.txt`. Without that file the script builds a working bundle with no updater and says so.

### What runs in the app

- `crates/ducktable/src/updater.rs` loads the embedded framework with `dlopen`, starts `SPUUpdater` with Sparkle's own standard user driver, and forwards the menu item. Every window the user sees is Sparkle's.
- Debug builds keep the updater dormant so the dev bundle never offers to replace itself; `DUCKTABLE_FORCE_UPDATER=1` exercises the real flow from one. A bundle that could not start the updater has no menu item.

### Where the feed lives

GitHub Releases only. Sparkle needs one URL that always serves the current appcast and GitHub's per-version URLs carry the tag, so one release that never changes name, **`ducktable-updates`**, holds the appcast, `DuckTable-<version>.zip` for every version on the feed, and the binary deltas. It is a prerelease and never `--latest`, so `/releases/latest` stays harbor's and `install.sh`, which resolves `ducktable-v*` tags by name, never sees it.

`DuckTableRelease.yml` refreshes it after the versioned release: download what is there, add this version, sign with the `SPARKLE_PRIVATE_KEY` secret through `scripts/appcast.sh`, upload back with `--clobber`. The smoke test refuses to release a bundle without the public key, and `appcast.sh` refuses to write a feed whose enclosures are unsigned.

### Setup already done

The key pair exists in the login keychain (account `ducktable`), the public half is committed, and the repository secret is set. `docs/UPDATES.md` records all of it, plus a local rehearsal recipe.

### Verified

`cargo check` and clippy clean on the touched files; the three scripts pass syntax checks; the workflow parses. A debug bundle built with the framework embedded and, run with the updater forced on, left Sparkle's first-launch marker in the app's defaults, which only happens once the framework has loaded and the updater started. An actual update installing needs a published feed, so the first tagged release after this merges exercises that end to end.

### After merging

Existing 0.20.x installs have no Sparkle in them and cannot update themselves to the first Sparkle-enabled version; that one is installed with the README one-liner as before. Every version after it arrives through the app.
