### PR TITLE
Choose a block size, run group statements, refuse a lost USE

### DIFF
--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,36 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.34.0 — 2026-09-09
+
+- **`USE` outside a session is now refused instead of silently discarded.**
+  It sets the current database on the connection it runs on; that connection
+  is pooled, and a request carries exactly one statement, so nothing could
+  ever follow it there. It reported success and was thrown away, every time.
+  The refusal names the session that does persist (`POST /sql/sessions`) and
+  the qualified names — `database.schema.table` — that need no session at all.
+  Inside a session `USE` is unchanged.
+- Adds `--block-size` and the matching `block-size` config key: the block size
+  for a database the call CREATES, from 16k to 256k. A block is both the unit
+  of allocation and the window a column's compression works in, and the
+  default suits few large tables rather than many small ones — a dozen
+  near-empty tables cost 9.5 MiB at 256k. It travels as an open-time option
+  because a later `SET` cannot reach it.
+- `default_block_size` under `[settings]` is now dropped and reported rather
+  than emitted as a `SET` that succeeds and changes nothing, and a server
+  asked for a block size the file does not have says so — block size is fixed
+  when a database is created, so a config naming another one was a wish that
+  read like a setting.
+- Fixes statements that expand to a group of statements — `COPY FROM DATABASE`
+  and `IMPORT DATABASE` — which could not run at all. The result schema was
+  read before anything had stepped, and for these the result-producing member
+  of the group is not prepared until something does. A failing group statement
+  now reports its own complaint rather than the readiness error that was only
+  how it surfaced.
+- The `unit` suite runs `--workspace --all-features`. `default-members` and two
+  off-by-default features had been hiding 101 tests — all of `crates/justhttp`
+  and all of the config reader — which compiled but never ran.
+
 ## 0.33.1 — 2026-09-06
 
 - A verb typed without a database (`harbor restart`) now names the attached

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.33.1"
+version = "0.34.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/crates/common/src/config.rs
+++ b/harbor/crates/common/src/config.rs
@@ -87,6 +87,7 @@ pub struct Connection {
     pub workers: Option<usize>,
     pub statement_timeout: Option<String>,
     pub max_temp_size: Option<String>,
+    pub block_size: Option<String>,
     pub sealed: Option<bool>,
     pub unsigned: Option<bool>,
     pub log: Option<bool>,
@@ -140,9 +141,32 @@ impl Connection {
         let mut keys: Vec<&String> = settings.keys().collect();
         keys.sort();
         keys.into_iter()
+            .filter(|k| !is_open_time_only(k))
             .filter_map(|k| sql_literal(&settings[k]).map(|lit| format!("SET {k} = {lit}")))
             .collect()
     }
+
+    /// Keys in `[settings]` that setting_statements refused, so the caller
+    /// can say so. Silence here would be the worst outcome: the SET runs,
+    /// reports success, and changes nothing.
+    pub fn rejected_settings(&self) -> Vec<&str> {
+        let Some(settings) = &self.settings else { return Vec::new() };
+        let mut out: Vec<&str> =
+            settings.keys().map(String::as_str).filter(|k| is_open_time_only(k)).collect();
+        out.sort_unstable();
+        out
+    }
+}
+
+/// Settings that are chosen when the database is OPENED and cannot be
+/// reached by a later SET — the SET succeeds and does nothing. Each has a
+/// config key of its own; `[settings]` is the wrong door for them.
+///
+/// `default_block_size` is the whole list today. It fixes a database file's
+/// block size at creation, which is exactly the moment before any statement
+/// can run — use `block-size` instead.
+pub fn is_open_time_only(key: &str) -> bool {
+    matches!(key.trim().to_ascii_lowercase().as_str(), "default_block_size")
 }
 
 /// A scalar TOML value as a DuckDB SQL literal: strings single-quoted (with
@@ -277,6 +301,20 @@ pub fn load() -> Result<FileConfig, Error> {
 
 #[cfg(test)]
 mod tests {
+
+    /// `default_block_size` cannot be reached by SET, so naming it in
+    /// `[settings]` would emit a statement that succeeds and does nothing.
+    /// It is dropped from the emitted SETs and reported separately.
+    #[test]
+    fn open_time_settings_are_refused_not_emitted() {
+        let c: Connection = toml::from_str(
+            "path = \"/tmp/x.duckdb\"\n[settings]\ndefault_block_size = 65536\nthreads = 3\n",
+        )
+        .expect("parse");
+        let sets = c.setting_statements();
+        assert_eq!(sets, ["SET threads = 3"], "the reachable setting still goes out");
+        assert_eq!(c.rejected_settings(), ["default_block_size"]);
+    }
     use super::*;
 
     const SAMPLE: &str = r#"

--- a/harbor/crates/harbor/src/engine/conn.rs
+++ b/harbor/crates/harbor/src/engine/conn.rs
@@ -179,8 +179,13 @@ impl Conn {
         for stmt in stmts.iter() {
             // In place, no fetch thread: boot-time helpers read a handful
             // of rows and should not depend on spawn succeeding.
-            let (mut fetcher, columns) = self.open_result(stmt, &[])?;
-            while let Some(chunk) = fetcher.next_chunk()? {
+            let (mut fetcher, mut held, columns) = self.open_result(stmt, &[])?;
+            // `held` first, then the rest: it is a chunk already taken off
+            // the result, not a chunk still to come.
+            while let Some(chunk) = match held.take() {
+                Some(c) => Some(c),
+                None => fetcher.next_chunk()?,
+            } {
                 let readers = chunk.readers(columns.len().min(1))?;
                 if let (Some(reader), Some((_, ty))) = (readers.first(), columns.first()) {
                     for row in 0..chunk.rows {
@@ -269,10 +274,22 @@ impl Conn {
     }
 
     /// Execute one parsed statement into a live result: the Fetcher that
-    /// owns it plus its prepare-time columns. The shared front half of
-    /// `execute` (which pipelines it) and `drain` (which consumes it in
-    /// place).
-    fn open_result(&self, stmt: &Stmt, params: &[Param]) -> Result<(Fetcher, Vec<(String, Type)>), Error> {
+    /// owns it, a chunk already taken off it, and its columns. The shared
+    /// front half of `execute` (which pipelines it) and `drain` (which
+    /// consumes it in place).
+    ///
+    /// The held chunk is normally None. It is Some only for a statement
+    /// that expands to a GROUP of statements — `COPY FROM DATABASE`,
+    /// `IMPORT DATABASE` — where the schema cannot be read until the
+    /// result-producing member of the group has been prepared, and the
+    /// only way to prepare it is to step. That step yields a chunk, and a
+    /// chunk cannot be pushed back, so it travels out with the result and
+    /// every caller must consume it FIRST. Losing it truncates the result.
+    fn open_result(
+        &self,
+        stmt: &Stmt,
+        params: &[Param],
+    ) -> Result<(Fetcher, Option<Chunk>, Vec<(String, Type)>), Error> {
         let api = &self.eng.api;
 
         // Params go in as owned values, positional ($1 = element 0).
@@ -310,15 +327,38 @@ impl Conn {
         executed?;
 
         // From here the Fetcher owns the result and destroys it on drop.
-        let fetcher = Fetcher { eng: self.eng, result };
-        let columns = result_columns(api, result)?;
-        Ok((fetcher, columns))
+        let mut fetcher = Fetcher { eng: self.eng, result };
+
+        // Ask first, step only if asking failed. The ordinary statement —
+        // every SELECT, every INSERT — answers here and never steps on
+        // this thread, which matters: next_chunk carries a step budget and
+        // falls back to a blocking fetch, and moving that work off the
+        // fetch thread would serialise the first chunk against the caller.
+        //
+        // Deliberately keyed on the failure, not on the statement type:
+        // the set of group-expanding statements is DuckDB's to grow, and a
+        // retry that asks again after one step needs no list of them.
+        match result_columns(api, result) {
+            Ok(columns) => Ok((fetcher, None, columns)),
+            Err(first) => {
+                // A step that fails carries the REAL complaint — the group's
+                // own error, the one naming the table or the file. The
+                // schema error above is only how it reached us, so it is
+                // dropped rather than reported over the top of it.
+                let held = fetcher.next_chunk()?;
+                // Still no schema after a successful step means the first
+                // error was never about readiness. Report that one — it is
+                // the one that describes what actually went wrong.
+                let columns = result_columns(api, result).map_err(|_| first)?;
+                Ok((fetcher, held, columns))
+            }
+        }
     }
 
     /// Execute one parsed statement as a pipelined stream. The statement is
     /// borrowed, not consumed.
     pub fn execute(&self, stmt: &Stmt, params: &[Param]) -> Result<Stream, Error> {
-        let (fetcher, columns) = self.open_result(stmt, params)?;
+        let (fetcher, pending, columns) = self.open_result(stmt, params)?;
         let (tx, rx) = mpsc::sync_channel(PREFETCH);
         let join = thread::Builder::new()
             .name("harbor-fetch".into())
@@ -329,6 +369,7 @@ impl Conn {
             })?;
         Ok(Stream {
             columns,
+            pending,
             rx: Some(rx),
             join: Some(join),
             interrupt: Interrupt { eng: self.eng, conn: self.interrupt.clone() },
@@ -340,7 +381,7 @@ impl Conn {
     /// pipeline is pure overhead: a spawn and a join to stream chunks that
     /// will be discarded.
     pub fn drain(&self, stmt: &Stmt) -> Result<(), Error> {
-        let (mut fetcher, _) = self.open_result(stmt, &[])?;
+        let (mut fetcher, _held, _) = self.open_result(stmt, &[])?;
         while fetcher.next_chunk()?.is_some() {}
         Ok(())
     }
@@ -417,6 +458,11 @@ pub struct Stream {
     /// The result's columns. Public so a caller can `mem::take` them and
     /// keep them across the mutable borrows the chunk loop needs.
     pub columns: Vec<(String, Type)>,
+    /// A chunk already taken off the result before the fetch thread got
+    /// it — see open_result. Handed out before anything from the channel,
+    /// because it came off the result first; a stream that skipped it
+    /// would drop its own opening rows.
+    pending: Option<Chunk>,
     /// Taken on the stream's terminal message (end or error) and on drop —
     /// dropping the receiver is what makes the fetch thread's next send
     /// fail and stop fetching.
@@ -446,6 +492,9 @@ impl Stream {
     /// the worst failure a result stream can have: a truncated result
     /// wearing a well-formed end record.
     pub fn next_chunk(&mut self) -> Result<Option<Chunk>, Error> {
+        if let Some(chunk) = self.pending.take() {
+            return Ok(Some(chunk));
+        }
         let Some(rx) = self.rx.as_ref() else {
             return Ok(None);
         };

--- a/harbor/crates/harbor/src/engine/mod.rs
+++ b/harbor/crates/harbor/src/engine/mod.rs
@@ -189,7 +189,7 @@ fn boot(lib: Library, path: PathBuf) -> Result<Engine, String> {
 }
 
 /// A failed v2 call: the structured code plus the engine's rendered text.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Error {
     pub code: ffi::ERROR,
     pub message: String,

--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -3279,6 +3279,31 @@ fn run_sql(
         return (true, 400);
     }
 
+    // `USE` sets the CURRENT DATABASE on the connection it runs on, and
+    // outside a session that connection is a pooled one that goes back to the
+    // pool when this request ends. Since a request carries exactly one
+    // statement (`ensure_single_statement`, just above), nothing can ever
+    // follow it on that connection — so the USE reports success and is
+    // discarded, every time. There is no case where the old behaviour was
+    // useful, which is what makes refusing safe rather than merely stricter.
+    //
+    // A session is the connection that persists, and inside one USE works
+    // normally; qualifying names (`db.schema.table`) needs no session at all.
+    // Other connection-local state — temp tables, PREPARE, session-scoped
+    // SET — is silently lost the same way; USE is fenced because it is the
+    // one whose whole purpose is to change what the NEXT statement sees.
+    if parsed.session.is_none() && lost_without_session(&parsed.sql) {
+        let _ = req.respond(error_response(
+            400,
+            "sql_error",
+            "USE has no effect outside a session: this connection returns to the pool when \
+             the request ends, and one request carries one statement, so nothing runs on it \
+             afterward. Open a session (POST /sql/sessions) and send USE on that, or qualify \
+             names instead — database.schema.table",
+        ));
+        return (true, 400);
+    }
+
     let shape = if wants_one_shot(&req) { Shape::Json } else { Shape::Ndjson };
 
     // A statement naming a lease goes to that lease's connection, wherever it
@@ -3524,6 +3549,17 @@ fn fenced_setting(sql: &str) -> Option<&'static str> {
         name = next_word(b, &mut i);
     }
     FENCED.iter().find(|f| name.eq_ignore_ascii_case(f)).copied()
+}
+
+/// Statements whose whole effect is connection-local, so a pooled connection
+/// discards it the moment the request ends. Companion to `fenced_setting`:
+/// that one refuses what would reach TOO far (process-global), this one
+/// refuses what would not reach far enough.
+///
+/// `USE` is the list. Reads through comments and whitespace via
+/// `first_keyword`, so `/*x*/ USE d` is caught with the bare form.
+fn lost_without_session(sql: &str) -> bool {
+    first_keyword(sql) == "USE"
 }
 
 /// What a statement does to the surrounding transaction, when that is knowable
@@ -4173,7 +4209,21 @@ mod tests {
     use super::Method;
     use crate::encode::civil_from_days;
     use super::ensure_single_statement as one;
-    use super::fenced_setting;
+    use super::{fenced_setting, lost_without_session};
+
+    /// USE outside a session is refused, not silently discarded: one request
+    /// carries one statement, so nothing can follow it on that connection.
+    #[test]
+    fn use_is_fenced_when_no_session_holds_the_connection() {
+        for sql in ["USE mydb", "use mydb", "  USE  mydb ", "/*x*/ USE mydb", "--c\nUSE mydb"] {
+            assert!(lost_without_session(sql), "should be fenced: {sql:?}");
+        }
+        // Statements that merely mention the word are untouched.
+        for sql in ["SELECT 'USE'", "CREATE TABLE use_log(i INT)", "SELECT * FROM t"] {
+            assert!(!lost_without_session(sql), "should pass: {sql:?}");
+        }
+    }
+
     use super::route_exists;
     use super::index_columns;
     use super::{IndexPart, catalog_count_sql, index_parts};

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -423,6 +423,11 @@ start options:
                        file access, no community extensions
   --statement-timeout <d>  hard deadline ceiling per statement (e.g. 30s)
   --max-temp-size <s>  cap spill-to-disk (e.g. 10GB; default: DuckDB's own)
+  --block-size <s>     block size for a database this call CREATES: 16k, 32k,
+                       64k, 128k or 256k (default: DuckDB's own 256k). Fixed
+                       at creation — ignored, with a warning, for a file that
+                       already exists. 64k suits many small tables; 256k suits
+                       few large ones
   --log                log requests to stderr
   --foreground         run in this terminal until Ctrl-C, output here, no
                        prompt — for watching a server work
@@ -441,6 +446,7 @@ struct Opts {
     sealed: bool,
     statement_timeout: Option<Duration>,
     max_temp_size: Option<String>,
+    block_size: Option<u64>,
     foreground: bool,
 }
 
@@ -459,6 +465,7 @@ fn default_opts(db: PathBuf) -> Opts {
         sealed: false,
         statement_timeout: None,
         max_temp_size: None,
+        block_size: None,
         foreground: false,
     }
 }
@@ -513,6 +520,18 @@ fn apply_berth_config(o: &mut Opts, canon: &Path, ephemeral: bool) {
     if let Some(v) = &c.max_temp_size {
         o.max_temp_size = Some(v.clone());
     }
+    if let Some(v) = &c.block_size {
+        match parse_block_size(v) {
+            Ok(n) => o.block_size = Some(n),
+            Err(e) => eprintln!("harbor: ignoring block-size — {e}"),
+        }
+    }
+    for key in c.rejected_settings() {
+        eprintln!(
+            "harbor: [settings] {key} is ignored — it is chosen when the database is \
+             opened, so a SET cannot reach it; use the `block-size` key instead"
+        );
+    }
     if let Some(v) = &c.statement_timeout
         && let Ok(d) = parse_duration(v)
     {
@@ -550,6 +569,7 @@ fn parse_opts(mut o: Opts, rest: Vec<String>) -> Result<Opts, String> {
             "--port" => o.port = Some(take("port")?.parse().map_err(|_| "bad --port")?),
             "--workers" => o.workers = take("workers")?.parse().map_err(|_| "bad --workers")?,
             "--memory-limit" => o.memory_limit = take("memory-limit")?,
+            "--block-size" => o.block_size = Some(parse_block_size(&take("block-size")?)?),
             "--threads" => o.threads = Some(take("threads")?.parse().map_err(|_| "bad --threads")?),
             "--init" => o.init.push(take("init")?),
             "--log" => o.log = true,
@@ -811,6 +831,29 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     Ok(())
 }
 
+/// A block size as bytes: `65536`, or a `k`/`kb`/`kib` suffix on the number
+/// people actually say — `64k`. DuckDB takes only a power of two from 16 KiB
+/// to 256 KiB, and refusing the rest HERE rather than at open means the
+/// complaint can name the flag and list the answers.
+fn parse_block_size(s: &str) -> Result<u64, String> {
+    let t = s.trim().to_ascii_lowercase();
+    let digits = t.trim_end_matches(|c: char| c.is_ascii_alphabetic());
+    let unit = &t[digits.len()..];
+    let n: u64 = digits.parse().map_err(|_| format!("bad --block-size {s:?}"))?;
+    let bytes = match unit {
+        "" | "b" => n,
+        "k" | "kb" | "kib" => n * 1024,
+        _ => return Err(format!("bad --block-size {s:?} — use bytes or a k suffix, e.g. 64k")),
+    };
+    if !(16384..=262144).contains(&bytes) || !bytes.is_power_of_two() {
+        return Err(format!(
+            "bad --block-size {s:?} — DuckDB takes a power of two from 16k to 256k \
+             (16k, 32k, 64k, 128k, 256k)"
+        ));
+    }
+    Ok(bytes)
+}
+
 fn duckdb_open(o: &Opts) -> Result<harbor::engine::conn::Conn, String> {
     // The engine loads on first use — the binary itself has no load-time
     // libduckdb dependency, so invocations that never open a database run
@@ -829,7 +872,16 @@ fn duckdb_open(o: &Opts) -> Result<harbor::engine::conn::Conn, String> {
     //               (the test fixtures themselves load CSV), so the safe edge
     //               is the operator's to draw, like TLS.
     // Signed-only, full-access is the default; each is opt-in.
+    //   --block-size  default_block_size — a database file's block size, fixed
+    //               when the file is CREATED. Applies to nothing else: an
+    //               existing file keeps the size it was born with, and the
+    //               check after open says so rather than letting the option
+    //               look like it worked.
+    let block_size = o.block_size.map(|n| n.to_string());
     let mut options: Vec<(&str, &str)> = Vec::new();
+    if let Some(bs) = &block_size {
+        options.push(("default_block_size", bs));
+    }
     if o.unsigned {
         options.push(("allow_unsigned_extensions", "true"));
     }
@@ -850,5 +902,54 @@ fn duckdb_open(o: &Opts) -> Result<harbor::engine::conn::Conn, String> {
         con.execute_batch(&format!("SET max_temp_directory_size='{s}'"))
             .map_err(|e| format!("max_temp_size: {e}"))?;
     }
+    // Asked for a block size but opened a file that already had one? DuckDB
+    // accepts the option and ignores it, so without this the config reads as
+    // a setting and behaves as a wish. Not fatal — the database is fine, it
+    // is only not the shape the operator asked for — but never silent.
+    if let Some(want) = o.block_size
+        && let Ok(rows) = con.query_strings("SELECT block_size::VARCHAR FROM pragma_database_size()")
+        && let Some(got) = rows.first().and_then(|r| r.parse::<u64>().ok())
+        && got != want
+    {
+        eprintln!(
+            "harbor: {} has {got}-byte blocks, --block-size asked for {want} — block size is \
+             fixed when a database is created; EXPORT DATABASE and replay into a new file \
+             to change it",
+            o.db.display()
+        );
+    }
     Ok(con)
+}
+
+#[cfg(test)]
+mod block_size_tests {
+    use super::parse_block_size;
+
+    #[test]
+    fn accepts_the_five_sizes_duckdb_takes() {
+        for (text, want) in [
+            ("16k", 16384u64),
+            ("32K", 32768),
+            ("64kb", 65536),
+            ("128KiB", 131072),
+            ("256k", 262144),
+            ("65536", 65536), // bare bytes
+            (" 64k ", 65536), // trimmed
+        ] {
+            assert_eq!(parse_block_size(text).unwrap(), want, "{text}");
+        }
+    }
+
+    #[test]
+    fn refuses_everything_else_and_says_why() {
+        // Below the floor, above the ceiling, and a non-power-of-two between
+        // them — DuckDB rejects all three, so the flag does too, by name.
+        for text in ["8k", "512k", "48k", "0"] {
+            let e = parse_block_size(text).expect_err(text);
+            assert!(e.contains("power of two from 16k to 256k"), "{text}: {e}");
+        }
+        // A unit that is not a unit must not be read as bytes.
+        let e = parse_block_size("64X").expect_err("64X");
+        assert!(e.contains("k suffix"), "{e}");
+    }
 }

--- a/harbor/crates/harbor/tests/engine.rs
+++ b/harbor/crates/harbor/tests/engine.rs
@@ -301,6 +301,86 @@ mod conn {
         // Aims at nothing; must not crash.
         handle.interrupt();
     }
+
+    // -- statements that expand to a GROUP of statements --------------------
+    //
+    // COPY FROM DATABASE, IMPORT DATABASE. Their schema is unreadable until
+    // the group's result-producing member has been prepared, and only a step
+    // prepares it — so opening one takes a chunk off the result before the
+    // caller sees it, and that chunk has to reach the caller first.
+
+    const N: i64 = 5000; // > one 2048-row chunk, so the stream is multi-chunk
+    const SUM: i64 = N * (N - 1) / 2;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("harbor-groups-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// The guard that matters most: an ordinary multi-chunk SELECT must not
+    /// lose or repeat its opening rows now that a chunk can arrive out of band.
+    #[test]
+    fn ordinary_statements_deliver_every_row_once() {
+        let Some(_) = v2_engine() else { return };
+        let mut c = conn::open(Path::new(":memory:"), &[]).expect("open");
+        let got = rows(&mut c, &format!("SELECT i FROM range({N}) r(i)"), &[]).unwrap();
+        assert_eq!(got.len(), N as usize, "row count");
+        let total: i64 = got.iter().map(|r| r.parse::<i64>().unwrap()).sum();
+        assert_eq!(total, SUM, "checksum — a dropped or doubled chunk moves this");
+        assert_eq!(got[0], "0", "the first row survived the out-of-band path");
+    }
+
+    #[test]
+    fn copy_from_database_copies_every_row() {
+        let Some(_) = v2_engine() else { return };
+        let dir = scratch("copy");
+        let mut c = conn::open(&dir.join("src.duckdb"), &[]).expect("open");
+        c.execute_batch(&format!("CREATE TABLE t AS SELECT i FROM range({N}) r(i)")).unwrap();
+        c.execute_batch(&format!("ATTACH '{}' AS dst", dir.join("dst.duckdb").display())).unwrap();
+        c.execute_batch("COPY FROM DATABASE src TO dst").unwrap();
+        let got = rows(&mut c, "SELECT count(*)::BIGINT, sum(i)::BIGINT FROM dst.t", &[]).unwrap();
+        assert_eq!(got, [format!("{N},{SUM}")]);
+    }
+
+    #[test]
+    fn import_database_restores_every_row() {
+        let Some(_) = v2_engine() else { return };
+        let dir = scratch("import");
+        let exp = dir.join("exp");
+        let mut c = conn::open(&dir.join("src.duckdb"), &[]).expect("open");
+        c.execute_batch(&format!("CREATE TABLE t AS SELECT i FROM range({N}) r(i)")).unwrap();
+        c.execute_batch(&format!("EXPORT DATABASE '{}' (FORMAT parquet)", exp.display())).unwrap();
+
+        let mut r = conn::open(&dir.join("restored.duckdb"), &[]).expect("open restored");
+        r.execute_batch(&format!("IMPORT DATABASE '{}'", exp.display())).unwrap();
+        let got = rows(&mut r, "SELECT count(*)::BIGINT, sum(i)::BIGINT FROM t", &[]).unwrap();
+        assert_eq!(got, [format!("{N},{SUM}")]);
+    }
+
+    /// A group statement that genuinely fails reports ITS complaint, not the
+    /// schema-not-ready error that is only how the failure reached us.
+    #[test]
+    fn a_failing_group_statement_reports_its_own_error() {
+        let Some(_) = v2_engine() else { return };
+        let dir = scratch("err");
+        let exp = dir.join("exp");
+        let mut c = conn::open(&dir.join("src.duckdb"), &[]).expect("open");
+        c.execute_batch("CREATE TABLE t AS SELECT 1 AS i").unwrap();
+        c.execute_batch(&format!("EXPORT DATABASE '{}' (FORMAT parquet)", exp.display())).unwrap();
+
+        // Importing back over itself collides on `t`.
+        let err = c
+            .execute_batch(&format!("IMPORT DATABASE '{}'", exp.display()))
+            .expect_err("should collide on t");
+        assert!(err.message.contains("already exists"), "want the catalog complaint, got: {}", err.message);
+        assert!(
+            !err.message.contains("result metadata is not yet available"),
+            "the readiness error must not mask the real one: {}",
+            err.message
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/harbor/test/scripts/check.sh
+++ b/harbor/test/scripts/check.sh
@@ -89,7 +89,12 @@ skip() { skipped+=("$1"); printf '%s— %s skipped: %s%s\n' "$dim" "$1" "$2" "$o
 # The suites that need no server
 # ---------------------------------------------------------------------------
 
-run unit     cargo test --release
+# --workspace --all-features, both load-bearing. `default-members` is wire and
+# harbor, so a bare `cargo test` never sees crates/common or crates/justhttp;
+# and `config`/`membership` are off by default, so it never compiles the config
+# reader either. Between them that left 101 tests — every justhttp test and
+# every config test — building fine and running nowhere.
+run unit     cargo test --release --workspace --all-features
 # The lifetime doctrine runs the real binary in its own $HARBOR_HOME sandbox —
 # no shared server, and nothing it starts outlives it.
 run lifecycle "$here/test/scripts/lifecycle.sh"


### PR DESCRIPTION
Three fixes and the CI gap that was hiding one of them. Cuts **0.34.0**.

### `--block-size` / `block-size` config key

Picks the block size for a database the call *creates*, 16k–256k. Rides the open-time option vector beside `--unsigned`/`--sealed`, because `default_block_size` is one of the settings a later `SET` cannot reach.

A block is both the unit of allocation and the window a column's compression works in, so the 256k default suits few large tables and punishes many small ones — a dozen near-empty tables measured 9.5 MiB. The 16k floor is not the answer either: DuckDB abandons BitPacking on integer columns entirely and a million rows go from 14 MiB to 50. 64k held compression at every size measured.

Two silences refused with it:
- `default_block_size` under `[settings]` is dropped and reported, not emitted as a `SET` that succeeds and changes nothing.
- Opening a file whose blocks aren't the size asked for now says so, rather than letting a config read as a setting and behave as a wish.

### Group-expanding statements

`COPY FROM DATABASE` and `IMPORT DATABASE` could not run at all — `open_result` read the result schema before anything had stepped, and for these the result-producing member of the group isn't prepared until something does.

Now it asks first and steps only if asking failed, so ordinary statements never step on the calling thread and keep their pipelining. The chunk that step yields rides out on the stream for the caller to take first; losing it would truncate the result, so every caller consumes it before the channel. A failing group statement reports its own complaint instead of the readiness error that was only how it surfaced.

### `USE` outside a session — behavior change

**The one thing here that can change a working client.** `USE` sets the current database on the connection it runs on, that connection is pooled, and a request carries exactly one statement — so nothing could ever follow it there. It reported success and was discarded, every time.

Now refused, naming the session that does persist and the qualified names that need none. Unchanged inside a session, where it works correctly.

Safe because there was no working behavior to break, and I checked the blast radius: nothing in DuckTable, rip, or medlabs sends `USE`.

### The CI gap

`unit` now runs `--workspace --all-features`. `default-members` is wire and harbor, and `config`/`membership` are off by default — between them, **101 tests compiled on every run and executed on none**, including all of `crates/justhttp` and all of the config reader. That included the `[settings]` guard added here, which is the wrong way round for a release to ship.

### Verification

- `cargo test --release --workspace --all-features` — 206 passing, 3 ignored (was 105 reachable)
- `test/scripts/check.sh` — 12/12 suites, including stress, hostile, sessions, cancel
- No warnings