### PR TITLE
Let a summoned database choose its block size

### DIFF
--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -3517,6 +3517,29 @@ fn first_keyword(sql: &str) -> String {
     next_word(sql.as_bytes(), &mut 0)
 }
 
+/// A block size as bytes: `65536`, or a `k`/`kb`/`kib` suffix on the number
+/// people actually say — `64k`. DuckDB takes only a power of two from 16 KiB
+/// to 256 KiB, and refusing the rest HERE rather than at open means the
+/// complaint can name the flag and list the answers.
+pub fn parse_block_size(s: &str) -> Result<u64, String> {
+    let t = s.trim().to_ascii_lowercase();
+    let digits = t.trim_end_matches(|c: char| c.is_ascii_alphabetic());
+    let unit = &t[digits.len()..];
+    let n: u64 = digits.parse().map_err(|_| format!("bad --block-size {s:?}"))?;
+    let bytes = match unit {
+        "" | "b" => n,
+        "k" | "kb" | "kib" => n * 1024,
+        _ => return Err(format!("bad --block-size {s:?} — use bytes or a k suffix, e.g. 64k")),
+    };
+    if !(16384..=262144).contains(&bytes) || !bytes.is_power_of_two() {
+        return Err(format!(
+            "bad --block-size {s:?} — DuckDB takes a power of two from 16k to 256k \
+             (16k, 32k, 64k, 128k, 256k)"
+        ));
+    }
+    Ok(bytes)
+}
+
 /// Settings a client must not change: they are process-global in DuckDB, so
 /// one `SET memory_limit='100GB'` raises it for every neighbor berth on the
 /// host and defeats the fleet-safe cap the operator chose at berth start.

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -408,6 +408,10 @@ client options:
   -c \"SQL\"                     run statements and exit (stdin works too)
   --mode <m>                   duckbox, duckboxy, markdown, csv, json, jsonlines, line, list, trash
   --json                       shorthand for --mode jsonlines
+  --block-size <s>             when this call CREATES the database, its block
+                               size: 16k, 32k, 64k, 128k or 256k. Ignored,
+                               with a word, if a server is already up — the
+                               size is fixed when the file is made
 
 start options:
   --port <p>           also listen on TCP, beside the unix socket — loopback
@@ -427,7 +431,8 @@ start options:
                        64k, 128k or 256k (default: DuckDB's own 256k). Fixed
                        at creation — ignored, with a warning, for a file that
                        already exists. 64k suits many small tables; 256k suits
-                       few large ones
+                       few large ones. Also a client option, for the database
+                       a bare `harbor <db>` summons into being
   --log                log requests to stderr
   --foreground         run in this terminal until Ctrl-C, output here, no
                        prompt — for watching a server work
@@ -521,7 +526,7 @@ fn apply_berth_config(o: &mut Opts, canon: &Path, ephemeral: bool) {
         o.max_temp_size = Some(v.clone());
     }
     if let Some(v) = &c.block_size {
-        match parse_block_size(v) {
+        match harbor::parse_block_size(v) {
             Ok(n) => o.block_size = Some(n),
             Err(e) => eprintln!("harbor: ignoring block-size — {e}"),
         }
@@ -569,7 +574,7 @@ fn parse_opts(mut o: Opts, rest: Vec<String>) -> Result<Opts, String> {
             "--port" => o.port = Some(take("port")?.parse().map_err(|_| "bad --port")?),
             "--workers" => o.workers = take("workers")?.parse().map_err(|_| "bad --workers")?,
             "--memory-limit" => o.memory_limit = take("memory-limit")?,
-            "--block-size" => o.block_size = Some(parse_block_size(&take("block-size")?)?),
+            "--block-size" => o.block_size = Some(harbor::parse_block_size(&take("block-size")?)?),
             "--threads" => o.threads = Some(take("threads")?.parse().map_err(|_| "bad --threads")?),
             "--init" => o.init.push(take("init")?),
             "--log" => o.log = true,
@@ -831,29 +836,6 @@ fn start(db: PathBuf, rest: Vec<String>, ephemeral: bool) -> Result<(), String> 
     Ok(())
 }
 
-/// A block size as bytes: `65536`, or a `k`/`kb`/`kib` suffix on the number
-/// people actually say — `64k`. DuckDB takes only a power of two from 16 KiB
-/// to 256 KiB, and refusing the rest HERE rather than at open means the
-/// complaint can name the flag and list the answers.
-fn parse_block_size(s: &str) -> Result<u64, String> {
-    let t = s.trim().to_ascii_lowercase();
-    let digits = t.trim_end_matches(|c: char| c.is_ascii_alphabetic());
-    let unit = &t[digits.len()..];
-    let n: u64 = digits.parse().map_err(|_| format!("bad --block-size {s:?}"))?;
-    let bytes = match unit {
-        "" | "b" => n,
-        "k" | "kb" | "kib" => n * 1024,
-        _ => return Err(format!("bad --block-size {s:?} — use bytes or a k suffix, e.g. 64k")),
-    };
-    if !(16384..=262144).contains(&bytes) || !bytes.is_power_of_two() {
-        return Err(format!(
-            "bad --block-size {s:?} — DuckDB takes a power of two from 16k to 256k \
-             (16k, 32k, 64k, 128k, 256k)"
-        ));
-    }
-    Ok(bytes)
-}
-
 fn duckdb_open(o: &Opts) -> Result<harbor::engine::conn::Conn, String> {
     // The engine loads on first use — the binary itself has no load-time
     // libduckdb dependency, so invocations that never open a database run
@@ -923,7 +905,6 @@ fn duckdb_open(o: &Opts) -> Result<harbor::engine::conn::Conn, String> {
 
 #[cfg(test)]
 mod block_size_tests {
-    use super::parse_block_size;
 
     #[test]
     fn accepts_the_five_sizes_duckdb_takes() {
@@ -936,7 +917,7 @@ mod block_size_tests {
             ("65536", 65536), // bare bytes
             (" 64k ", 65536), // trimmed
         ] {
-            assert_eq!(parse_block_size(text).unwrap(), want, "{text}");
+            assert_eq!(harbor::parse_block_size(text).unwrap(), want, "{text}");
         }
     }
 
@@ -945,11 +926,11 @@ mod block_size_tests {
         // Below the floor, above the ceiling, and a non-power-of-two between
         // them — DuckDB rejects all three, so the flag does too, by name.
         for text in ["8k", "512k", "48k", "0"] {
-            let e = parse_block_size(text).expect_err(text);
+            let e = harbor::parse_block_size(text).expect_err(text);
             assert!(e.contains("power of two from 16k to 256k"), "{text}: {e}");
         }
         // A unit that is not a unit must not be read as bytes.
-        let e = parse_block_size("64X").expect_err("64X");
+        let e = harbor::parse_block_size("64X").expect_err("64X");
         assert!(e.contains("k suffix"), "{e}");
     }
 }

--- a/harbor/crates/harbor/src/repl/interactive.rs
+++ b/harbor/crates/harbor/src/repl/interactive.rs
@@ -245,7 +245,7 @@ pub fn run(
                         DotResult::Quit => return std::process::ExitCode::SUCCESS,
                         DotResult::Handled => continue,
                         DotResult::Open(target) => {
-                            match crate::repl::resolve(&target) {
+                            match crate::repl::resolve(&target, &[]) {
                                 Ok((c, name)) => {
                                     // Moor at the new server before letting
                                     // the old mooring go: the switch must

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -36,6 +36,12 @@ use std::time::{Duration, Instant};
 
 /// Set by SIGINT while a statement streams (registered in cli_main);
 /// checked at every read tick. Cleared before each statement.
+/// Set when this invocation spawned the server it is talking to, rather
+/// than joining one already up. Only `--block-size` reads it, and only to
+/// tell the caller when their size had nothing to shape — a flag that
+/// silently does nothing is worse than one that is refused.
+static SPAWNED: AtomicBool = AtomicBool::new(false);
+
 static CANCEL: LazyLock<std::sync::Arc<AtomicBool>> =
     LazyLock::new(|| std::sync::Arc::new(AtomicBool::new(false)));
 static QUERY_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -67,12 +73,24 @@ pub fn cli_main(args: impl IntoIterator<Item = String>) -> ExitCode {
     let mut sql: Option<String> = None;
     let mut json = false;
     let mut mode: Option<String> = None;
+    let mut block_size: Option<String> = None;
 
     while let Some(a) = args.next() {
         match a.as_str() {
             "-c" | "--command" => match args.next() {
                 Some(v) => sql = Some(v),
                 None => return fail("-c needs the SQL to run"),
+            },
+            // Not a server tuning knob, which is why it is here and not
+            // only in config.toml: block size shapes the FILE, and this is
+            // one of the paths that creates a file. It reaches the server
+            // only when this call spawns one — see below.
+            "--block-size" => match args.next() {
+                Some(v) => match crate::parse_block_size(&v) {
+                    Ok(_) => block_size = Some(v),
+                    Err(e) => return fail(&e),
+                },
+                None => return fail("--block-size needs a size (16k, 32k, 64k, 128k, 256k)"),
             },
             "--json" => json = true,
             "--mode" => match args.next() {
@@ -91,10 +109,24 @@ pub fn cli_main(args: impl IntoIterator<Item = String>) -> ExitCode {
     let Some(target) = target else {
         return fail("which database? (harbor <db.duckdb> — or bare harbor to see what's running)");
     };
-    let (conn, name) = match resolve(&target) {
+    let spawn: Vec<String> = match &block_size {
+        Some(v) => vec!["--block-size".into(), v.clone()],
+        None => Vec::new(),
+    };
+    let (conn, name) = match resolve(&target, &spawn) {
         Ok(c) => c,
         Err(e) => return fail(&e),
     };
+    // A size that reached nothing is worth a word. It only shapes a file at
+    // the moment of creation, so joining a server that is already up — or
+    // opening a database that already exists — leaves it with nothing to do,
+    // and silence there reads exactly like success.
+    if block_size.is_some() && !SPAWNED.load(std::sync::atomic::Ordering::Relaxed) {
+        eprintln!(
+            "harbor: --block-size was not used — {name} is already being served, and a block \
+             size is fixed when a database is created"
+        );
+    }
     // The mooring, held for the life of this invocation: a spawned server
     // lives while anyone is connected, and between statements — a human
     // thinking at the prompt, a script paused mid-pipe — this silent open
@@ -248,7 +280,7 @@ pub fn deref_db(target: &str) -> Result<PathBuf, String> {
 /// connection and the name the prompt wears: what the server calls itself
 /// when the fleet resolved the target (so `harbor 1` prompts `ducks>`, not
 /// `1>`), the target's own stem otherwise.
-fn resolve(target: &str) -> Result<(Conn, String), String> {
+fn resolve(target: &str, spawn: &[String]) -> Result<(Conn, String), String> {
     if target.starts_with("http://") || target.starts_with("https://") {
         return Ok((Conn { transport: url_transport(target)? }, prompt_name(target)));
     }
@@ -258,7 +290,7 @@ fn resolve(target: &str) -> Result<(Conn, String), String> {
         // opened the way its path would be: joined or summoned.
         let row = fleet_find(target)?;
         if let Some(stopped) = row.stopped {
-            return Ok((Conn { transport: ensure_server(&stopped.db)? }, stopped.name));
+            return Ok((Conn { transport: ensure_server(&stopped.db, spawn)? }, stopped.name));
         }
         #[cfg(unix)]
         {
@@ -290,7 +322,7 @@ fn resolve(target: &str) -> Result<(Conn, String), String> {
         #[cfg(windows)]
         return Err("Unix socket targets are not supported on Windows; use http://host:port".into());
     }
-    Ok((Conn { transport: ensure_server(&p)? }, prompt_name(target)))
+    Ok((Conn { transport: ensure_server(&p, spawn)? }, prompt_name(target)))
 }
 
 /// Join the server that owns this file, or spawn one — this same binary,
@@ -298,10 +330,10 @@ fn resolve(target: &str) -> Result<(Conn, String), String> {
 /// socket with it when the last client leaves. The socket is identity, not
 /// registry: derived from the file's canonical path, so every spelling of the
 /// same file lands on the same server and no scan or sidecar is needed.
-fn ensure_server(path: &Path) -> Result<Transport, String> {
+fn ensure_server(path: &Path, spawn: &[String]) -> Result<Transport, String> {
     #[cfg(windows)]
     {
-        let _ = path;
+        let _ = (path, spawn);
         return Err(
             "spawn-on-use needs unix sockets; on Windows run `harbor <db> start --port <p>` \
              and connect to http://127.0.0.1:<p>"
@@ -317,7 +349,8 @@ fn ensure_server(path: &Path) -> Result<Transport, String> {
         if ready(&transport) {
             return Ok(transport);
         }
-        launch(&runtime, &canon, &sock, &[], true)?;
+        SPAWNED.store(true, std::sync::atomic::Ordering::Relaxed);
+        launch(&runtime, &canon, &sock, spawn, true)?;
         Ok(transport)
     }
 }

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -122,6 +122,22 @@ check "a bare word is refused, never served" 1 "names nothing running" \
   "$harbor" nosuchname -c "SELECT 1"
 if [[ -f $work/nosuchname ]]; then bad "a bare word conjured a file"; else ok "no file conjured for a bare word"; fi
 
+echo "— --block-size shapes the file a summon creates"
+# Block size is fixed when a database is CREATED, and a summon is one of the
+# ways a database gets created — so the flag has to reach the server this
+# client spawns, not just an explicit `start`.
+check "a summoned database takes the block size it was asked for" 0 "16384" \
+  "$harbor" "$work/sized.duckdb" --block-size 16k --mode csv \
+  -c "CREATE TABLE t AS SELECT 1 AS i; CHECKPOINT; SELECT block_size FROM pragma_database_size()"
+# ...and says so when it reached nothing, because the file already existed and
+# a server is already holding it. Silence here would read as success.
+check "the size is refused quietly when there is nothing to shape" 0 "was not used" \
+  "$harbor" "$work/sized.duckdb" --block-size 64k -c "SELECT 1"
+check "a size DuckDB will not take is refused by the client" 1 "power of two" \
+  "$harbor" "$work/other.duckdb" --block-size 48k -c "SELECT 1"
+if [[ -f $work/other.duckdb ]]; then bad "a refused size still conjured a file"; else ok "a refused size conjures no file"; fi
+"$harbor" "$work/sized.duckdb" stop >/dev/null 2>&1
+
 echo "— the server is everyone's: it lives while anyone is connected"
 sock=$(live_sock)
 # A silent open connection, well past the linger AND past justhttp's 5s read


### PR DESCRIPTION
`--block-size` was a start option only, so this failed:

```
$ harbor new.duckdb --block-size 16k -c "SELECT 1"
harbor: unexpected argument: --block-size
```

…on one of the two paths that *creates* a database. A summon opens a missing file exactly the way `start` does, and block size is the one property that can only be chosen at creation — so the flag now rides the summon too:

```
$ harbor new.duckdb --block-size 16k --mode csv -c "CREATE TABLE t AS SELECT 1; CHECKPOINT; SELECT block_size FROM pragma_database_size()"
block_size
16384
```

### Not silently ignored

It shapes a file only at the moment of creation, so joining a server that is already up leaves it with nothing to do. Dropping it quietly there reads exactly like success, so it doesn't:

```
harbor: --block-size was not used — sized is already being served, and a block
        size is fixed when a database is created
```

Same instinct as the server-side mismatch warning added in 0.34.0.

### One move

`parse_block_size` goes from `main.rs` to `lib.rs`. The client parser lives in the library and the flag parser lived in the binary; the validation has to be the same function in both, or the two doors disagree about what a block size is. That accounts for most of the `main.rs` diff — the function relocated, it didn't grow.

### Tests

Four new checks in the lifecycle suite, which drives the real binary across processes — the only place this behaviour is visible:

```
— --block-size shapes the file a summon creates
  ✓ a summoned database takes the block size it was asked for
  ✓ the size is refused quietly when there is nothing to shape
  ✓ a size DuckDB will not take is refused by the client
  ✓ a refused size conjures no file
```

Full suite 12/12. No version bump — this rides along with whatever lands next.