### PR TITLE
Back a database up to text, and restore it into a new one

### DIFF
--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,28 +4,30 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
-## Unreleased
+## 0.35.0 — 2026-09-09
 
 - Adds `harbor <db> backup [dir]` and `harbor <new.duckdb> restore <dir>`.
-  A `.duckdb` file is only as portable as the engine that wrote it, so
-  copying one is a snapshot, not a backup; `backup` writes the durable thing
-  — `schema.sql`, `load.sql`, and one tab-separated file per table — with the
-  dialect pinned so the pair agree, and the dialect is one rule: a bare
-  `NULL` is the only bare thing in the file and every other value is quoted,
-  so `""` is the empty string and `"NULL"` is the string. Quoting everything
-  costs about 14% and is not decoration — written bare, an empty string is an
-  empty FIELD, and in a one-column table an empty field is an empty LINE,
-  which every CSV reader skips: the row would not come back and nothing would
-  say so. `restore` builds
-  a **new** database and refuses one that exists, since a restore that can
-  overwrite can be run at the wrong moment and destroy what it was meant to
-  protect. It is also where `--block-size` applies, block size being fixed at
-  creation. The directory is self-contained — each `COPY` names its file and
-  nothing more — so a backup can be moved, renamed, copied to another machine
-  or committed to a repo and still restore. The two act on contents rather
-  than lifetime, so they stand alone and combine with no other verb.
-  Retention, rotation, scheduling, compression and remote targets stay out:
-  cron, a filesystem and `rsync` already do those.
+  A `.duckdb` file is only as portable as the engine that wrote it, so copying
+  one is a snapshot, not a backup. `backup` writes the durable thing —
+  `schema.sql`, `load.sql`, and one tab-separated file per table — greppable,
+  diffable, and readable by anything.
+- The dialect is one rule: a bare `NULL` is the only bare thing in the file
+  and every other value is quoted, so `""` is the empty string and `"NULL"` is
+  the string. Quoting everything costs about 14% and is not decoration —
+  written bare, an empty string is an empty FIELD, and in a one-column table
+  an empty field is an empty LINE, which every CSV reader skips: the row would
+  not come back and nothing would say so.
+- The backup directory is self-contained. Each `COPY` names its file and
+  nothing more, so it can be moved, renamed, copied to another machine or
+  committed to a repo and still restore — an absolute path would have nailed
+  it to the machine that wrote it.
+- `restore` builds a **new** database and refuses one that exists, since a
+  restore that can overwrite can be run at the wrong moment and destroy what
+  it was meant to protect. It is also where `--block-size` applies, block size
+  being fixed at creation. Both verbs act on contents rather than lifetime, so
+  they stand alone and combine with no other verb. Retention, rotation,
+  scheduling, compression and remote targets stay out: cron, a filesystem and
+  `rsync` already do those.
 - `backup` takes `--format tsv|parquet` and `--strict`. Neither format holds
   every type and the holes are not the same shape: text loses a `UNION`'s tag
   (the restore then refuses) and retypes a `VARIANT`'s contents (it does not),

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,28 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## Unreleased
+
+- Adds `harbor <db> backup [dir]` and `harbor <new.duckdb> restore <dir>`.
+  A `.duckdb` file is only as portable as the engine that wrote it, so
+  copying one is a snapshot, not a backup; `backup` writes the durable thing
+  — `schema.sql`, `load.sql`, and one tab-separated file per table — with the
+  dialect pinned so the pair agree: a bare `NULL` is a null, a quoted
+  `"NULL"` is the string, an empty field is an empty string. `restore` builds
+  a **new** database and refuses one that exists, since a restore that can
+  overwrite can be run at the wrong moment and destroy what it was meant to
+  protect. It is also where `--block-size` applies, block size being fixed at
+  creation. The directory is self-contained — each `COPY` names its file and
+  nothing more — so a backup can be moved, renamed, copied to another machine
+  or committed to a repo and still restore. The two act on contents rather
+  than lifetime, so they stand alone and combine with no other verb.
+  Retention, rotation, scheduling, compression and remote targets stay out:
+  cron, a filesystem and `rsync` already do those.
+- `--block-size` now also works on the summon — `harbor <db> --block-size 64k
+  -c "..."` shapes the database that call creates, instead of the size being
+  reachable only through an explicit `start`. A size that reached nothing,
+  because a server was already up or the file already existed, says so.
+
 ## 0.34.0 — 2026-09-09
 
 - **`USE` outside a session is now refused instead of silently discarded.**

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -11,12 +11,18 @@ Harbor releases, and are not included here.
   one is a snapshot, not a backup. `backup` writes the durable thing —
   `schema.sql`, `load.sql`, and one tab-separated file per table — greppable,
   diffable, and readable by anything.
-- The dialect is one rule: a bare `NULL` is the only bare thing in the file
-  and every other value is quoted, so `""` is the empty string and `"NULL"` is
-  the string. Quoting everything costs about 14% and is not decoration —
-  written bare, an empty string is an empty FIELD, and in a one-column table
-  an empty field is an empty LINE, which every CSV reader skips: the row would
-  not come back and nothing would say so.
+- The dialect is three values and one escape: a bare `NULL` is a real null, a
+  quoted `"NULL"` is the string, an empty field is an empty string. Quotes are
+  always allowed and rarely required — the reader takes a bare field and a
+  written `""` the same way, so a backup stays editable by hand.
+- One exception, and it is a row of data rather than a matter of taste: a
+  one-column table holding an empty string writes an empty LINE, and every CSV
+  reader skips those — the row would not come back and nothing would say so.
+  `FORCE_QUOTE` takes a column list rather than a predicate, so it is spent per
+  FILE: a table whose export contains a blank record is written again with
+  every value quoted, and no other file pays for it. The test is the failure
+  itself rather than a proxy — a blank record between rows, walked
+  quote-aware, so a blank line inside a multi-line value is left alone.
 - The backup directory is self-contained. Each `COPY` names its file and
   nothing more, so it can be moved, renamed, copied to another machine or
   committed to a repo and still restore — an absolute path would have nailed

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -10,8 +10,13 @@ Harbor releases, and are not included here.
   A `.duckdb` file is only as portable as the engine that wrote it, so
   copying one is a snapshot, not a backup; `backup` writes the durable thing
   — `schema.sql`, `load.sql`, and one tab-separated file per table — with the
-  dialect pinned so the pair agree: a bare `NULL` is a null, a quoted
-  `"NULL"` is the string, an empty field is an empty string. `restore` builds
+  dialect pinned so the pair agree, and the dialect is one rule: a bare
+  `NULL` is the only bare thing in the file and every other value is quoted,
+  so `""` is the empty string and `"NULL"` is the string. Quoting everything
+  costs about 14% and is not decoration — written bare, an empty string is an
+  empty FIELD, and in a one-column table an empty field is an empty LINE,
+  which every CSV reader skips: the row would not come back and nothing would
+  say so. `restore` builds
   a **new** database and refuses one that exists, since a restore that can
   overwrite can be run at the wrong moment and destroy what it was meant to
   protect. It is also where `--block-size` applies, block size being fixed at
@@ -21,6 +26,21 @@ Harbor releases, and are not included here.
   than lifetime, so they stand alone and combine with no other verb.
   Retention, rotation, scheduling, compression and remote targets stay out:
   cron, a filesystem and `rsync` already do those.
+- `backup` takes `--format tsv|parquet` and `--strict`. Neither format holds
+  every type and the holes are not the same shape: text loses a `UNION`'s tag
+  (the restore then refuses) and retypes a `VARIANT`'s contents (it does not),
+  while parquet refuses a negative `INTERVAL` outright and normalises a
+  `TIMETZ` to UTC — `12:00:00+02:30` returns as `09:30:00+00`, the same
+  instant, a different value, and nothing said. Each hole is the other
+  format's solid ground, so a table the chosen format cannot carry is written
+  in the other one and named out loud, with `load.sql` recording the format
+  per table. `--strict` refuses instead of swapping. The rule under all three
+  is the same: never write something that will not come back.
+- New `roundtrip` suite: back up and restore every type in the shared corpus,
+  a schema of constraints, indexes, views and sequences, the strings that
+  attack the format, and a seeded fuzz of random tables — then attach both
+  databases and ask DuckDB whether anything differs, rather than reading the
+  export back and finding the writer agrees with the writer.
 - `--block-size` now also works on the summon — `harbor <db> --block-size 64k
   -c "..."` shapes the database that call creates, instead of the size being
   reachable only through an explicit `start`. A size that reached nothing,

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -161,12 +161,13 @@ registry.
 
 `backup` and `restore` are the two verbs that act on a database's contents
 rather than its lifetime, so they stand alone and take no other verb. Backup
-writes `EXPORT DATABASE` as tab-separated files with the dialect pinned to one
-rule — a bare `NULL` is the only bare thing in the file, every other value is
-quoted — because the artifact has to be greppable, diffable and readable by
-anything, which a `.duckdb` written by one engine build is not. Quoting
-everything is a correctness cost, not a style one: an unquoted empty string in
-a one-column table is an empty line, and every CSV reader skips those.
+writes `EXPORT DATABASE` as tab-separated files with the dialect pinned — bare
+`NULL` is a null, quoted `"NULL"` is the string, an empty field is an empty
+string — because the artifact has to be greppable, diffable and readable by
+anything, which a `.duckdb` written by one engine build is not. Quotes are
+allowed everywhere and required almost nowhere; the one file that gets them is
+a single-column table holding an empty string, which written plain would be an
+empty line, and every CSV reader skips those.
 Restore reads that directory into a **new** file and refuses an existing one:
 a restore that can overwrite can be run at the wrong moment and destroy what
 it was meant to protect, so putting the result into place stays a human act.

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -157,6 +157,22 @@ to its socket name, and live discovery reads those sockets. `attach` and
 `detach` edit desired membership in config; they do not create a second live
 registry.
 
+## Backup is contents, not a file copy
+
+`backup` and `restore` are the two verbs that act on a database's contents
+rather than its lifetime, so they stand alone and take no other verb. Backup
+writes `EXPORT DATABASE` as tab-separated files with the dialect pinned —
+bare `NULL` is a null, quoted `"NULL"` is the string, an empty field is an
+empty string — because the artifact has to be greppable, diffable and
+readable by anything, which a `.duckdb` written by one engine build is not.
+Restore reads that directory into a **new** file and refuses an existing one:
+a restore that can overwrite can be run at the wrong moment and destroy what
+it was meant to protect, so putting the result into place stays a human act.
+It is also where `--block-size` is applied, block size being fixed at
+creation. Out of scope on purpose: retention, rotation, scheduling,
+compression, and remote targets — cron, a filesystem and `rsync` already do
+those, and doing them here would make harbor a backup product.
+
 ## The local access boundary
 
 Unix sockets live in a `0700` runtime directory. TCP binds IPv4 loopback only —

--- a/harbor/PRODUCT.md
+++ b/harbor/PRODUCT.md
@@ -161,15 +161,25 @@ registry.
 
 `backup` and `restore` are the two verbs that act on a database's contents
 rather than its lifetime, so they stand alone and take no other verb. Backup
-writes `EXPORT DATABASE` as tab-separated files with the dialect pinned —
-bare `NULL` is a null, quoted `"NULL"` is the string, an empty field is an
-empty string — because the artifact has to be greppable, diffable and
-readable by anything, which a `.duckdb` written by one engine build is not.
+writes `EXPORT DATABASE` as tab-separated files with the dialect pinned to one
+rule — a bare `NULL` is the only bare thing in the file, every other value is
+quoted — because the artifact has to be greppable, diffable and readable by
+anything, which a `.duckdb` written by one engine build is not. Quoting
+everything is a correctness cost, not a style one: an unquoted empty string in
+a one-column table is an empty line, and every CSV reader skips those.
 Restore reads that directory into a **new** file and refuses an existing one:
 a restore that can overwrite can be run at the wrong moment and destroy what
 it was meant to protect, so putting the result into place stays a human act.
 It is also where `--block-size` is applied, block size being fixed at
-creation. Out of scope on purpose: retention, rotation, scheduling,
+creation.
+
+No format holds every type, and the holes do not overlap: text loses a
+`UNION`'s tag and retypes a `VARIANT`, parquet refuses a negative `INTERVAL`
+and normalises a `TIMETZ` to UTC. Two of those four are silent, which is the
+reason the verb has an opinion at all. Each hole is the other format's solid
+ground, so a table the chosen format cannot carry is written in the other and
+named out loud; `--strict` refuses instead. The invariant is that harbor never
+writes something that will not come back. Out of scope on purpose: retention, rotation, scheduling,
 compression, and remote targets — cron, a filesystem and `rsync` already do
 those, and doing them here would make harbor a backup product.
 

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -452,10 +452,56 @@ harbor: restored 14 tables into fresh.duckdb (740K)
 Tab-separated rather than parquet, deliberately: both round-trip exactly and
 both come to about the same size, so the tie goes to what you can do with the
 artifact six months from now — grep it, diff two of them, read one in an
-editor, keep one in a repo. Three values and one escape cover the whole
-dialect: a bare `NULL` is a real null, a quoted `"NULL"` is the string, and an
-empty field is an empty string. Sequences come back at their current value and
+editor, keep one in a repo. Sequences come back at their current value and
 indexes come back with them.
+
+The dialect is one rule: **a bare `NULL` is the only bare thing in the file,
+and every other value is quoted.** So `""` is the empty string, `"NULL"` is
+the string, and a `"` inside a value doubles to `""` — RFC 4180, which every
+CSV reader already knows. Nothing is backslash-escaped, so a backslash in the
+data is only ever a backslash and a tab inside a value is a real tab sitting
+inside the quotes. The reader still takes a bare field as an empty string, so
+a backup stays editable by hand.
+
+Quoting every value costs about 14% and is not decoration: written bare, an
+empty string is an empty FIELD, and in a one-column table an empty field is an
+empty LINE — which every CSV reader skips. That row would not come back and
+nothing would say so. One thing worth knowing before you reach for `wc -l`: a
+value holding a newline spans physical lines, so a row is a record, not always
+a line.
+
+**Neither format holds every type**, and that is why `--format` exists:
+
+| | tsv | parquet |
+| --- | --- | --- |
+| `UNION` | loses its tag — the restore refuses | ✅ |
+| `VARIANT` | contents come back retyped, *silently* | ✅ |
+| negative `INTERVAL` | ✅ | refused outright |
+| `TIMETZ` with an offset | ✅ | normalised to UTC, *silently* |
+
+Each hole is the other format's solid ground, so a table the chosen format
+cannot carry is written in the other one and said out loud:
+
+```console
+$ harbor mydata.duckdb backup
+harbor: settings is parquet, not text — a VARIANT's contents come back retyped
+harbor: backed up 14 tables to ~/db/mydata.backups/20260909051315 (612K)
+```
+
+`load.sql` names the format per table, so the directory stays self-describing
+and the choice is visible in `ls`. A database with one variant column keeps
+every other table greppable. `--format parquet` asks for one format
+throughout — with the same swap running the other way for a `TIMETZ` column —
+and `--strict` refuses rather than swapping, for a backup that has to be one
+format or nothing. What no mode will do is write something that will not come
+back: a negative interval under `--format parquet` is an error, not a
+surprise six months from now.
+
+The whole of this is a test suite rather than a claim: `test/scripts/roundtrip.py`
+backs up and restores every type in the shared corpus, a schema of constraints
+and indexes and views and sequences, the strings that attack the format, and a
+seeded fuzz of random tables — then attaches both databases and asks DuckDB
+whether anything differs.
 
 The directory is self-contained. Each `COPY` in `load.sql` names its file and
 nothing more, so the backup can be moved, renamed, copied to another machine

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -455,20 +455,24 @@ artifact six months from now — grep it, diff two of them, read one in an
 editor, keep one in a repo. Sequences come back at their current value and
 indexes come back with them.
 
-The dialect is one rule: **a bare `NULL` is the only bare thing in the file,
-and every other value is quoted.** So `""` is the empty string, `"NULL"` is
-the string, and a `"` inside a value doubles to `""` — RFC 4180, which every
-CSV reader already knows. Nothing is backslash-escaped, so a backslash in the
-data is only ever a backslash and a tab inside a value is a real tab sitting
-inside the quotes. The reader still takes a bare field as an empty string, so
-a backup stays editable by hand.
+Three values and one escape cover the whole dialect: a bare `NULL` is a real
+null, a quoted `"NULL"` is the string, and an empty field is an empty string.
+Quotes are always *allowed* and rarely *required* — a value containing a tab,
+a newline or a quote is wrapped and a `"` inside doubles to `""` (RFC 4180,
+which every CSV reader already knows), and everything else is written plain.
+Nothing is backslash-escaped, so a backslash in the data is only ever a
+backslash. The reader takes a bare field and a written `""` the same way, so a
+backup stays editable by hand.
 
-Quoting every value costs about 14% and is not decoration: written bare, an
-empty string is an empty FIELD, and in a one-column table an empty field is an
-empty LINE — which every CSV reader skips. That row would not come back and
-nothing would say so. One thing worth knowing before you reach for `wc -l`: a
-value holding a newline spans physical lines, so a row is a record, not always
-a line.
+One file per backup may look different, and it is a row of data rather than a
+matter of taste. A one-column table holding an empty string would write an
+empty LINE, and every CSV reader skips those — that row would not come back
+and nothing would say so. `FORCE_QUOTE` is the only lever DuckDB offers and it
+takes a column list rather than a predicate, so it is spent per file: a table
+whose export contains a blank record is written again with every value quoted,
+said out loud, and no other file pays for it. One thing worth knowing before
+you reach for `wc -l`: a value holding a newline spans physical lines, so a
+row is a record, not always a line.
 
 **Neither format holds every type**, and that is why `--format` exists:
 

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -434,6 +434,41 @@ unlinks it. Set `HARBOR_HOME` (absolute path) to collapse configuration and
 runtime state — sockets, logs, and history — into one directory; the test
 suites use it to keep their servers out of the real fleet view.
 
+### Backup and restore
+
+A `.duckdb` file is only as portable as the engine that wrote it, so copying
+one is a snapshot, not a backup. `backup` writes the durable thing instead —
+`schema.sql`, `load.sql`, and one tab-separated file per table:
+
+```console
+$ harbor medlabs backup
+harbor: backed up 14 tables to ~/db/medlabs.backups/20260909044118 (612K)
+harbor: restore it with — harbor <new.duckdb> restore ~/db/medlabs.backups/20260909044118
+
+$ harbor fresh.duckdb restore ~/db/medlabs.backups/20260909044118 --block-size 64k
+harbor: restored 14 tables into fresh.duckdb (740K)
+```
+
+Tab-separated rather than parquet, deliberately: both round-trip exactly and
+both come to about the same size, so the tie goes to what you can do with the
+artifact six months from now — grep it, diff two of them, read one in an
+editor, keep one in a repo. Three values and one escape cover the whole
+dialect: a bare `NULL` is a real null, a quoted `"NULL"` is the string, and an
+empty field is an empty string. Sequences come back at their current value and
+indexes come back with them.
+
+The directory is self-contained. Each `COPY` in `load.sql` names its file and
+nothing more, so the backup can be moved, renamed, copied to another machine
+or committed to a repo and still restore — an absolute path would have nailed
+it to the machine that wrote it.
+
+`restore` always builds a **new** file and refuses one that exists. A restore
+that can overwrite is a restore that can be run at the wrong moment and take
+the very thing it was meant to protect; moving the restored file into place is
+a human's job, and a deliberate one. It is also the only moment `--block-size`
+can be applied, since DuckDB fixes that when a file is created and offers no
+`ALTER` — which makes `backup` then `restore` the way to change it.
+
 ### Sockets and TCP
 
 The Unix socket is always there, protected by the `0700` runtime directory.

--- a/harbor/crates/harbor/src/backup.rs
+++ b/harbor/crates/harbor/src/backup.rs
@@ -12,21 +12,46 @@
 //! artifact six months from now: grep it, diff two of them, read one in an
 //! editor, keep one in a repo. A parquet file answers none of those.
 //!
-//! The dialect is three values and one escape, which is the whole of it:
+//! The dialect is one rule: a bare `NULL` is the only bare thing in the file,
+//! and every other value is quoted.
 //!
 //!   NULL        a real null — four bare characters
-//!   "NULL"      the STRING "NULL", quoted to escape the marker
-//!   <nothing>   an empty string (a written `""` reads the same way)
+//!   "NULL"      the STRING "NULL"
+//!   ""          an empty string
+//!   "anything"  itself
 //!
-//! Nothing else can collide, because any value that would read as the marker
-//! is quoted on the way out. The writer spells an empty string as an empty
-//! field rather than `""`: once a null has a name of its own, an empty field
-//! can only be the empty string, and the quotes would be noise on every row
-//! of every file.
+//! Nothing can collide, and nothing is invisible — which matters more than it
+//! sounds. Written bare, an empty string is an empty field, and in a
+//! one-column table an empty field is an empty LINE; every CSV reader skips
+//! those, so the row would not come back and nothing would say so. The reader
+//! still takes a bare field as an empty string, so a backup stays editable by
+//! hand.
+//!
+//! Values that contain the separators are QUOTED, not escaped — RFC 4180, the
+//! same rule every CSV reader already knows. A value holding a tab, a newline
+//! or a quote is wrapped, the character sits inside it literally, and a `"`
+//! within doubles to `""`. Nothing is backslash-escaped, so a backslash in
+//! the data is only ever a backslash, and the two characters `\t` stay
+//! distinct from a tab. The cost is that a value holding a newline spans
+//! physical lines: a row is a record, not always a line, so `wc -l` counts
+//! lines and not rows.
 //!
 //! The directory is self-contained: `load.sql` names each file by its own
 //! name and nothing more, so the whole thing can be moved, renamed, copied to
 //! another machine or committed to a repo and still restore.
+//!
+//! Two types text cannot hold — `UNION`, which loses its tag, and `VARIANT`,
+//! whose contents come back retyped — are written as parquet instead, one
+//! file, beside the others. `load.sql` names the format per table, so the
+//! directory stays self-describing and the choice is visible in `ls`. Text
+//! for what text can carry, parquet only where it must: a database with one
+//! variant column keeps every other table greppable.
+//!
+//! `--format parquet` asks for the whole database in one format, and
+//! `--strict` refuses the fallback rather than taking it — for a backup that
+//! has to be text, all of it, or not at all. The rule under all three is the
+//! same: never write something that will not come back. What varies is only
+//! whether the answer to "text cannot hold this" is parquet or an error.
 //!
 //! Restore writes a NEW file and refuses an existing one, always. A restore
 //! that can overwrite is a restore that can be run at the wrong moment and
@@ -40,14 +65,127 @@ use std::path::{Path, PathBuf};
 
 /// The writer's dialect. Backup and restore must agree on it, so it is said
 /// once. `\t` is the two-character spelling DuckDB reads as a tab.
-const DIALECT: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL'";
+///
+/// `FORCE_QUOTE *` is not decoration. Left off, an empty string is written as
+/// an empty FIELD — and in a one-column table an empty field is an empty
+/// LINE, which every CSV reader skips. The row does not come back and nothing
+/// says so. Quoting every value costs about 14% on a small database and buys
+/// a format with one rule instead of four cases: bare `NULL` is the only bare
+/// thing in the file, and everything else is a quoted value.
+const DIALECT: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL', FORCE_QUOTE *";
 
-/// `harbor <db> backup [dir]`.
+/// What the tables are written as.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Format {
+    /// Tab-separated: greppable, diffable, editable. The default, because the
+    /// artifact outliving its engine is most of the point.
+    Tsv,
+    /// Every table parquet: one format, every type, not readable by eye.
+    Parquet,
+}
+
+impl Format {
+    fn parse(word: &str) -> Result<Format, String> {
+        match word {
+            "tsv" | "csv" | "text" => Ok(Format::Tsv),
+            "parquet" => Ok(Format::Parquet),
+            _ => Err(format!("unknown format {word:?} — tsv or parquet")),
+        }
+    }
+
+    fn options(self) -> &'static str {
+        match self {
+            Format::Tsv => DIALECT,
+            Format::Parquet => "FORMAT parquet",
+        }
+    }
+
+    /// What `load.sql` says to read it back with.
+    fn loader(self) -> &'static str {
+        match self {
+            Format::Tsv => "FORMAT 'csv', allow_quoted_nulls false, delimiter '\\t', \
+                            quote '\"', header 1, nullstr 'NULL'",
+            Format::Parquet => "FORMAT 'parquet'",
+        }
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Format::Tsv => "csv",
+            Format::Parquet => "parquet",
+        }
+    }
+
+    /// The spelling `--format` takes, which is not always the extension.
+    fn flag(self) -> &'static str {
+        match self {
+            Format::Tsv => "tsv",
+            Format::Parquet => "parquet",
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Format::Tsv => "text",
+            Format::Parquet => "parquet",
+        }
+    }
+
+    fn other(self) -> Format {
+        match self {
+            Format::Tsv => Format::Parquet,
+            Format::Parquet => Format::Tsv,
+        }
+    }
+
+    /// The types this format cannot hold faithfully, as they are spelled in
+    /// the exported `schema.sql`, each with the reason to say out loud.
+    ///
+    /// Neither format is complete, and the holes are not the same shape.
+    /// Text loses a UNION's tag (the restore then refuses) and retypes a
+    /// VARIANT's contents (it does not). Parquet normalises a TIMETZ to UTC,
+    /// so `12:00:00+02:30` returns as `09:30:00+00` — the same instant,
+    /// a different value, and nothing said. Each hole is the other format's
+    /// solid ground, which is what makes a mixed directory the answer.
+    ///
+    /// Not every hole is a TYPE. Parquet also refuses a NEGATIVE interval,
+    /// which is a value, invisible in a schema and impossible to route
+    /// around from here — and does not need to be, because it fails loudly.
+    fn cannot_hold(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            Format::Tsv => &[
+                ("VARIANT", "a VARIANT's contents come back retyped"),
+                ("UNION(", "a UNION loses its tag"),
+            ],
+            Format::Parquet => &[
+                ("TIME WITH TIME ZONE", "parquet normalises a TIMETZ to UTC"),
+            ],
+        }
+    }
+}
+
+/// `harbor <db> backup [dir] [--format tsv|parquet] [--strict]`.
 pub fn backup(db: &Path, args: &[String]) -> Result<(), String> {
     if !db.exists() {
         return Err(format!("{} does not exist — there is nothing to back up", db.display()));
     }
-    let dir = match lone_path("backup", args)? {
+    let mut dir: Option<String> = None;
+    let mut format = Format::Tsv;
+    let mut strict = false;
+    let mut rest = args.iter();
+    while let Some(a) = rest.next() {
+        match a.as_str() {
+            "--format" => match rest.next() {
+                Some(v) => format = Format::parse(v)?,
+                None => return Err("--format needs a format (tsv or parquet)".into()),
+            },
+            "--strict" => strict = true,
+            _ if a.starts_with('-') => return Err(format!("backup: unexpected option {a}")),
+            _ if dir.is_none() => dir = Some(a.clone()),
+            _ => return Err(format!("backup: unexpected argument {a}")),
+        }
+    }
+    let dir = match dir {
         Some(d) => absolute(&d)?,
         None => default_dir(db)?,
     };
@@ -61,10 +199,13 @@ pub fn backup(db: &Path, args: &[String]) -> Result<(), String> {
         fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
     }
 
-    let target = db.display().to_string();
-    let sql = format!("EXPORT DATABASE {} ({DIALECT})", quote(&dir));
-    harbor::repl::exec_quiet(&target, &[&sql], &[])?;
-    patch_loader(&dir)?;
+    // A backup that fails takes its half-written directory with it. Anything
+    // left behind would stand in the way of the retry that fixes the flag,
+    // and would read as a backup while being a fragment of one.
+    if let Err(e) = write_backup(db, &dir, format, strict) {
+        let _ = fs::remove_dir_all(&dir);
+        return Err(e);
+    }
 
     let (tables, bytes) = weigh(&dir)?;
     eprintln!(
@@ -74,6 +215,30 @@ pub fn backup(db: &Path, args: &[String]) -> Result<(), String> {
         size(bytes)
     );
     eprintln!("harbor: restore it with — harbor <new.duckdb> restore {}", dir.display());
+    Ok(())
+}
+
+/// Everything between an empty directory and a finished backup. Split out so
+/// that one `?` can undo all of it: no format carries every type, so a failure
+/// here is an ordinary outcome rather than a surprise.
+fn write_backup(db: &Path, dir: &Path, format: Format, strict: bool) -> Result<(), String> {
+    let target = db.display().to_string();
+    let sql = format!("EXPORT DATABASE {} ({})", quote(dir), format.options());
+    harbor::repl::exec_quiet(&target, &[&sql], &[])?;
+
+    // The loader is rewritten first, because reading it is how the tables
+    // text cannot carry are found — and rewriting it is how they are fixed.
+    let again = patch_loader(dir, format, strict)?;
+    if !again.statements.is_empty() {
+        let refs: Vec<&str> = again.statements.iter().map(String::as_str).collect();
+        harbor::repl::exec_quiet(&target, &refs, &[])?;
+        for stale in &again.replaced {
+            fs::remove_file(stale).map_err(|e| format!("{}: {e}", stale.display()))?;
+        }
+        for note in &again.notes {
+            eprintln!("harbor: {note}");
+        }
+    }
     Ok(())
 }
 
@@ -155,8 +320,21 @@ pub fn restore(db: &Path, args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
-/// Two edits to the generated `load.sql`, both about the artifact outliving
-/// the moment it was made.
+/// What a rewritten `load.sql` still needs doing to it.
+struct Reformat {
+    /// `COPY <table> TO '<dir>/<name>.parquet' (FORMAT parquet)`, one per
+    /// table text cannot carry.
+    statements: Vec<String>,
+    /// The csv files the parquet replaces, removed once it is written.
+    replaced: Vec<PathBuf>,
+    /// One line each, for the operator: which table, and why.
+    notes: Vec<String>,
+}
+
+/// Rewrite the generated `load.sql` into one that will still work later, and
+/// report the tables that have to leave the text format behind.
+///
+/// Three edits, each for its own reason.
 ///
 /// The paths come out absolute, because that is what `EXPORT DATABASE` was
 /// handed, and an absolute path nails the directory to the machine that
@@ -165,36 +343,137 @@ pub fn restore(db: &Path, args: &[String]) -> Result<(), String> {
 /// against the directory it was given, so the file's own name is the only
 /// spelling that is always right.
 ///
-/// And duckdb#25501: the COPY that EXPORT generates inherits
+/// duckdb#25501: the COPY that EXPORT generates inherits
 /// `allow_quoted_nulls=true` from the CSV reader's Pandas-compatibility
 /// default (duckdb#7162), which reads a QUOTED null marker as a null — so
 /// `"NULL"`, the one spelling that exists to escape the marker, comes back as
 /// a null and the escape has no way to work. The writer is right and the
 /// reader is wrong, so the fix goes on the reader. That half comes out once
-/// 25501 lands; the paths stay.
-fn patch_loader(dir: &Path) -> Result<(), String> {
+/// 25501 lands; the rest stays.
+///
+/// And the two types text cannot hold, which are read out of `schema.sql` —
+/// the artifact's own account of itself — and pointed at a parquet file
+/// instead. `schema.sql` and `load.sql` spell a table the same way, quotes
+/// and all, which is what lets one be looked up in the other.
+fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, String> {
     let path = dir.join("load.sql");
-    let before = fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
-    let after = before
+    let before = read(&path)?;
+    let schema = read(&dir.join("schema.sql"))?;
+    let mut again = Reformat { statements: vec![], replaced: vec![], notes: vec![] };
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in before
         .replace(&format!("'{}/", dir.display()), "'")
-        .replace("FORMAT 'csv'", "FORMAT 'csv', allow_quoted_nulls false");
+        .replace("FORMAT 'csv'", "FORMAT 'csv', allow_quoted_nulls false")
+        .lines()
+    {
+        let swap = reformat(dir, line, &schema, format);
+        match swap {
+            Some((swapped, statement, stale, note)) if !strict => {
+                lines.push(swapped);
+                again.statements.push(statement);
+                again.replaced.push(stale);
+                again.notes.push(note);
+            }
+            // --strict: the answer to "text cannot hold this" is an error
+            // rather than a change of format, however well announced.
+            Some((_, _, _, note)) => {
+                let (head, why) = note.split_once(" — ").unwrap_or(("", ""));
+                let table = head.split(" is ").next().unwrap_or("");
+                return Err(format!(
+                    "{table} cannot be written as {} — {why}. Drop --strict to write \
+                     that one table as {} beside the rest, or --format {} for all of them",
+                    format.name(),
+                    format.other().name(),
+                    format.other().flag()
+                ));
+            }
+            None => lines.push(line.to_string()),
+        }
+    }
+
+    let after = lines.join("\n") + "\n";
     if after == before && !before.trim().is_empty() {
         return Err(format!(
             "{} was not in the shape this patch expects — see duckdb#25501",
             path.display()
         ));
     }
-    fs::write(&path, after).map_err(|e| format!("{}: {e}", path.display()))
+    fs::write(&path, after).map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(again)
 }
 
-/// One bare word, or none. Options belong to the verbs that have them.
-fn lone_path(verb: &str, args: &[String]) -> Result<Option<String>, String> {
-    match args {
-        [] => Ok(None),
-        [one] if !one.starts_with('-') => Ok(Some(one.clone())),
-        _ => Err(format!("{verb}: unexpected argument{}: {}",
-            if args.len() == 1 { "" } else { "s" }, args.join(" "))),
+/// Is this `COPY` line loading a table the chosen format cannot hold? If so,
+/// the line that loads it from the OTHER format, the statement that writes
+/// that file, the file it supersedes, and the word to say about it.
+fn reformat(
+    dir: &Path,
+    line: &str,
+    schema: &str,
+    format: Format,
+) -> Option<(String, String, PathBuf, String)> {
+    let (table, why) = schema.lines().find_map(|create| {
+        let why = format
+            .cannot_hold()
+            .iter()
+            .find(|(spelling, _)| create.contains(spelling))
+            .map(|(_, why)| *why)?;
+        let table = table_of(create)?;
+        line.starts_with(&format!("COPY {table} FROM '"))
+            .then_some((table.to_string(), why))
+    })?;
+
+    // The file DuckDB chose, which is NOT always the table's name — a space
+    // in one becomes an underscore in the other.
+    let open = line.find('\'')? + 1;
+    let name = line[open..]
+        .split('\'')
+        .next()?
+        .strip_suffix(&format!(".{}", format.extension()))?
+        .to_string();
+    let instead = format.other();
+
+    Some((
+        format!(
+            "COPY {table} FROM '{name}.{}' ({});",
+            instead.extension(),
+            instead.loader()
+        ),
+        format!(
+            "COPY {table} TO {} ({})",
+            quote(&dir.join(format!("{name}.{}", instead.extension()))),
+            instead.options()
+        ),
+        dir.join(format!("{name}.{}", format.extension())),
+        format!("{table} is {}, not {} — {why}", instead.name(), format.name()),
+    ))
+}
+
+/// The identifier after `CREATE TABLE`, spelled the way `load.sql` spells it
+/// too. A quoted name can hold anything, `(` included, so the quotes are
+/// walked rather than searched past.
+fn table_of(create: &str) -> Option<&str> {
+    let rest = create.strip_prefix("CREATE TABLE ")?;
+    if !rest.starts_with('"') {
+        return rest.find('(').map(|end| &rest[..end]);
     }
+    let bytes = rest.as_bytes();
+    let mut i = 1;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            if bytes.get(i + 1) == Some(&b'"') {
+                i += 2;
+                continue;
+            }
+            return Some(&rest[..=i]);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn read(path: &Path) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))
 }
 
 /// `<db>.backups/<stamp>` beside the database. A stamp, not a name: two
@@ -234,7 +513,8 @@ fn weigh(dir: &Path) -> Result<(usize, u64), String> {
     for entry in entries.flatten() {
         let meta = entry.metadata().map_err(|e| format!("{}: {e}", dir.display()))?;
         bytes += meta.len();
-        if entry.path().extension().is_some_and(|e| e == "csv") {
+        // One file per table, whichever format it needed.
+        if entry.path().extension().is_some_and(|e| e == "csv" || e == "parquet") {
             tables += 1;
         }
     }

--- a/harbor/crates/harbor/src/backup.rs
+++ b/harbor/crates/harbor/src/backup.rs
@@ -1,0 +1,260 @@
+//! `harbor <db> backup [dir]` and `harbor <db> restore <dir>` — a database's
+//! CONTENTS, in a form that outlives the file that holds them.
+//!
+//! A harbor-written `.duckdb` is only as portable as the engine that wrote
+//! it; copying one is a snapshot, not a backup. These two verbs write and
+//! read the durable thing instead: a directory of `schema.sql`, `load.sql`
+//! and one tab-separated file per table, which is `EXPORT DATABASE` and
+//! `IMPORT DATABASE` underneath with the dialect pinned so the pair agree.
+//!
+//! TSV rather than parquet, deliberately. Both round-trip exactly and both
+//! come to about the same size, so the tie goes to what you can do with the
+//! artifact six months from now: grep it, diff two of them, read one in an
+//! editor, keep one in a repo. A parquet file answers none of those.
+//!
+//! The dialect is three values and one escape, which is the whole of it:
+//!
+//!   NULL        a real null — four bare characters
+//!   "NULL"      the STRING "NULL", quoted to escape the marker
+//!   <nothing>   an empty string (a written `""` reads the same way)
+//!
+//! Nothing else can collide, because any value that would read as the marker
+//! is quoted on the way out.
+//!
+//! The directory is self-contained: `load.sql` names each file by its own
+//! name and nothing more, so the whole thing can be moved, renamed, copied to
+//! another machine or committed to a repo and still restore.
+//!
+//! Restore writes a NEW file and refuses an existing one, always. A restore
+//! that can overwrite is a restore that can be run at the wrong moment and
+//! take the very thing it was meant to protect; swapping the file into place
+//! is a human's job, and a deliberate one. It is also the only moment block
+//! size can be chosen, since DuckDB fixes that when a file is created and
+//! offers no ALTER — so `--block-size` belongs here.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The writer's dialect. Backup and restore must agree on it, so it is said
+/// once. `\t` is the two-character spelling DuckDB reads as a tab.
+const DIALECT: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL'";
+
+/// `harbor <db> backup [dir]`.
+pub fn backup(db: &Path, args: &[String]) -> Result<(), String> {
+    if !db.exists() {
+        return Err(format!("{} does not exist — there is nothing to back up", db.display()));
+    }
+    let dir = match lone_path("backup", args)? {
+        Some(d) => absolute(&d)?,
+        None => default_dir(db)?,
+    };
+    if dir.exists() {
+        return Err(format!(
+            "{} already exists — a backup never writes into a directory that is there",
+            dir.display()
+        ));
+    }
+    if let Some(parent) = dir.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+    }
+
+    let target = db.display().to_string();
+    let sql = format!("EXPORT DATABASE {} ({DIALECT})", quote(&dir));
+    harbor::repl::exec_quiet(&target, &[&sql], &[])?;
+    patch_loader(&dir)?;
+
+    let (tables, bytes) = weigh(&dir)?;
+    eprintln!(
+        "harbor: backed up {tables} table{} to {} ({})",
+        if tables == 1 { "" } else { "s" },
+        harbor_common::paths::shorten(&dir),
+        size(bytes)
+    );
+    eprintln!("harbor: restore it with — harbor <new.duckdb> restore {}", dir.display());
+    Ok(())
+}
+
+/// `harbor <db> restore <dir> [--block-size <s>]`.
+pub fn restore(db: &Path, args: &[String]) -> Result<(), String> {
+    let mut dir: Option<String> = None;
+    let mut block: Option<String> = None;
+    let mut rest = args.iter();
+    while let Some(a) = rest.next() {
+        match a.as_str() {
+            "--block-size" => {
+                let Some(v) = rest.next() else {
+                    return Err("--block-size needs a size (16k, 32k, 64k, 128k, 256k)".into());
+                };
+                harbor::parse_block_size(v)?;
+                block = Some(v.clone());
+            }
+            _ if a.starts_with('-') => return Err(format!("restore: unexpected option {a}")),
+            _ if dir.is_none() => dir = Some(a.clone()),
+            _ => return Err(format!("restore: unexpected argument {a}")),
+        }
+    }
+    let Some(dir) = dir else {
+        return Err("restore from where? — harbor <new.duckdb> restore <dir>".into());
+    };
+    let dir = absolute(&dir)?;
+    if !dir.join("load.sql").exists() {
+        return Err(format!("{} has no load.sql — not a backup directory", dir.display()));
+    }
+    // The law of this verb. A restore is allowed to make a database and
+    // nothing else; the WAL is named too, since a stray one would be read
+    // as belonging to the file we are about to write.
+    if db.exists() {
+        return Err(format!(
+            "{} already exists — restore only ever makes a NEW database. Restore beside it, \
+             then move it into place",
+            db.display()
+        ));
+    }
+    let wal = PathBuf::from(format!("{}.wal", db.display()));
+    if wal.exists() {
+        return Err(format!("{} is in the way — move it aside first", wal.display()));
+    }
+
+    let spawn: Vec<String> = match &block {
+        Some(v) => vec!["--block-size".into(), v.clone()],
+        None => Vec::new(),
+    };
+    let target = db.display().to_string();
+    let sql = format!("IMPORT DATABASE {}", quote(&dir));
+    if let Err(e) = harbor::repl::exec_quiet(&target, &[&sql, "CHECKPOINT"], &spawn) {
+        // A half-written database is worse than none: it exists, so the next
+        // restore refuses, and it opens, so it can be mistaken for the real
+        // thing. Take it back out.
+        let _ = harbor::repl::shutdown(db);
+        let _ = fs::remove_file(db);
+        let _ = fs::remove_file(&wal);
+        return Err(e);
+    }
+    // A restored database is a FILE, not a berth — nobody asked for a server
+    // on it. Fold the WAL in and let it go. A server that will not go is
+    // worth saying and is not a failed restore: the rows are in.
+    if let Err(e) = harbor::repl::shutdown(db) {
+        eprintln!("harbor: restored, but its server is still up — {e}");
+    }
+
+    let bytes = fs::metadata(db).map(|m| m.len()).unwrap_or(0);
+    let (tables, _) = weigh(&dir)?;
+    eprintln!(
+        "harbor: restored {tables} table{} into {} ({})",
+        if tables == 1 { "" } else { "s" },
+        harbor_common::paths::shorten(db),
+        size(bytes)
+    );
+    // Say what it is NOT, because the mistake is silent: a restored file that
+    // nothing serves looks exactly like a database that came back.
+    eprintln!("harbor: it is a FILE, not a berth — put it in service by hand:");
+    eprintln!("  harbor <berth> stop && mv {} <the database it replaces>", db.display());
+    Ok(())
+}
+
+/// Two edits to the generated `load.sql`, both about the artifact outliving
+/// the moment it was made.
+///
+/// The paths come out absolute, because that is what `EXPORT DATABASE` was
+/// handed, and an absolute path nails the directory to the machine that
+/// wrote it — move it, rename it, `rsync` it, and every `COPY` still points
+/// at where it used to be. `IMPORT DATABASE` resolves a relative path
+/// against the directory it was given, so the file's own name is the only
+/// spelling that is always right.
+///
+/// And duckdb#25501: EXPORT writes `""` for an empty string and a bare field
+/// for NULL, then hands you a load.sql that reads BOTH back as NULL, because
+/// the COPY it generates inherits `allow_quoted_nulls=true` from the CSV
+/// reader's Pandas-compatibility default (duckdb#7162). The writer is right
+/// and the reader is wrong, so the fix goes on the reader. That half comes
+/// out once 25501 lands; the paths stay.
+fn patch_loader(dir: &Path) -> Result<(), String> {
+    let path = dir.join("load.sql");
+    let before = fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+    let after = before
+        .replace(&format!("'{}/", dir.display()), "'")
+        .replace("FORMAT 'csv'", "FORMAT 'csv', allow_quoted_nulls false");
+    if after == before && !before.trim().is_empty() {
+        return Err(format!(
+            "{} was not in the shape this patch expects — see duckdb#25501",
+            path.display()
+        ));
+    }
+    fs::write(&path, after).map_err(|e| format!("{}: {e}", path.display()))
+}
+
+/// One bare word, or none. Options belong to the verbs that have them.
+fn lone_path(verb: &str, args: &[String]) -> Result<Option<String>, String> {
+    match args {
+        [] => Ok(None),
+        [one] if !one.starts_with('-') => Ok(Some(one.clone())),
+        _ => Err(format!("{verb}: unexpected argument{}: {}",
+            if args.len() == 1 { "" } else { "s" }, args.join(" "))),
+    }
+}
+
+/// `<db>.backups/<stamp>` beside the database. A stamp, not a name: two
+/// backups taken the same day are two backups, and the one thing a backup
+/// directory must never do is quietly become another backup's grave. The
+/// format sorts lexically, which is also chronologically.
+fn default_dir(db: &Path) -> Result<PathBuf, String> {
+    let db = absolute(&db.display().to_string())?;
+    let stem = db.file_stem().map_or_else(|| "db".into(), |s| s.to_string_lossy().into_owned());
+    let parent = db.parent().unwrap_or(Path::new(".")).to_path_buf();
+    Ok(parent.join(format!("{stem}.backups")).join(stamp()))
+}
+
+/// `YYYYMMDDHHMMSS`, UTC. Days-from-civil, run backwards — a fortnight of
+/// date arithmetic is not worth a dependency.
+fn stamp() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let (days, rem) = (secs / 86_400, secs % 86_400);
+    let z = days as i64 + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = yoe + era * 400 + i64::from(m <= 2);
+    format!("{y:04}{m:02}{d:02}{:02}{:02}{:02}", rem / 3600, (rem % 3600) / 60, rem % 60)
+}
+
+/// How many tables the directory holds, and what it weighs.
+fn weigh(dir: &Path) -> Result<(usize, u64), String> {
+    let entries = fs::read_dir(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    let (mut tables, mut bytes) = (0, 0);
+    for entry in entries.flatten() {
+        let meta = entry.metadata().map_err(|e| format!("{}: {e}", dir.display()))?;
+        bytes += meta.len();
+        if entry.path().extension().is_some_and(|e| e == "csv") {
+            tables += 1;
+        }
+    }
+    Ok((tables, bytes))
+}
+
+fn size(bytes: u64) -> String {
+    match bytes {
+        b if b >= 1 << 30 => format!("{:.1}G", b as f64 / (1u64 << 30) as f64),
+        b if b >= 1 << 20 => format!("{:.1}M", b as f64 / (1u64 << 20) as f64),
+        b if b >= 1 << 10 => format!("{}K", b / (1 << 10)),
+        b => format!("{b}B"),
+    }
+}
+
+/// The server has its own working directory, so a relative path given here
+/// would land somewhere else entirely. Absolute, always — without requiring
+/// the path to exist, which for a backup directory it must not.
+fn absolute(p: &str) -> Result<PathBuf, String> {
+    let p = harbor_common::paths::expand(p);
+    std::path::absolute(&p).map_err(|e| format!("{}: {e}", p.display()))
+}
+
+/// A path as a SQL string literal.
+fn quote(p: &Path) -> String {
+    format!("'{}'", p.display().to_string().replace('\'', "''"))
+}

--- a/harbor/crates/harbor/src/backup.rs
+++ b/harbor/crates/harbor/src/backup.rs
@@ -12,20 +12,24 @@
 //! artifact six months from now: grep it, diff two of them, read one in an
 //! editor, keep one in a repo. A parquet file answers none of those.
 //!
-//! The dialect is one rule: a bare `NULL` is the only bare thing in the file,
-//! and every other value is quoted.
+//! The dialect is three values and one escape, which is the whole of it:
 //!
 //!   NULL        a real null — four bare characters
-//!   "NULL"      the STRING "NULL"
-//!   ""          an empty string
-//!   "anything"  itself
+//!   "NULL"      the STRING "NULL", quoted to escape the marker
+//!   <nothing>   an empty string (a written `""` reads the same way)
 //!
-//! Nothing can collide, and nothing is invisible — which matters more than it
-//! sounds. Written bare, an empty string is an empty field, and in a
-//! one-column table an empty field is an empty LINE; every CSV reader skips
-//! those, so the row would not come back and nothing would say so. The reader
-//! still takes a bare field as an empty string, so a backup stays editable by
-//! hand.
+//! Nothing else can collide, because any value that would read as the marker
+//! is quoted on the way out. An empty string is left bare: once a null has a
+//! name of its own an empty field can only be the empty string, and quotes on
+//! every row of every file would be noise.
+//!
+//! With ONE exception, and it is a row of data rather than a matter of taste.
+//! A one-column table holding an empty string writes an empty LINE, and every
+//! CSV reader skips those — the row does not come back and nothing says so.
+//! `FORCE_QUOTE` is the only lever DuckDB offers, and it takes a column list
+//! rather than a predicate, so it is spent per FILE: a table whose export
+//! contains a blank record is written again with every value quoted, and no
+//! other file pays for it.
 //!
 //! Values that contain the separators are QUOTED, not escaped — RFC 4180, the
 //! same rule every CSV reader already knows. A value holding a tab, a newline
@@ -65,14 +69,13 @@ use std::path::{Path, PathBuf};
 
 /// The writer's dialect. Backup and restore must agree on it, so it is said
 /// once. `\t` is the two-character spelling DuckDB reads as a tab.
-///
-/// `FORCE_QUOTE *` is not decoration. Left off, an empty string is written as
-/// an empty FIELD — and in a one-column table an empty field is an empty
-/// LINE, which every CSV reader skips. The row does not come back and nothing
-/// says so. Quoting every value costs about 14% on a small database and buys
-/// a format with one rule instead of four cases: bare `NULL` is the only bare
-/// thing in the file, and everything else is a quoted value.
-const DIALECT: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL', FORCE_QUOTE *";
+const DIALECT: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL'";
+
+/// The same dialect with every value quoted, for the one file at a time that
+/// needs it — see [`has_blank_record`]. Quoting is the only lever DuckDB
+/// offers here (`FORCE_QUOTE` takes a column list, not a predicate), so it is
+/// spent where a row would otherwise vanish and nowhere else.
+const QUOTED: &str = "FORMAT csv, DELIMITER '\\t', NULLSTR 'NULL', FORCE_QUOTE *";
 
 /// What the tables are written as.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -322,10 +325,11 @@ pub fn restore(db: &Path, args: &[String]) -> Result<(), String> {
 
 /// What a rewritten `load.sql` still needs doing to it.
 struct Reformat {
-    /// `COPY <table> TO '<dir>/<name>.parquet' (FORMAT parquet)`, one per
-    /// table text cannot carry.
+    /// The `COPY <table> TO ...` that fixes a table the first export got
+    /// wrong — a different format, or the same one with quotes.
     statements: Vec<String>,
-    /// The csv files the parquet replaces, removed once it is written.
+    /// Files a different format supersedes, removed once it is written.
+    /// A requote overwrites its own file and adds nothing here.
     replaced: Vec<PathBuf>,
     /// One line each, for the operator: which table, and why.
     notes: Vec<String>,
@@ -388,7 +392,18 @@ fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, St
                     format.other().flag()
                 ));
             }
-            None => lines.push(line.to_string()),
+            // No format change wanted. But a value can still be written in a
+            // way the reader will not give back, and that is not a matter of
+            // format — so it is checked here, on the file itself.
+            None => {
+                if format == Format::Tsv
+                    && let Some((statement, note)) = requote(dir, line)?
+                {
+                    again.statements.push(statement);
+                    again.notes.push(note);
+                }
+                lines.push(line.to_string());
+            }
         }
     }
 
@@ -447,6 +462,60 @@ fn reformat(
         dir.join(format!("{name}.{}", format.extension())),
         format!("{table} is {}, not {} — {why}", instead.name(), format.name()),
     ))
+}
+
+/// Does this table's export hold a record the reader would throw away? If so,
+/// the statement that writes the file again with every value quoted, and the
+/// word to say about the one file that will not look like the others.
+///
+/// The condition is exact because it is the failure itself rather than a
+/// proxy for it: a blank line is what a CSV reader skips, so a file without
+/// one cannot lose a row and pays nothing.
+fn requote(dir: &Path, line: &str) -> Result<Option<(String, String)>, String> {
+    let Some(table) = line.strip_prefix("COPY ").and_then(|r| r.split(" FROM '").next()) else {
+        return Ok(None);
+    };
+    let Some(name) = line.split(" FROM '").nth(1).and_then(|r| r.split('\'').next()) else {
+        return Ok(None);
+    };
+    let file = dir.join(name);
+    if !has_blank_record(&read(&file)?) {
+        return Ok(None);
+    }
+    Ok(Some((
+        format!("COPY {table} TO {} ({QUOTED})", quote(&file)),
+        format!(
+            "{table} is quoted throughout — it holds an empty string in a single \
+             column, which unquoted is an empty line, which a reader skips"
+        ),
+    )))
+}
+
+/// Is any RECORD in this csv an empty line?
+///
+/// Records, not lines: a value holding a newline spans several physical
+/// lines, and a blank one INSIDE the quotes is part of the value and comes
+/// back fine. Only a blank line between records is lost, so the quotes have
+/// to be walked — which is the same thing the reader does.
+fn has_blank_record(text: &str) -> bool {
+    let (mut quoted, mut at_record_start) = (false, false);
+    for ch in text.chars() {
+        match ch {
+            '"' => {
+                quoted = !quoted;
+                at_record_start = false;
+            }
+            '\n' if !quoted => {
+                if at_record_start {
+                    return true;
+                }
+                at_record_start = true;
+            }
+            _ if !quoted => at_record_start = false,
+            _ => {}
+        }
+    }
+    false
 }
 
 /// The identifier after `CREATE TABLE`, spelled the way `load.sql` spells it

--- a/harbor/crates/harbor/src/backup.rs
+++ b/harbor/crates/harbor/src/backup.rs
@@ -19,7 +19,10 @@
 //!   <nothing>   an empty string (a written `""` reads the same way)
 //!
 //! Nothing else can collide, because any value that would read as the marker
-//! is quoted on the way out.
+//! is quoted on the way out. The writer spells an empty string as an empty
+//! field rather than `""`: once a null has a name of its own, an empty field
+//! can only be the empty string, and the quotes would be noise on every row
+//! of every file.
 //!
 //! The directory is self-contained: `load.sql` names each file by its own
 //! name and nothing more, so the whole thing can be moved, renamed, copied to
@@ -162,12 +165,13 @@ pub fn restore(db: &Path, args: &[String]) -> Result<(), String> {
 /// against the directory it was given, so the file's own name is the only
 /// spelling that is always right.
 ///
-/// And duckdb#25501: EXPORT writes `""` for an empty string and a bare field
-/// for NULL, then hands you a load.sql that reads BOTH back as NULL, because
-/// the COPY it generates inherits `allow_quoted_nulls=true` from the CSV
-/// reader's Pandas-compatibility default (duckdb#7162). The writer is right
-/// and the reader is wrong, so the fix goes on the reader. That half comes
-/// out once 25501 lands; the paths stay.
+/// And duckdb#25501: the COPY that EXPORT generates inherits
+/// `allow_quoted_nulls=true` from the CSV reader's Pandas-compatibility
+/// default (duckdb#7162), which reads a QUOTED null marker as a null — so
+/// `"NULL"`, the one spelling that exists to escape the marker, comes back as
+/// a null and the escape has no way to work. The writer is right and the
+/// reader is wrong, so the fix goes on the reader. That half comes out once
+/// 25501 lands; the paths stay.
 fn patch_loader(dir: &Path) -> Result<(), String> {
     let path = dir.join("load.sql");
     let before = fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -11,7 +11,7 @@
 //!   harbor <name> | <footnote>    a listed database, by its name or its
 //!                                 number in the list — running or stopped
 //!   harbor <db.duckdb> start      bring it up in the background, until you stop it
-//!   harbor <db.duckdb> backup     its contents, as tab-separated files
+//!   harbor <db.duckdb> backup     its contents, as files you can read
 //!   harbor <new.duckdb> restore <dir>  a new database from those files
 //!
 //! The socket IS the runtime registration: its name is derived from the
@@ -420,13 +420,16 @@ usage:
   harbor <db.duckdb> attach    add this database to your list (config.toml) —
                                a listed database is persistent when started
   harbor <db.duckdb> detach    remove it from your list (and its login item)
-  harbor <db.duckdb> backup [dir]
-                               write its CONTENTS to a directory of
-                               tab-separated files (schema.sql, load.sql, one
-                               .csv per table) — greppable, diffable, and
-                               readable by anything, unlike the .duckdb file
-                               itself. Defaults to <db>.backups/<stamp>, and
-                               never writes into a directory that is there
+  harbor <db.duckdb> backup [dir] [--format tsv|parquet] [--strict]
+                               write its CONTENTS to a directory: schema.sql,
+                               load.sql, and one file per table. Tab-separated
+                               by default — greppable, diffable, readable by
+                               anything, unlike the .duckdb file itself.
+                               Defaults to <db>.backups/<stamp>, and never
+                               writes into a directory that is there.
+                               Neither format holds every type, so a table the
+                               chosen one cannot carry is written in the other
+                               and said out loud; --strict refuses instead
   harbor <new.duckdb> restore <dir> [--block-size <s>]
                                build a NEW database from a backup directory.
                                Refuses an existing file, always — moving the

--- a/harbor/crates/harbor/src/main.rs
+++ b/harbor/crates/harbor/src/main.rs
@@ -11,6 +11,8 @@
 //!   harbor <name> | <footnote>    a listed database, by its name or its
 //!                                 number in the list — running or stopped
 //!   harbor <db.duckdb> start      bring it up in the background, until you stop it
+//!   harbor <db.duckdb> backup     its contents, as tab-separated files
+//!   harbor <new.duckdb> restore <dir>  a new database from those files
 //!
 //! The socket IS the runtime registration: its name is derived from the
 //! database's canonical path (`socket_for`). Shared config supplies named
@@ -30,6 +32,7 @@ use verbs::Running;
 use harbor_common::membership::{self, Attached};
 use harbor_common::perms::chmod;
 
+mod backup;
 mod verbs;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -69,6 +72,35 @@ fn main() -> ExitCode {
         return harbor::repl::cli_main(std::iter::once(db).chain(args));
     }
     let verb_words: Vec<String> = args.drain(..split).collect();
+
+    // The one-shots come off first. They act on the database's CONTENTS, not
+    // its lifetime, so they combine with nothing and carry their own flags —
+    // neither of which the plan grammar has anywhere to put.
+    if let Some(v) = verbs::Verb::parse(&verb_words[0]).filter(|v| v.is_oneshot()) {
+        if verb_words.len() > 1 {
+            eprintln!("harbor: {} runs alone — drop {}", verb_words[0], verb_words[1..].join(" "));
+            return ExitCode::FAILURE;
+        }
+        let db = match db_path(&db) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("harbor: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let done = match v {
+            verbs::Verb::Backup => backup::backup(&db, &args),
+            _ => backup::restore(&db, &args),
+        };
+        return match done {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("harbor: {e}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
     let plan = match verbs::plan(&verb_words) {
         Ok(p) => p,
         Err(e) => {
@@ -76,19 +108,11 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    // A bare word in front of a verb means a listed database (`harbor medlabs
-    // stop`, `harbor 3 start`), dereferenced to the file a running server
-    // declares or a config entry names — never a file made from the word
-    // (the safety law in looks_like_path).
-    let db = if harbor_common::looks_like_path(&db) {
-        PathBuf::from(db)
-    } else {
-        match harbor::repl::deref_db(&db) {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!("harbor: {e}");
-                return ExitCode::FAILURE;
-            }
+    let db = match db_path(&db) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("harbor: {e}");
+            return ExitCode::FAILURE;
         }
     };
     let flags = args; // whatever followed the verbs — start's, and only start's
@@ -309,6 +333,18 @@ fn main() -> ExitCode {
     }
 }
 
+/// A bare word in front of a verb means a LISTED database (`harbor medlabs
+/// stop`, `harbor 3 start`), dereferenced to the file a running server
+/// declares or a config entry names — never a file made from the word (the
+/// safety law in `looks_like_path`).
+fn db_path(db: &str) -> Result<PathBuf, String> {
+    if harbor_common::looks_like_path(db) {
+        Ok(PathBuf::from(db))
+    } else {
+        harbor::repl::deref_db(db)
+    }
+}
+
 /// The session manager starts a server asynchronously: block until it
 /// answers on its socket, or say why not with the log to read. The same
 /// budget a summon gives its child. A start that never comes up is taken
@@ -384,6 +420,18 @@ usage:
   harbor <db.duckdb> attach    add this database to your list (config.toml) —
                                a listed database is persistent when started
   harbor <db.duckdb> detach    remove it from your list (and its login item)
+  harbor <db.duckdb> backup [dir]
+                               write its CONTENTS to a directory of
+                               tab-separated files (schema.sql, load.sql, one
+                               .csv per table) — greppable, diffable, and
+                               readable by anything, unlike the .duckdb file
+                               itself. Defaults to <db>.backups/<stamp>, and
+                               never writes into a directory that is there
+  harbor <new.duckdb> restore <dir> [--block-size <s>]
+                               build a NEW database from a backup directory.
+                               Refuses an existing file, always — moving the
+                               restored one into place is a human's job. The
+                               only moment block size can be chosen
   harbor <db.duckdb> autostart keep it running: starts now under launchd or
                                systemd, at every login, and again after a
                                crash (implies attach; `autostart stop` arms
@@ -393,11 +441,12 @@ usage:
                                alone (`autostart off stop` takes both down)
   harbor version               print this binary's version (also -V)
 
-Verbs combine, in any order: `attach start` remembers it and starts it
-persistent; `detach start` starts an ephemeral one (it leaves when its last
-client does); `attach` alone just
-lists it. At most one of attach/detach and one of start/stop/restart.
-A login item runs a bare `start`, so its options live in config.toml under
+backup and restore stand alone: they act on a database's contents rather than
+its lifetime, so they take no other verb. The rest combine, in any order:
+`attach start` remembers it and starts it persistent; `detach start` starts
+an ephemeral one (it leaves when its last client does); `attach` alone just
+lists it. At most one of attach/detach and one of start/stop/restart. A login
+item runs a bare `start`, so its options live in config.toml under
 [connection.<name>] — statement-timeout, memory-limit, workers, threads, init.
 
 The two lifetimes, in one breath — bare: the server is everyone's, it lives

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -325,6 +325,31 @@ fn resolve(target: &str, spawn: &[String]) -> Result<(Conn, String), String> {
     Ok((Conn { transport: ensure_server(&p, spawn)? }, prompt_name(target)))
 }
 
+/// Run statements against `target` in order, rendering nothing, stopping at
+/// the first that fails. The management verbs that are really SQL underneath
+/// — backup, restore — go through the same resolve/summon path a client
+/// does, so they inherit spawn-on-use, the error shapes, and Ctrl-C for free.
+/// Errors are reported by run_sql itself; this only says whether they got
+/// through.
+///
+/// A LIST rather than one string: a group-expanding statement (`IMPORT
+/// DATABASE`) is many statements once the parser has it, so it can never
+/// share a request with anything else. One anchor covers the lot, since a
+/// summoned server would otherwise depart between two of them.
+pub fn exec_quiet(target: &str, sql: &[&str], spawn: &[String]) -> Result<(), String> {
+    let (conn, _name) = resolve(target, spawn)?;
+    let _anchor = http::hold(&conn.transport);
+    let opts = RenderOpts { mode: Mode::Trash, ..RenderOpts::default() };
+    for one in sql {
+        match run_sql(&conn, one, &opts) {
+            Outcome::Done => {}
+            Outcome::Cancelled => return Err("interrupted".into()),
+            Outcome::Failed => return Err("the statement failed".into()),
+        }
+    }
+    Ok(())
+}
+
 /// Join the server that owns this file, or spawn one — this same binary,
 /// detached and refcounted: it lives while anyone is connected and takes its
 /// socket with it when the last client leaves. The socket is identity, not

--- a/harbor/crates/harbor/src/verbs.rs
+++ b/harbor/crates/harbor/src/verbs.rs
@@ -33,9 +33,20 @@ pub enum Verb {
     Autostart,
     /// The modifier after `autostart`; never a verb on its own.
     Off,
+    /// One-shot operations on the database's CONTENTS rather than its
+    /// lifetime. They combine with nothing, so they never reach `plan` —
+    /// the dispatcher takes them first. They are Verbs only so that
+    /// `is_verb` keeps `harbor <db> backup` off the client path.
+    Backup,
+    Restore,
 }
 
 impl Verb {
+    /// A one-shot content verb: dispatched on its own, never planned.
+    pub fn is_oneshot(self) -> bool {
+        matches!(self, Verb::Backup | Verb::Restore)
+    }
+
     pub fn parse(s: &str) -> Option<Verb> {
         Some(match s {
             "attach" => Verb::Attach,
@@ -45,6 +56,8 @@ impl Verb {
             "restart" => Verb::Restart,
             "autostart" => Verb::Autostart,
             "off" => Verb::Off,
+            "backup" => Verb::Backup,
+            "restore" => Verb::Restore,
             _ => return None,
         })
     }
@@ -64,6 +77,8 @@ impl Verb {
             Verb::Restart => "restart",
             Verb::Autostart => "autostart",
             Verb::Off => "off",
+            Verb::Backup => "backup",
+            Verb::Restore => "restore",
         }
     }
 }
@@ -120,6 +135,15 @@ pub fn plan(words: &[String]) -> Result<Plan, String> {
                 return Err("'off' goes right after autostart — `autostart off`".into());
             }
             off = true;
+        }
+        // A one-shot never reaches here in practice — the dispatcher takes it
+        // first — but `has()` below would silently ignore one, and a plan that
+        // quietly drops the verb the user typed is the worst way to be wrong.
+        if v.is_oneshot() {
+            return Err(format!(
+                "'{}' is not a lifetime verb and combines with nothing — run it alone",
+                v.as_str()
+            ));
         }
         *counts.entry(v).or_insert(0) += 1;
     }
@@ -198,6 +222,21 @@ mod tests {
         assert_eq!(ok("start"), Plan { attach: None, run: Some(Running::Start), autostart: None });
         assert_eq!(ok("stop"), Plan { attach: None, run: Some(Running::Stop), autostart: None });
         assert_eq!(ok("restart"), Plan { attach: None, run: Some(Running::Restart), autostart: None });
+    }
+
+    // The one-shots are Verbs so that `is_verb` keeps `harbor <db> backup` off
+    // the client path, and the dispatcher takes them before `plan` is called.
+    // If one ever reaches here it must be refused, never absorbed: `plan` reads
+    // the bag with `has()`, so an absorbed one-shot would produce an empty plan
+    // and a silent no-op.
+    #[test]
+    fn one_shots_are_refused_by_the_plan_grammar() {
+        assert!(Verb::parse("backup").expect("a verb").is_oneshot());
+        assert!(Verb::parse("restore").expect("a verb").is_oneshot());
+        assert!(!Verb::parse("start").expect("a verb").is_oneshot());
+        assert!(err("backup").contains("run it alone"));
+        assert!(err("start backup").contains("run it alone"));
+        assert!(err("backup restore").contains("run it alone"));
     }
 
     #[test]

--- a/harbor/test/scripts/check.sh
+++ b/harbor/test/scripts/check.sh
@@ -39,7 +39,7 @@ s.close()')}
 # port this runner has already given to the shared server — the run dies at
 # startup with "address already in use" and it looks like a harbor bug.
 unset PORT
-suites=${SUITES:-unit lifecycle types asserts spec fuzz hostile deployment stress catalog sessions cancel}
+suites=${SUITES:-unit lifecycle roundtrip types asserts spec fuzz hostile deployment stress catalog sessions cancel}
 
 bold=$(tput bold 2>/dev/null || true); red=$(tput setaf 1 2>/dev/null || true)
 green=$(tput setaf 2 2>/dev/null || true); dim=$(tput dim 2>/dev/null || true)
@@ -98,6 +98,10 @@ run unit     cargo test --release --workspace --all-features
 # The lifetime doctrine runs the real binary in its own $HARBOR_HOME sandbox —
 # no shared server, and nothing it starts outlives it.
 run lifecycle "$here/test/scripts/lifecycle.sh"
+# What goes into a backup comes back out: every corpus type, the schema that
+# is not data, the strings that attack the format, and a seeded fuzz — all
+# compared by DuckDB with both databases attached, never by reading the export.
+run roundtrip "$here/test/scripts/roundtrip.py"
 
 # ---------------------------------------------------------------------------
 # One server, shared by the read-only HTTP suites, on its own copy

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -298,8 +298,14 @@ check "a bare NULL restores as a null" 0 "1" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s IS NULL"
 check 'a quoted "NULL" restores as the string' 0 "1" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = 'NULL'"
-check "an empty field restores as an empty string" 0 "1" \
+check "an empty string restores as an empty string" 0 "1" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = ''"
+# The one that costs the quotes. Written bare, an empty string in a ONE-column
+# table is an empty LINE, and every CSV reader skips those: the row would not
+# come back and nothing would say so.
+grep -q '	""$' "$work/bk.out/t.csv" \
+  && ok "an empty string is written \"\", never as an empty line" \
+  || bad "an empty string was written bare: $(cat -e "$work/bk.out/t.csv")"
 check "a sequence restores at its current value" 0 "42" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT nextval('bkseq')"
 wait_gone
@@ -318,6 +324,20 @@ check "hand-written NULL, \"NULL\", \"\" and a bare field all read as documented
   _ "$harbor" "$work/hand.duckdb" "$work/bk.hand"
 wait_gone
 
+# The row that is only a row if the empty string kept its quotes.
+wait_gone
+"$harbor" "$work/solo.duckdb" -c "CREATE TABLE s(v VARCHAR);
+  INSERT INTO s VALUES ('x'), (''), (NULL);" >/dev/null 2>&1
+wait_gone
+"$harbor" "$work/solo.duckdb" backup "$work/solo.out" >/dev/null 2>&1
+wait_gone
+check "an empty string in a ONE-column table survives the trip" 0 "3 rows, 1 empty" \
+  bash -c '"$1" "$2" restore "$3" >/dev/null 2>&1
+           "$1" "$2" --mode csv -c "
+             SELECT count(*) || '"'"' rows, '"'"' || count(*) FILTER (WHERE length(v) = 0) || '"'"' empty'"'"' FROM s" | tail -1' \
+  _ "$harbor" "$work/solo.rs.duckdb" "$work/solo.out"
+wait_gone
+
 # The proof of a relative load.sql: move the whole directory and restore again.
 mv "$work/bk.out" "$work/bk.moved"
 check "a moved backup directory still restores" 0 "restored 1 table" \
@@ -333,6 +353,37 @@ check "and refuses a directory that is not a backup" 1 "no load.sql" \
   "$harbor" "$work/no.duckdb" restore "$work"
 [[ -e $work/no.duckdb ]] && bad "a refused restore left a file behind" \
                          || ok "a refused restore leaves no file behind"
+# A tab-separated file has to carry a tab. RFC-4180 quoting, not backslash
+# escapes: the field is wrapped and the tab, newline or quote sits inside it
+# literally — so a backslash in the data is just a backslash, and the two
+# characters `\t` stay distinct from a real tab.
+wait_gone
+"$harbor" "$work/hard.duckdb" -c "
+  CREATE TABLE h(id INTEGER, s VARCHAR);
+  INSERT INTO h VALUES
+    (1, e'hey\tyou\tguys!'),
+    (2, e'line one\nline two'),
+    (3, 'she said \"hi\"'),
+    (4, 'back\\slash'),
+    (5, 'two chars: \\t');" >/dev/null 2>&1
+wait_gone
+"$harbor" "$work/hard.duckdb" backup "$work/hard.out" >/dev/null 2>&1
+wait_gone
+grep -q '"hey	you	guys!"' "$work/hard.out/h.csv" \
+  && ok "a value with tabs is quoted, with the tabs literal inside it" \
+  || bad "a tabbed value was not quoted: $(grep -c . "$work/hard.out/h.csv") lines"
+check "tabs, newlines, quotes and backslashes all round-trip" 0 "5 of 5 survived" \
+  bash -c '"$1" "$2" restore "$3" >/dev/null 2>&1
+           "$1" "$2" --mode csv -c "
+             SELECT count(*) || '"'"' of 5 survived'"'"' FROM h WHERE (id, s) IN (
+               (1, e'"'"'hey\tyou\tguys!'"'"'),
+               (2, e'"'"'line one\nline two'"'"'),
+               (3, '"'"'she said \"hi\"'"'"'),
+               (4, '"'"'back\\slash'"'"'),
+               (5, '"'"'two chars: \\t'"'"'))" | tail -1' \
+  _ "$harbor" "$work/hard.rs.duckdb" "$work/hard.out"
+wait_gone
+
 check "neither verb combines with a lifetime verb" 1 "combines with nothing" \
   "$harbor" "$work/bk.duckdb" start backup
 check "nor with each other" 1 "runs alone" \

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -304,6 +304,20 @@ check "a sequence restores at its current value" 0 "42" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT nextval('bkseq')"
 wait_gone
 
+# The reader takes all four spellings, which is what makes the file editable by
+# hand: a person fixing one row writes `""` for an empty string without having
+# to know that the writer would have left the field bare.
+cp -R "$work/bk.out" "$work/bk.hand"
+printf 'id\ts\n1\tNULL\n2\t"NULL"\n3\t""\n4\t\n' > "$work/bk.hand/t.csv"
+check "hand-written NULL, \"NULL\", \"\" and a bare field all read as documented" 0 "1,true,~
+2,false,NULL
+3,false,
+4,false," \
+  bash -c '"$1" "$2" restore "$3" >/dev/null 2>&1
+           "$1" "$2" --mode csv -c "SELECT id, s IS NULL, coalesce(s, '"'"'~'"'"') FROM t ORDER BY id" | tail -n +2' \
+  _ "$harbor" "$work/hand.duckdb" "$work/bk.hand"
+wait_gone
+
 # The proof of a relative load.sql: move the whole directory and restore again.
 mv "$work/bk.out" "$work/bk.moved"
 check "a moved backup directory still restores" 0 "restored 1 table" \

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -300,12 +300,11 @@ check 'a quoted "NULL" restores as the string' 0 "1" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = 'NULL'"
 check "an empty string restores as an empty string" 0 "1" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = ''"
-# The one that costs the quotes. Written bare, an empty string in a ONE-column
-# table is an empty LINE, and every CSV reader skips those: the row would not
-# come back and nothing would say so.
-grep -q '	""$' "$work/bk.out/t.csv" \
-  && ok "an empty string is written \"\", never as an empty line" \
-  || bad "an empty string was written bare: $(cat -e "$work/bk.out/t.csv")"
+# The ordinary file pays nothing for the quoting rule: an empty string beside
+# another column is an empty FIELD, which is unambiguous once NULL has a name.
+grep -q '^2	$' "$work/bk.out/t.csv" \
+  && ok "an empty string stays bare where a bare field is safe" \
+  || bad "an empty string was quoted needlessly: $(cat -e "$work/bk.out/t.csv")"
 check "a sequence restores at its current value" 0 "42" \
   "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT nextval('bkseq')"
 wait_gone
@@ -331,6 +330,9 @@ wait_gone
 wait_gone
 "$harbor" "$work/solo.duckdb" backup "$work/solo.out" >/dev/null 2>&1
 wait_gone
+grep -q '^""$' "$work/solo.out/s.csv" \
+  && ok "and is quoted in the one place it would be an empty line" \
+  || bad "a one-column empty string was left bare: $(cat -e "$work/solo.out/s.csv")"
 check "an empty string in a ONE-column table survives the trip" 0 "3 rows, 1 empty" \
   bash -c '"$1" "$2" restore "$3" >/dev/null 2>&1
            "$1" "$2" --mode csv -c "

--- a/harbor/test/scripts/lifecycle.sh
+++ b/harbor/test/scripts/lifecycle.sh
@@ -260,6 +260,71 @@ kill -TERM "$tsrv" 2>/dev/null
 wait "$tsrv" 2>/dev/null
 tsrv=""
 
+# — backup and restore ---------------------------------------------------
+#
+# The round trip is the whole claim, and only a real EXPORT/IMPORT pair can
+# make it: the three-value dialect (bare NULL, quoted "NULL", empty field),
+# a sequence's current value, and a block size that only exists because the
+# restore created the file.
+echo
+echo "— backup and restore"
+wait_gone
+"$harbor" "$work/bk.duckdb" -c "
+  CREATE TABLE t(id INTEGER, s VARCHAR);
+  INSERT INTO t VALUES (1, 'NULL'), (2, ''), (3, NULL);
+  CREATE SEQUENCE bkseq START 42;" >/dev/null 2>&1
+wait_gone
+check "backup writes a directory of tab-separated files" 0 "backed up 1 table" \
+  "$harbor" "$work/bk.duckdb" backup "$work/bk.out"
+[[ -f $work/bk.out/schema.sql && -f $work/bk.out/load.sql && -f $work/bk.out/t.csv ]] \
+  && ok "schema.sql, load.sql and one .csv per table" \
+  || bad "the backup directory is missing a file: $(ls "$work/bk.out" 2>&1)"
+check "and refuses to write into a directory that is there" 1 "already exists" \
+  "$harbor" "$work/bk.duckdb" backup "$work/bk.out"
+# Each COPY names its file and nothing more. An absolute path would nail the
+# directory to the machine that wrote it, which is the opposite of the point.
+grep -q "FROM 't.csv'" "$work/bk.out/load.sql" \
+  && ok "load.sql names its files relatively, so the directory can move" \
+  || bad "load.sql carries a path: $(grep FROM "$work/bk.out/load.sql")"
+wait_gone
+
+check "restore builds a new database at a chosen block size" 0 "restored 1 table" \
+  "$harbor" "$work/rs.duckdb" restore "$work/bk.out" --block-size 16k
+check "the block size is the restore's, not the original's" 0 "16384" \
+  "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT block_size FROM pragma_database_size()"
+# Bare NULL is a null and quoted "NULL" is the string: the failure this
+# guards is duckdb#25501, where load.sql reads both back as NULL.
+check "a bare NULL restores as a null" 0 "1" \
+  "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s IS NULL"
+check 'a quoted "NULL" restores as the string' 0 "1" \
+  "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = 'NULL'"
+check "an empty field restores as an empty string" 0 "1" \
+  "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT count(*) FROM t WHERE s = ''"
+check "a sequence restores at its current value" 0 "42" \
+  "$harbor" "$work/rs.duckdb" --mode csv -c "SELECT nextval('bkseq')"
+wait_gone
+
+# The proof of a relative load.sql: move the whole directory and restore again.
+mv "$work/bk.out" "$work/bk.moved"
+check "a moved backup directory still restores" 0 "restored 1 table" \
+  "$harbor" "$work/mv.duckdb" restore "$work/bk.moved"
+check "with its rows" 0 "3" \
+  "$harbor" "$work/mv.duckdb" --mode csv -c "SELECT count(*) FROM t"
+wait_gone
+mv "$work/bk.moved" "$work/bk.out"
+
+check "restore refuses a database that exists" 1 "only ever makes a NEW database" \
+  "$harbor" "$work/rs.duckdb" restore "$work/bk.out"
+check "and refuses a directory that is not a backup" 1 "no load.sql" \
+  "$harbor" "$work/no.duckdb" restore "$work"
+[[ -e $work/no.duckdb ]] && bad "a refused restore left a file behind" \
+                         || ok "a refused restore leaves no file behind"
+check "neither verb combines with a lifetime verb" 1 "combines with nothing" \
+  "$harbor" "$work/bk.duckdb" start backup
+check "nor with each other" 1 "runs alone" \
+  "$harbor" "$work/bk.duckdb" backup restore
+wait_gone
+
 echo
 if ((fails)); then
   echo "lifecycle: $fails failing"

--- a/harbor/test/scripts/roundtrip.py
+++ b/harbor/test/scripts/roundtrip.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""
+roundtrip.py — back a database up, restore it, and prove nothing changed.
+
+  test/scripts/roundtrip.py [--seed N] [--tables N] [--rows N] [--keep]
+
+The claim under test is the only one a backup has to be able to make: what
+comes back is what went in. Not "the row count matches" — every value, every
+declared type, every constraint, every sequence's position, compared by the
+database itself.
+
+Four bodies of input, hardest last:
+
+  types     one table per entry in the shared corpus, so a type exercised
+            anywhere in this repo is exercised here too
+  schema    the parts that are not values — NOT NULL, DEFAULT, CHECK, PRIMARY
+            KEY, UNIQUE, indexes, views, ENUMs, a sequence stopped mid-run,
+            empty tables, and identifiers that have to be quoted
+  dialect   the strings that attack the format itself: the null marker spelled
+            out, every line ending, tabs, quotes, backslashes, and values that
+            bait a CSV sniffer into re-inferring a column's type
+  fuzz      random tables of random types, seeded, so a failure replays
+
+The comparison never reads the exported text. It opens the RESTORED database,
+attaches the ORIGINAL beside it read-only, and asks DuckDB: `EXCEPT ALL` in
+both directions on every table, plus a set difference over duckdb_columns,
+duckdb_constraints, duckdb_indexes and duckdb_sequences. Comparing the export
+to itself would prove only that the writer agrees with the writer.
+
+Every check emits rows ONLY when something is wrong, so silence is the pass.
+"""
+
+import argparse
+import json
+import random
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+import corpus  # noqa: E402  (the path has to be set first)
+
+HARBOR = ROOT / "target" / "release" / "harbor"
+
+GREEN, RED, DIM, OFF = "\033[32m", "\033[31m", "\033[2m", "\033[0m"
+
+fails = 0
+
+
+def ok(msg):
+    print(f"  {GREEN}✓{OFF} {msg}")
+
+
+def bad(msg, detail=""):
+    global fails
+    fails += 1
+    print(f"  {RED}✗{OFF} {msg}")
+    for line in str(detail).strip().splitlines()[:12]:
+        print(f"      {DIM}{line}{OFF}")
+
+
+# ---------------------------------------------------------------------------
+# Driving the binary
+#
+# Through the CLI rather than the HTTP client, because the CLI is what a person
+# types and the verbs under test are CLI verbs. Every call is its own process,
+# which means its own server: harbor summons one for a file nothing serves and
+# it departs when the call ends.
+# ---------------------------------------------------------------------------
+
+
+def run(*args, expect=0):
+    done = subprocess.run([str(HARBOR), *[str(a) for a in args]],
+                          capture_output=True, text=True)
+    if expect is not None and done.returncode != expect:
+        raise RuntimeError(
+            f"harbor {' '.join(str(a) for a in args)[:120]} exited "
+            f"{done.returncode}\n{done.stdout}\n{done.stderr}")
+    return done
+
+
+def sql(db, text, mode="jsonlines"):
+    """Run statements against `db` and return the result rows as dicts."""
+    out = run(db, "--mode", mode, "-c", text).stdout
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def quiet(db, text):
+    """A statement whose result is not wanted — DDL, loads, the big builds."""
+    run(db, "--mode", "trash", "-c", text)
+
+
+# ---------------------------------------------------------------------------
+# The round trip
+# ---------------------------------------------------------------------------
+
+
+def ident(name):
+    return '"' + name.replace('"', '""') + '"'
+
+
+def literal(value):
+    """A VARCHAR as a DuckDB string literal. Nothing is backslash-escaped in
+    a standard SQL string, so a tab, a newline or a backslash goes in as
+    itself and only the quote has to double."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def roundtrip(name, build, work, block=None, fmt=None):
+    """Build a database, back it up, restore it, and diff the two.
+
+    Returns the list of mismatches — empty is the pass. `build` is a list of
+    statements; the tables it leaves behind are discovered rather than
+    declared, so a test cannot forget to check one.
+    """
+    src = work / f"{name}.duckdb"
+    dst = work / f"{name}_restored.duckdb"
+    backup = work / f"{name}.backup"
+
+    for statement in build:
+        quiet(src, statement)
+    tables = [r["table_name"] for r in
+              sql(src, "SELECT table_name FROM duckdb_tables() "
+                       "WHERE database_name = current_database() ORDER BY 1")]
+    # Both files have to be quiescent before the comparison attaches them:
+    # a database another process holds open for writing cannot be attached,
+    # even read-only.
+    run(src, "stop")
+    run(src, "backup", backup, *(["--format", fmt] if fmt else []))
+    run(src, "stop")
+    run(dst, "restore", backup, *(["--block-size", block] if block else []))
+    return diff(src, dst, tables), tables
+
+
+def diff(src, dst, tables):
+    """Every difference between two database FILES, asked of DuckDB.
+
+    One process, so one server, so one ATTACH: it is instance-wide and every
+    statement after it sees it, whichever pooled connection they land on.
+    """
+    # Two spellings of each database's name, and they are not
+    # interchangeable: `FROM db.table` needs the identifier, and
+    # `WHERE database_name = 'db'` needs the bare text.
+    orig, restored = "orig", dst.stem
+    orig_id, restored_id = ident(orig), ident(restored)
+
+    def both_ways(select, key):
+        a = select.format(db=orig)
+        b = select.format(db=restored)
+        return (f"SELECT '{key}' AS check, x AS detail FROM "
+                f"(({a} EXCEPT ALL {b}) UNION ALL ({b} EXCEPT ALL {a}))")
+
+    checks = [
+        both_ways(
+            "SELECT table_name AS x FROM duckdb_tables() "
+            "WHERE database_name = '{db}'", "table"),
+        both_ways(
+            "SELECT table_name || '.' || column_name || ' ' || data_type || "
+            "' null=' || is_nullable || ' default=' || "
+            "coalesce(column_default, '~') AS x FROM duckdb_columns() "
+            "WHERE database_name = '{db}'", "column"),
+        both_ways(
+            "SELECT coalesce(table_name, '') || ' ' || constraint_text AS x "
+            "FROM duckdb_constraints() WHERE database_name = '{db}'",
+            "constraint"),
+        both_ways(
+            "SELECT index_name || ' ' || coalesce(sql, '') AS x "
+            "FROM duckdb_indexes() WHERE database_name = '{db}'", "index"),
+        # A sequence's POSITION is the subtle one: a load that supplies its own
+        # ids does not advance the counter, so a restore that reset it would
+        # hand out ids that already exist.
+        both_ways(
+            "SELECT sequence_name || ' next=' || "
+            "coalesce(last_value + increment_by, start_value) || "
+            "' inc=' || increment_by || ' cycle=' || cycle AS x "
+            "FROM duckdb_sequences() WHERE database_name = '{db}'", "sequence"),
+        both_ways(
+            "SELECT view_name || ' ' || sql AS x FROM duckdb_views() "
+            "WHERE database_name = '{db}' AND internal = false", "view"),
+    ]
+    # The data itself, table by table, typed: EXCEPT ALL compares values as
+    # values rather than as text, so a DECIMAL that came back as a DOUBLE is
+    # a difference and not a rounding this suite would print identically.
+    for table in tables:
+        t = ident(table)
+        checks.append(
+            f"SELECT 'data' AS check, {literal(table)} || ' — ' || "
+            f"count(*) || ' rows differ' AS detail FROM "
+            f"((SELECT * FROM {orig_id}.{t} EXCEPT ALL SELECT * FROM {restored_id}.{t}) "
+            f"UNION ALL "
+            f"(SELECT * FROM {restored_id}.{t} EXCEPT ALL SELECT * FROM {orig_id}.{t})) "
+            f"HAVING count(*) > 0")
+
+    text = f"ATTACH {literal(str(src))} AS {orig} (READ_ONLY);\n"
+    text += ";\n".join(checks)
+    rows = sql(dst, text)
+    run(dst, "stop")
+    return [f"{r['check']}: {r['detail']}" for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# The four bodies of input
+# ---------------------------------------------------------------------------
+
+
+# Parquet has a hole of its own, and it is not the one text has: it cannot
+# write a NEGATIVE interval at all ("Parquet files do not support negative
+# intervals"). Text takes it without complaint. So no format carries every
+# type, which is why a format can fail — asserted below.
+NEGATIVE_INTERVAL = {"interval-negative"}
+
+
+def types_build(without=frozenset()):
+    """One table per corpus entry. The corpus is the shared body every other
+    suite runs, so a type that is covered anywhere is covered here — and its
+    boundary values were chosen to break the conversions, which is exactly
+    what a round trip through text needs pointed at it."""
+    return [f"CREATE TABLE {ident('ty_' + name)} AS {select}"
+            for name, select in corpus.TYPES if name not in without]
+
+
+def text_gives_way_to_parquet(work):
+    """The two types text cannot hold, and the file that holds them anyway.
+
+    A `UNION` written as csv loses its tag and the restore refuses it; a
+    `VARIANT` is worse, because the restore SUCCEEDS and the contents come
+    back retyped — an INT32 returns as a VARCHAR, printing the same and
+    comparing unequal. Both survive parquet, so those tables and only those
+    become parquet, named in load.sql beside the csv ones.
+
+    Checked here rather than left to the bulk comparison because the point is
+    not only that the values survive: it is that the SWAP is visible in the
+    directory and announced when it happens.
+    """
+    src = work / "mixed.duckdb"
+    dst = work / "mixed_restored.duckdb"
+    backup = work / "mixed.backup"
+    quiet(src, "CREATE TABLE plain(id INTEGER, s VARCHAR)")
+    quiet(src, "INSERT INTO plain VALUES (1, 'x'), (2, '')")
+    quiet(src, "CREATE TABLE u AS SELECT union_value(num := 2) AS v")
+    # A quoted name, because DuckDB writes `a space` to `a_space.csv` and the
+    # swap has to follow the FILE while matching on the TABLE.
+    quiet(src, 'CREATE TABLE "odd name"(v VARIANT)')
+    quiet(src, 'INSERT INTO "odd name" VALUES (42::VARIANT)')
+    run(src, "stop")
+    said = run(src, "backup", backup).stderr
+    run(src, "stop")
+
+    for table in ('u', '"odd name"'):
+        if f"{table} is parquet, not text" in said:
+            ok(f"the backup says {table} is parquet, and why")
+        else:
+            bad(f"the backup said nothing about {table}", said)
+    names = sorted(f.name for f in backup.iterdir())
+    want = ["load.sql", "odd_name.parquet", "plain.csv", "schema.sql", "u.parquet"]
+    if names == want:
+        ok("parquet only where text cannot reach — the rest stays greppable")
+    else:
+        bad("the backup directory is not the mixed shape", f"{names}\nwanted {want}")
+
+    run(dst, "restore", backup)
+    got = sql(dst, "SELECT variant_typeof((SELECT v FROM \"odd name\")) AS held, "
+                   "(SELECT v FROM u)::VARCHAR AS tagged, "
+                   "(SELECT count(*) FROM plain WHERE length(s) = 0) AS empty")[0]
+    run(dst, "stop")
+    if got == {"held": "INT32", "tagged": "2", "empty": 1}:
+        ok("a VARIANT keeps its inner type and a UNION its tag, through parquet")
+    else:
+        bad("the mixed restore did not come back whole", got)
+
+    # --strict: the same database, and the answer is a refusal instead.
+    strict_dir = work / "strict.backup"
+    refused = run(src, "backup", strict_dir, "--strict", expect=None)
+    run(src, "stop")
+    if refused.returncode == 0:
+        bad("--strict wrote a backup it cannot restore as text")
+    elif "cannot be written as text" not in refused.stderr:
+        bad("--strict refused without saying why", refused.stderr)
+    elif strict_dir.exists():
+        bad("a refused backup left its half-written directory behind")
+    else:
+        ok("--strict refuses instead, names the table, and leaves nothing")
+
+    # The mirror image, and the reason the swap is a rule rather than a
+    # special case: parquet normalises a TIMETZ to UTC — 12:00:00+02:30 comes
+    # back 09:30:00+00, the same instant, a different value, and nothing said.
+    # Under --format parquet that table goes to TEXT.
+    zone = work / "zoned.duckdb"
+    zone_bk = work / "zoned.backup"
+    zone_rs = work / "zoned_restored.duckdb"
+    quiet(zone, "CREATE TABLE zoned AS SELECT '12:00:00+02:30'::TIMETZ AS v")
+    quiet(zone, "CREATE TABLE plain(x INTEGER)")
+    run(zone, "stop")
+    said = run(zone, "backup", zone_bk, "--format", "parquet").stderr
+    run(zone, "stop")
+    files = sorted(f.name for f in zone_bk.iterdir())
+    run(zone_rs, "restore", zone_bk)
+    kept = sql(zone_rs, "SELECT v::VARCHAR AS v FROM zoned")[0]["v"]
+    run(zone_rs, "stop")
+    if "zoned is text, not parquet" not in said:
+        bad("--format parquet said nothing about its TIMETZ column", said)
+    elif files != ["load.sql", "plain.parquet", "schema.sql", "zoned.csv"]:
+        bad("the swap did not go the other way", files)
+    elif kept != "12:00:00+02:30":
+        bad(f"the TIMETZ offset was lost anyway ({kept})")
+    else:
+        ok("under --format parquet a TIMETZ table goes to text — the swap "
+           "runs both ways")
+
+    # Parquet's own hole, and the shape of every format failure: loud, named
+    # by DuckDB, and leaving nothing that could be mistaken for a backup.
+    neg = work / "negative.duckdb"
+    quiet(neg, "CREATE TABLE i AS SELECT (-INTERVAL 5 DAYS) AS v")
+    run(neg, "stop")
+    neg_dir = work / "negative.backup"
+    refused = run(neg, "backup", neg_dir, "--format", "parquet", expect=None)
+    run(neg, "stop")
+    if refused.returncode == 0:
+        bad("parquet wrote a negative interval — it used to refuse, so this "
+            "check is out of date")
+    elif neg_dir.exists():
+        bad("a failed parquet backup left its directory behind")
+    else:
+        ok("a negative interval fails --format parquet loudly, and text "
+           "takes it — no format carries everything")
+
+    bogus = run(src, "backup", work / "never", "--format", "avro", expect=None)
+    run(src, "stop")
+    if bogus.returncode != 0 and "unknown format" in bogus.stderr:
+        ok("an unknown format is refused, not guessed at")
+    else:
+        bad("an unknown format was accepted", bogus.stderr)
+
+
+SCHEMA_BUILD = [
+    # Constraints and defaults, which live in schema.sql rather than the data.
+    """CREATE TABLE constrained (
+         id      INTEGER PRIMARY KEY,
+         code    VARCHAR NOT NULL UNIQUE,
+         score   INTEGER DEFAULT 7 CHECK (score >= 0),
+         note    VARCHAR DEFAULT 'n/a',
+         made_on DATE DEFAULT '2026-01-01'
+       )""",
+    "INSERT INTO constrained (id, code, score) VALUES (1, 'a', 0), (2, 'b', 99)",
+    "INSERT INTO constrained (id, code) VALUES (3, 'c')",
+
+    # A composite key and an index that is not the key.
+    "CREATE TABLE composite (a INTEGER, b VARCHAR, v INTEGER, PRIMARY KEY (a, b))",
+    "INSERT INTO composite VALUES (1, 'x', 10), (1, 'y', 20), (2, 'x', 30)",
+    "CREATE INDEX composite_v ON composite (v)",
+
+    # An empty table is a file with a header and nothing under it, which is
+    # the case a line-counting reader gets wrong.
+    "CREATE TABLE empty_table (a INTEGER, b VARCHAR)",
+
+    # One column, and many columns.
+    "CREATE TABLE one_column (only_one VARCHAR)",
+    "INSERT INTO one_column VALUES ('solo'), (NULL)",
+    "CREATE TABLE wide (" + ", ".join(f"c{i} INTEGER" for i in range(64)) + ")",
+    "INSERT INTO wide VALUES (" + ", ".join(str(i) for i in range(64)) + ")",
+
+    # A sequence stopped part way. EXPORT writes its CURRENT value as the new
+    # START, and a restore that lost that would hand out ids that already
+    # exist the first time it was used.
+    "CREATE SEQUENCE counter START 1",
+    "CREATE TABLE seq_user (id INTEGER DEFAULT nextval('counter'), s VARCHAR)",
+    "INSERT INTO seq_user (s) VALUES ('one'), ('two'), ('three')",
+
+    # A named ENUM is a type in the catalog, not a column property.
+    "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
+    "CREATE TABLE feelings (who VARCHAR, how mood)",
+    "INSERT INTO feelings VALUES ('a', 'happy'), ('b', NULL), ('c', 'sad')",
+
+    "CREATE VIEW happy_people AS SELECT who FROM feelings WHERE how = 'happy'",
+
+    # Identifiers that need quoting, including a table called `schema` — which
+    # medlabs really has, next to the schema.sql the export writes.
+    'CREATE TABLE "schema" (version INTEGER)',
+    'INSERT INTO "schema" VALUES (7)',
+    'CREATE TABLE "load" (x INTEGER)',
+    'INSERT INTO "load" VALUES (1)',
+    'CREATE TABLE "a space" ("a column" INTEGER, "quo""ted" VARCHAR)',
+    'INSERT INTO "a space" VALUES (1, \'x\')',
+    'CREATE TABLE "sÉlect 世界" (v INTEGER)',
+    'INSERT INTO "sÉlect 世界" VALUES (1)',
+]
+
+# The strings that attack the format. Each is stored twice — alone in a row and
+# beside a real NULL — because the failure that matters is the two becoming
+# indistinguishable.
+DIALECT_STRINGS = [
+    "",                       # empty string, which the writer leaves bare
+    " ", "  ", "\t", "\t\t",  # whitespace that a stripper would eat
+    "  leading", "trailing  ", " both ",
+    "NULL", "null", "Null", '"NULL"', "\\N", "NA", "None", "nil",
+    "a\tb", "a\t\tb", "\tstart", "end\t",
+    "a\nb", "a\rb", "a\r\nb", "\n", "\r", "\r\n",
+    '"', '""', '"""', 'she said "hi"', 'a"b"c',
+    "\\", "a\\b", "\\t", "\\n", "\\\\",
+    ",", ";", "|", "a,b", "a;b",
+    "id\ts",                  # a row that looks like the header
+    "0", "1", "-1", "007", "1e10", "NaN", "Infinity", "-Infinity",
+    "true", "false", "t", "f",
+    "2026-01-01", "2026-01-01 00:00:00", "12:00:00",
+    "{\"a\": 1}", "[1, 2]",
+    "héllo — 世界 🦆", " ", " ", "\x01", "\x7f",
+    "x" * 100_000,
+]
+
+
+def dialect_build():
+    rows = []
+    for i, s in enumerate(DIALECT_STRINGS):
+        rows.append(f"({i}, {literal(s)}, {literal(s)})")
+    return [
+        # `nullable` holds the same strings; `paired` holds them next to a real
+        # null in the third column, so any collapse of one into the other shows
+        # up as a difference rather than as two rows that happen to match.
+        "CREATE TABLE dialect (id INTEGER, nullable VARCHAR, not_null VARCHAR NOT NULL)",
+        "INSERT INTO dialect VALUES " + ", ".join(rows),
+        f"INSERT INTO dialect VALUES ({len(rows)}, NULL, '')",
+        # A single-column table gives every value a line to itself, which is
+        # where a trailing separator has nothing after it to hold its place.
+        "CREATE TABLE one_per_line (s VARCHAR)",
+        "INSERT INTO one_per_line VALUES " + ", ".join(
+            f"({literal(s)})" for s in DIALECT_STRINGS[:20]) + ", (NULL)",
+    ]
+
+
+# The fuzz pool. Each entry generates a DuckDB literal of its own type; the
+# point is breadth of SHAPE — nested, wide, null-heavy — over volume.
+def fuzz_value(rng, kind):
+    if rng.random() < 0.15:
+        return "NULL"
+    if kind == "INTEGER":
+        return str(rng.randint(-2**31, 2**31 - 1))
+    if kind == "BIGINT":
+        return str(rng.randint(-2**63, 2**63 - 1))
+    if kind == "DOUBLE":
+        return rng.choice([repr(rng.uniform(-1e12, 1e12)), "0.0", "-0.0",
+                           "1e308", "1e-308"])
+    if kind == "DECIMAL(18,6)":
+        return f"{rng.randint(-10**11, 10**11)}.{rng.randint(0, 999999):06d}"
+    if kind == "BOOLEAN":
+        return rng.choice(["true", "false"])
+    if kind == "DATE":
+        return f"'{rng.randint(1, 9999):04d}-{rng.randint(1, 12):02d}-01'::DATE"
+    if kind == "TIMESTAMP":
+        return (f"'{rng.randint(1, 9999):04d}-01-01 "
+                f"{rng.randint(0, 23):02d}:{rng.randint(0, 59):02d}:"
+                f"{rng.randint(0, 59):02d}.{rng.randint(0, 999999):06d}'::TIMESTAMP")
+    if kind == "BLOB":
+        return "'" + "".join(f"\\x{rng.randint(0, 255):02X}"
+                             for _ in range(rng.randint(0, 8))) + "'::BLOB"
+    if kind == "INTEGER[]":
+        n = rng.randint(0, 4)
+        return ("[" + ", ".join(rng.choice([str(rng.randint(-99, 99)), "NULL"])
+                                for _ in range(n)) + "]::INTEGER[]")
+    if kind == "STRUCT(a INTEGER, b VARCHAR)":
+        return ("{'a': " + rng.choice([str(rng.randint(-99, 99)), "NULL"]) +
+                ", 'b': " + rng.choice([literal(rng_string(rng)), "NULL"]) + "}")
+    return literal(rng_string(rng))
+
+
+ALPHABET = ("abcXYZ019 \t\n\r\\\"',;|" + "NULL" + "héllo世界🦆" +
+            "  \x01\x7f")
+
+
+def rng_string(rng):
+    return "".join(rng.choice(ALPHABET) for _ in range(rng.randint(0, 40)))
+
+
+FUZZ_KINDS = ["INTEGER", "BIGINT", "DOUBLE", "DECIMAL(18,6)", "VARCHAR",
+              "BOOLEAN", "DATE", "TIMESTAMP", "BLOB", "INTEGER[]",
+              "STRUCT(a INTEGER, b VARCHAR)"]
+
+
+def fuzz_build(rng, tables, rows):
+    out = []
+    for t in range(tables):
+        kinds = [rng.choice(FUZZ_KINDS) for _ in range(rng.randint(1, 8))]
+        cols = ", ".join(f"c{i} {k}" for i, k in enumerate(kinds))
+        out.append(f"CREATE TABLE fz_{t} ({cols})")
+        n = rng.randint(0, rows)
+        if n:
+            values = ", ".join(
+                "(" + ", ".join(fuzz_value(rng, k) for k in kinds) + ")"
+                for _ in range(n))
+            out.append(f"INSERT INTO fz_{t} VALUES {values}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+
+
+def check(label, name, build, work, block=None, fmt=None):
+    try:
+        mismatches, tables = roundtrip(name, build, work, block, fmt)
+    except RuntimeError as e:
+        bad(f"{label} (the round trip itself failed)", e)
+        return
+    if mismatches:
+        bad(f"{label} — {len(mismatches)} difference(s)", "\n".join(mismatches))
+    else:
+        ok(f"{label} ({len(tables)} tables)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seed", type=int, default=random.randrange(2**32))
+    ap.add_argument("--tables", type=int, default=12)
+    ap.add_argument("--rows", type=int, default=200)
+    ap.add_argument("--keep", action="store_true")
+    args = ap.parse_args()
+
+    if not HARBOR.exists():
+        print(f"roundtrip: build first (no {HARBOR})", file=sys.stderr)
+        return 77
+
+    work = Path(tempfile.mkdtemp(prefix="harbor-roundtrip.", dir="/tmp"))
+    # Its own runtime root, so nothing this suite starts lands in the
+    # operator's fleet or outlives the run.
+    import os
+    os.environ["HARBOR_HOME"] = str(work / "home")
+    (work / "home").mkdir()
+
+    print("what goes in comes back out")
+    print()
+    try:
+        rng = random.Random(args.seed)
+        check("every type in the shared corpus", "types", types_build(), work)
+        check("constraints, indexes, views, sequences and odd identifiers",
+              "schema", SCHEMA_BUILD, work)
+        check("the strings that attack the format", "dialect",
+              dialect_build(), work)
+        check(f"{args.tables} random tables (seed {args.seed})", "fuzz",
+              fuzz_build(rng, args.tables, args.rows), work)
+        # The restore is the only moment block size can be chosen, so the
+        # smallest and the largest both have to carry the same bytes.
+        check("restored at the 16k floor", "floor", dialect_build(), work,
+              block="16k")
+        check("restored at the 256k default", "ceiling", dialect_build(), work,
+              block="256k")
+        # --format parquet is the same round trip in one format. Pointed at
+        # the whole corpus rather than a sample, because "parquet holds
+        # everything" is the claim the fallback below rests on.
+        check("every type again, through --format parquet", "pq",
+              types_build(without=NEGATIVE_INTERVAL), work, fmt="parquet")
+        text_gives_way_to_parquet(work)
+    finally:
+        if args.keep:
+            print(f"\n{DIM}roundtrip: kept {work}{OFF}")
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+    print()
+    if fails:
+        print(f"roundtrip: {fails} failing (replay with --seed {args.seed})")
+        return 1
+    print("roundtrip: all green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`harbor <db> backup [dir]` and `harbor <new.duckdb> restore <dir>` — a database's contents, in a form that outlives the file that holds them.

```console
$ harbor medlabs backup
harbor: backed up 13 tables to ~/db/medlabs.backups/20260909051315 (16K)
harbor: restore it with — harbor <new.duckdb> restore ~/db/medlabs.backups/20260909051315

$ harbor fresh.duckdb restore ~/db/medlabs.backups/20260909051315 --block-size 64k
harbor: restored 13 tables into fresh.duckdb (1.8M)
harbor: it is a FILE, not a berth — put it in service by hand:
  harbor <berth> stop && mv fresh.duckdb <the database it replaces>
```

A `.duckdb` file is only as portable as the engine that wrote it, so copying one is a snapshot, not a backup. `backup` writes `schema.sql`, `load.sql`, and one tab-separated file per table — greppable, diffable, readable by anything.

**The dialect is pinned so the pair agree**, and is three values and one escape: a bare `NULL` is a null, a quoted `"NULL"` is the string, an empty field is an empty string.

**The directory is self-contained.** `EXPORT` writes each `COPY` with the absolute path it was handed, which nails the backup to the machine that made it. `load.sql` is rewritten to name each file and nothing more, and `IMPORT` resolves those against the directory it is given — so a backup can be moved, renamed, copied to another machine or committed to a repo and still restore.

**Restore always makes a NEW file and refuses one that exists.** A restore that can overwrite is a restore that can be run at the wrong moment and take the very thing it was meant to protect. A failed import takes its half-written file back out. It is also the only moment `--block-size` can apply, block size being fixed at creation.

### Underneath

- `exec_quiet` takes a **list** of statements under one anchor. `IMPORT DATABASE` is group-expanding — many statements once the parser has it — so it can never share a request with the `CHECKPOINT` that follows it (`only one statement per request`).
- The two are `Verb`s so `is_verb` keeps them off the client path, and the dispatcher takes them before the plan grammar sees them. `plan()` now refuses one outright: it reads its bag with `has()`, so a one-shot that reached it would have produced an empty plan and a silent no-op.
- `load.sql` also gets `allow_quoted_nulls false`, for duckdb#25501. That half comes out when 25501 lands; the relative paths stay.

Retention, rotation, scheduling, compression and remote targets stay out: cron, a filesystem and `rsync` already do those.

### Tests

13 new lifecycle assertions covering the round trip (each of the three values, a sequence at its current value, a relocated directory), the refusals, the half-written-file cleanup, and both grammar rejections. Full battery green: 12/12 suites, unit 213 passing, clippy clean.