### PR TITLE
Select many rows with ⌘-click and ⇧-click

### DIFF
--- a/ducktable/crates/ducktable/src/edits.rs
+++ b/ducktable/crates/ducktable/src/edits.rs
@@ -5,9 +5,11 @@
 //!
 //! This module is pure model: no GPUI, no HTTP. The grid projects it
 //! onto the current page for rendering; commit turns it into
-//! parameterized statements. Every mutation — including a discard — is
+//! parameterized statements. Every gesture — including a discard — is
 //! one entry on the undo stack, so nothing is ever more than one
-//! keystroke from recovery.
+//! keystroke from recovery. A gesture that touches many rows (⌘⌫ over a
+//! selection, discard-all) is one entry too: the rows stay separate
+//! changes for review, and one ⌘Z takes the whole gesture back.
 
 use gpui::SharedString;
 use serde_json::Value;
@@ -53,9 +55,10 @@ pub struct Statement {
     pub expectation: StatementExpectation,
 }
 
-/// One undo step: the row entry's state before and after a mutation.
-/// Undo restores `prev`, redo restores `next` — one uniform shape for
-/// edits, clears, deletes, and discards.
+/// One row mutation: the row entry's state before and after. Undo
+/// restores `prev`, redo restores `next` — one uniform shape for edits,
+/// clears, deletes, and discards. An undo step is a group of these:
+/// usually one, many for a gesture over many rows.
 struct Op {
     key: String,
     identity: Vec<Value>,
@@ -77,8 +80,8 @@ pub struct Edits {
     /// All schema column names, in result order (for SET clauses).
     columns: Vec<String>,
     changes: HashMap<String, Entry>,
-    undo: Vec<Op>,
-    redo: Vec<Op>,
+    undo: Vec<Vec<Op>>,
+    redo: Vec<Vec<Op>>,
     next_draft: u64,
 }
 
@@ -267,8 +270,22 @@ impl Edits {
                 self.changes.remove(&op.key);
             }
         }
-        self.undo.push(op);
+        self.undo.push(vec![op]);
         self.redo.clear();
+    }
+
+    /// Run a gesture over many rows as ONE undo step. Every mutation the
+    /// closure makes lands on the stack as usual; afterwards they are
+    /// folded into a single group, so ⌘Z takes the gesture back whole
+    /// and ⌘⇧Z replays it whole. A gesture of one mutation, or none,
+    /// leaves the stack exactly as the mutations did.
+    pub fn grouped(&mut self, f: impl FnOnce(&mut Self)) {
+        let start = self.undo.len();
+        f(self);
+        if self.undo.len() > start + 1 {
+            let ops: Vec<Op> = self.undo.drain(start..).flatten().collect();
+            self.undo.push(ops);
+        }
     }
 
     /// Stage one cell. Editing a value back to its original auto-cleans;
@@ -324,37 +341,37 @@ impl Edits {
     }
 
     pub fn undo(&mut self) -> bool {
-        let Some(op) = self.undo.pop() else { return false };
-        match &op.prev {
-            Some(change) => {
-                self.changes.insert(
-                    op.key.clone(),
-                    Entry { identity: op.identity.clone(), change: change.clone() },
-                );
-            }
-            None => {
-                self.changes.remove(&op.key);
-            }
+        let Some(group) = self.undo.pop() else { return false };
+        // Walked backwards: within a group the same row may appear
+        // twice, and its earlier state must be the one that stands.
+        for op in group.iter().rev() {
+            self.restore(&op.key, &op.identity, &op.prev);
         }
-        self.redo.push(op);
+        self.redo.push(group);
         true
     }
 
     pub fn redo(&mut self) -> bool {
-        let Some(op) = self.redo.pop() else { return false };
-        match &op.next {
+        let Some(group) = self.redo.pop() else { return false };
+        for op in &group {
+            self.restore(&op.key, &op.identity, &op.next);
+        }
+        self.undo.push(group);
+        true
+    }
+
+    fn restore(&mut self, key: &str, identity: &[Value], change: &Option<RowChange>) {
+        match change {
             Some(change) => {
                 self.changes.insert(
-                    op.key.clone(),
-                    Entry { identity: op.identity.clone(), change: change.clone() },
+                    key.to_string(),
+                    Entry { identity: identity.to_vec(), change: change.clone() },
                 );
             }
             None => {
-                self.changes.remove(&op.key);
+                self.changes.remove(key);
             }
         }
-        self.undo.push(op);
-        true
     }
 
     /// Everything is committed or nothing is: clear after a successful
@@ -566,6 +583,43 @@ mod tests {
         assert!(e.undo());
         assert!(!e.is_deleted(&key));
         assert_eq!(e.staged_text(&key, 1), Some(txt("b")));
+    }
+
+    #[test]
+    fn a_gesture_over_many_rows_is_one_undo_step() {
+        let mut e = edits();
+        e.stage_cell(vec![json!(1)], 1, txt("a"), txt("b"), json!("b"));
+        e.grouped(|e| {
+            e.stage_delete(vec![json!(1)]);
+            e.stage_delete(vec![json!(2)]);
+            e.stage_delete(vec![json!(3)]);
+        });
+        assert_eq!(e.counts(), (0, 0, 3));
+        // One ⌘Z takes the whole gesture back, and the cell edit the
+        // delete had replaced is standing again.
+        assert!(e.undo());
+        assert_eq!(e.counts(), (0, 1, 0));
+        assert_eq!(e.staged_text(&key_of(&[json!(1)]), 1), Some(txt("b")));
+        // One ⌘⇧Z replays it whole.
+        assert!(e.redo());
+        assert_eq!(e.counts(), (0, 0, 3));
+        // Then the cell edit is its own step, as before.
+        assert!(e.undo());
+        assert!(e.undo());
+        assert!(e.is_empty());
+        assert!(!e.undo());
+    }
+
+    #[test]
+    fn a_gesture_of_one_or_no_mutations_leaves_the_stack_as_it_was() {
+        let mut e = edits();
+        e.grouped(|_| {});
+        assert!(!e.undo());
+        e.grouped(|e| e.stage_delete(vec![json!(1)]));
+        e.grouped(|e| e.stage_delete(vec![json!(1)])); // already deleted: no-op
+        assert!(e.undo());
+        assert!(e.is_empty());
+        assert!(!e.undo());
     }
 
     #[test]

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -1446,7 +1446,7 @@ impl Grid {
         }
         if m.platform && m.shift && ks.key == "backspace" {
             // ⌘⇧⌫, TablePlus's own chord: discard everything staged —
-            // each discard is an undo entry, so even this is reversible.
+            // one undo entry, so even this is reversible.
             self.discard_all(cx);
             cx.stop_propagation();
             return;
@@ -2023,8 +2023,8 @@ impl Grid {
 
     /// Stage a DELETE for every selected row — visible, ghosted,
     /// reversible until commit. No dialog: reversibility is the
-    /// confirmation model. Each row is its own staged change, so the
-    /// review popover and ⌘Z see them one at a time.
+    /// confirmation model. Each row is its own staged change for the
+    /// review popover; the gesture is one ⌘Z.
     fn stage_delete_row(&mut self, cx: &mut Context<Self>) {
         let targets: Vec<(Option<Vec<Value>>, Option<String>)> = {
             let d = self.table.read(cx).delegate();
@@ -2038,13 +2038,15 @@ impl Grid {
                 .collect()
         };
         let Some(edits) = &mut self.edits else { return };
-        for (identity, draft_key) in targets {
-            if let Some(key) = draft_key {
-                edits.discard(&key);
-            } else if let Some(identity) = identity {
-                edits.stage_delete(identity);
+        edits.grouped(|edits| {
+            for (identity, draft_key) in targets {
+                if let Some(key) = draft_key {
+                    edits.discard(&key);
+                } else if let Some(identity) = identity {
+                    edits.stage_delete(identity);
+                }
             }
-        }
+        });
         self.sync_staged(cx);
     }
 
@@ -2354,15 +2356,17 @@ impl Grid {
         self.sync_staged(cx);
     }
 
-    /// Discard everything staged — as individual discards, so each one
-    /// stays on the undo stack.
+    /// Discard everything staged — one gesture, one undo step, so ⌘Z
+    /// brings all of it back at once.
     pub(crate) fn discard_all(&mut self, cx: &mut Context<Self>) {
         if let Some(e) = &mut self.edits {
             let keys: Vec<String> =
                 e.entries().iter().map(|(k, _, _)| k.to_string()).collect();
-            for key in keys {
-                e.discard(&key);
-            }
+            e.grouped(|e| {
+                for key in keys {
+                    e.discard(&key);
+                }
+            });
         }
         self.sync_staged(cx);
     }

--- a/ducktable/crates/ducktable/src/grid.rs
+++ b/ducktable/crates/ducktable/src/grid.rs
@@ -278,10 +278,11 @@ pub(crate) struct GridDelegate {
     /// placeholders; fetched rows retain exact values so Duplicate Row
     /// never round-trips through display formatting.
     raw_rows: Vec<Vec<Value>>,
-    /// Mirror of the table's selected row (synced from TableEvent), so
-    /// render_tr can tint the selection — the delegate cannot read the
-    /// TableState it is rendering inside.
-    selected: Option<usize>,
+    /// Every selected row, and the one that leads them (docs/EDITING.md
+    /// "Selecting rows"). The lead mirrors the table's own selected row
+    /// (synced from TableEvent) — the delegate cannot read the TableState
+    /// it is rendering inside, so render_tr tints from here.
+    selection: RowSelection,
     /// The Sheets corner state: "#" was clicked, every cell highlights,
     /// and the next divider double-click fits the whole table. Any
     /// ordinary cell or row click disarms it.
@@ -432,7 +433,7 @@ impl Grid {
             gutter,
             rows: Vec::new(),
             raw_rows: Vec::new(),
-            selected: None,
+            selection: RowSelection::default(),
             all_selected: false,
             active_cell: None,
             loading: false,
@@ -516,7 +517,7 @@ impl Grid {
                     let ix = *ix;
                     table.update(cx, |state, cx| {
                         let d = state.delegate_mut();
-                        d.selected = Some(ix);
+                        d.selection.lead_on(Some(ix));
                         // Keyboard row moves carry the active-cell ring to
                         // the same column of the new row (Sheets' arrow
                         // behavior).
@@ -584,9 +585,9 @@ impl Grid {
                 // That intentional `real = None` is not an Escape and must
                 // not erase the active-cell ring (especially between a
                 // Tab-confirm and opening its destination editor).
-                let dirty_mirror = d.selected.is_some_and(|row| d.row_dirty(row));
-                if should_reconcile_selection(real, d.selected, dirty_mirror) {
-                    d.selected = real;
+                let dirty_mirror = d.selection.lead.is_some_and(|row| d.row_dirty(row));
+                if should_reconcile_selection(real, d.selection.lead, dirty_mirror) {
+                    d.selection.lead_on(real);
                     if real.is_none() {
                         d.active_cell = None;
                     }
@@ -780,7 +781,7 @@ impl Grid {
                             } else {
                                 d.adopt_rows(result.rows, base);
                             }
-                            d.selected = None;
+                            d.selection.clear();
                             d.active_cell = None;
                             d.editing = None;
                             d.editor_input = None;
@@ -1189,7 +1190,7 @@ impl Grid {
     /// tints from.
     pub(crate) fn row_kv(&self, cx: &App) -> Option<Vec<(SharedString, SharedString, bool)>> {
         let d = self.table.read(cx).delegate();
-        let row_ix = d.selected?;
+        let row_ix = d.selection.lead?;
         let row = d.rows.get(row_ix)?;
         let is_draft = d.draft_key(row_ix).is_some();
         Some(
@@ -1259,7 +1260,7 @@ impl Grid {
         }
         let (identity, mut raw, first_schema, pk_ix) = {
             let d = self.table.read(cx).delegate();
-            let row = d.selected.or(d.active_cell.map(|(row, _)| row));
+            let row = d.selection.lead.or(d.active_cell.map(|(row, _)| row));
             let Some(row) = row else { return };
             // A draft is already an INSERT. Duplicate Row deliberately
             // targets persisted rows so it always has exact source values.
@@ -2020,24 +2021,31 @@ impl Grid {
         self.stage_delete_row(cx);
     }
 
-    /// Stage the selected row's DELETE — visible, ghosted, reversible
-    /// until commit. No dialog: reversibility is the confirmation model.
+    /// Stage a DELETE for every selected row — visible, ghosted,
+    /// reversible until commit. No dialog: reversibility is the
+    /// confirmation model. Each row is its own staged change, so the
+    /// review popover and ⌘Z see them one at a time.
     fn stage_delete_row(&mut self, cx: &mut Context<Self>) {
-        let (identity, draft_key) = {
+        let targets: Vec<(Option<Vec<Value>>, Option<String>)> = {
             let d = self.table.read(cx).delegate();
-            let row = d.selected
-                .or(d.active_cell.map(|(r, _)| r))
-                .unwrap_or(usize::MAX);
-            (d.identities.get(row).cloned(), d.draft_key(row).map(str::to_string))
+            let rows: Vec<usize> = if d.selection.rows.is_empty() {
+                d.active_cell.map(|(r, _)| r).into_iter().collect()
+            } else {
+                d.selection.rows.iter().copied().collect()
+            };
+            rows.into_iter()
+                .map(|row| (d.identities.get(row).cloned(), d.draft_key(row).map(str::to_string)))
+                .collect()
         };
-        if let Some(edits) = &mut self.edits {
+        let Some(edits) = &mut self.edits else { return };
+        for (identity, draft_key) in targets {
             if let Some(key) = draft_key {
                 edits.discard(&key);
             } else if let Some(identity) = identity {
                 edits.stage_delete(identity);
             }
-            self.sync_staged(cx);
         }
+        self.sync_staged(cx);
     }
 
     /// PageUp/PageDown: one screenful within the loaded page — Sheets'
@@ -2088,6 +2096,10 @@ impl Grid {
             let d = state.delegate_mut();
             d.active_cell = None;
             d.tab_anchor = None;
+            // Cleared here, not left to the reconcile observer: a dirty
+            // lead deliberately has no library selection to lose, so the
+            // observer would read the Escape as nothing having happened.
+            d.selection.clear();
             state.clear_selection(cx);
             cx.notify();
         });
@@ -2286,7 +2298,7 @@ impl Grid {
                 }
             }
             if draft_shape_changed {
-                d.selected = None;
+                d.selection.clear();
                 d.active_cell = None;
                 d.editing = None;
                 d.editor_input = None;
@@ -2301,7 +2313,7 @@ impl Grid {
             }
             // Dirtiness just changed under the selection: re-decide the
             // wash (undoing a row's last edit gives its wash back).
-            if let Some(row) = state.delegate().selected {
+            if let Some(row) = state.delegate().selection.lead {
                 select_row(state, row, cx);
             }
             state.refresh(cx);
@@ -2484,7 +2496,7 @@ impl Grid {
                             d.rebuild_cols();
                             state.clear_selection(cx);
                             let d = state.delegate_mut();
-                            d.selected = None;
+                            d.selection.clear();
                             d.active_cell = None;
                             state.refresh(cx);
                             cx.notify();
@@ -2543,23 +2555,144 @@ impl Grid {
     }
 }
 
-/// Select a row the dirty-aware way. The delegate always records it —
-/// the ring and ⌘⌫ need a selected row — but the library's selection
-/// (the blue row wash) is only requested for clean rows: once a row
-/// carries staged changes, its amber or red owns the story, and two
-/// washes fighting on one row read as confusion, not state.
+/// Make a row the selection's lead the dirty-aware way. The delegate
+/// always records it — the ring and ⌘⌫ need a selected row — but the
+/// library's selection (the blue row wash) is only requested for clean
+/// rows: once a row carries staged changes, its amber or red owns the
+/// story, and two washes fighting on one row read as confusion, not
+/// state. A row not yet in the selection replaces it.
 fn select_row(
     state: &mut TableState<GridDelegate>,
     row: usize,
     cx: &mut Context<TableState<GridDelegate>>,
 ) {
-    state.delegate_mut().selected = Some(row);
+    state.delegate_mut().selection.lead_on(Some(row));
     if state.delegate().row_dirty(row) {
         state.clear_selection(cx);
-        state.delegate_mut().selected = Some(row);
+        state.delegate_mut().selection.lead_on(Some(row));
         state.scroll_to_row(row, cx);
     } else {
         state.set_selected_row(row, cx);
+    }
+}
+
+/// Route a click on a row through the selection grammar, then seat the
+/// library on the new lead. Returns that lead — None when the click
+/// emptied the selection, which the library learns about through
+/// clear_selection. A click that deselects the ring's row takes the ring
+/// with it, from the gutter and the body alike: a ring on a row the
+/// selection no longer includes would lie about where the keys act.
+fn click_row(
+    state: &mut TableState<GridDelegate>,
+    row: usize,
+    kind: ClickKind,
+    cx: &mut Context<TableState<GridDelegate>>,
+) -> Option<usize> {
+    let d = state.delegate_mut();
+    let lead = d.selection.click(row, kind);
+    if !d.selection.contains(row) && d.active_cell.is_some_and(|(r, _)| r == row) {
+        d.active_cell = None;
+    }
+    match lead {
+        Some(lead) => select_row(state, lead, cx),
+        None => state.clear_selection(cx),
+    }
+    lead
+}
+
+/// What a click on a row means for the selection — the macOS list
+/// grammar (Finder, NSTableView, TablePro's row gutter): plain replaces,
+/// ⌘ toggles one row, ⇧ spans from the anchor. ⇧ wins when both are down.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ClickKind {
+    Plain,
+    Toggle,
+    Extend,
+}
+
+impl ClickKind {
+    fn of(m: &Modifiers) -> Self {
+        if m.shift {
+            Self::Extend
+        } else if m.platform {
+            Self::Toggle
+        } else {
+            Self::Plain
+        }
+    }
+}
+
+/// The rows a grid has selected. `rows` is every one of them; `lead` is
+/// the one the ring, the inspector, and the library's own selection
+/// follow; `anchor` is where the next ⇧-click spans from. All display
+/// positions, like every selection index here (docs/DESIGN.md). Invariant:
+/// the lead is in `rows`, and an empty selection has no lead.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+struct RowSelection {
+    rows: std::collections::BTreeSet<usize>,
+    lead: Option<usize>,
+    anchor: Option<usize>,
+}
+
+impl RowSelection {
+    /// Apply a click and return the new lead.
+    fn click(&mut self, row: usize, kind: ClickKind) -> Option<usize> {
+        match kind {
+            ClickKind::Plain => {
+                self.rows.clear();
+                self.rows.insert(row);
+                self.anchor = Some(row);
+                self.lead = Some(row);
+            }
+            ClickKind::Toggle => {
+                self.anchor = Some(row);
+                if self.rows.remove(&row) {
+                    // Deselecting the lead hands the role to the last
+                    // remaining row; deselecting any other row leaves
+                    // the lead where it was, so nothing scrolls.
+                    if self.lead == Some(row) {
+                        self.lead = self.rows.iter().next_back().copied();
+                    }
+                } else {
+                    self.rows.insert(row);
+                    self.lead = Some(row);
+                }
+            }
+            ClickKind::Extend => {
+                // The span REPLACES the selection rather than joining it,
+                // the way Finder and TablePro read a ⇧-click; the anchor
+                // stays put so a second ⇧-click re-spans from the same row.
+                let anchor = self.anchor.unwrap_or(row);
+                self.rows = (anchor.min(row)..=anchor.max(row)).collect();
+                self.anchor = Some(anchor);
+                self.lead = Some(row);
+            }
+        }
+        self.lead
+    }
+
+    /// Adopt a lead chosen elsewhere — the library's own click, or a
+    /// re-select after staging changed a row's wash. A lead already
+    /// selected keeps the rest of the selection; any other row replaces
+    /// it; None empties it.
+    fn lead_on(&mut self, row: Option<usize>) {
+        match row {
+            Some(row) if self.rows.contains(&row) => self.lead = Some(row),
+            Some(row) => {
+                self.click(row, ClickKind::Plain);
+            }
+            None => self.clear(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.rows.clear();
+        self.lead = None;
+        self.anchor = None;
+    }
+
+    fn contains(&self, row: usize) -> bool {
+        self.rows.contains(&row)
     }
 }
 
@@ -2847,9 +2980,9 @@ impl TableDelegate for GridDelegate {
                 .border_color(t.grid_line)
                 .on_mouse_down(
                     MouseButton::Left,
-                    cx.listener(move |state, _, _, cx| {
+                    cx.listener(move |state, e: &MouseDownEvent, _, cx| {
                         state.delegate_mut().all_selected = false;
-                        select_row(state, row_ix, cx);
+                        click_row(state, row_ix, ClickKind::of(&e.modifiers), cx);
                     }),
                 )
                 .child(
@@ -3014,15 +3147,20 @@ impl TableDelegate for GridDelegate {
             )
             .on_mouse_down(
                 MouseButton::Left,
-                cx.listener(move |state, _, _, cx| {
+                cx.listener(move |state, e: &MouseDownEvent, _, cx| {
                     // Row and cell select together on mouse DOWN — the
                     // Table's own row selection waits for the click (mouse
                     // up), which reads as lag next to the ring.
                     let d = state.delegate_mut();
                     d.all_selected = false;
-                    d.active_cell = Some((row_ix, data_col));
                     d.tab_anchor = None;
-                    select_row(state, row_ix, cx);
+                    let lead = click_row(state, row_ix, ClickKind::of(&e.modifiers), cx);
+                    // The ring sits on the clicked cell while its row is
+                    // selected; click_row has already dropped it if the
+                    // click deselected the row.
+                    if lead == Some(row_ix) {
+                        state.delegate_mut().active_cell = Some((row_ix, data_col));
+                    }
                     cx.notify();
                 }),
             )
@@ -3234,7 +3372,7 @@ impl TableDelegate for GridDelegate {
         div()
             .id(("row", row_ix))
             .relative()
-            .when(self.selected == Some(row_ix), |d| {
+            .when(self.selection.contains(row_ix), |d| {
                 d.bg(t.row_active).child(
                     // The Table makes the selected row's own bottom border
                     // transparent (expecting its overlay border, which the
@@ -3253,6 +3391,12 @@ impl TableDelegate for GridDelegate {
 
     fn loading(&self, _: &App) -> bool {
         self.loading && self.rows.is_empty()
+    }
+
+    /// Keeps the Table's hover wash off every selected row, not only the
+    /// lead it knows about.
+    fn row_selected(&self, row_ix: usize, _: &App) -> bool {
+        self.selection.contains(row_ix)
     }
 }
 
@@ -3851,9 +3995,10 @@ fn should_reconcile_selection(
 #[cfg(test)]
 mod tests {
     use super::{
-        conditional_hint_min_width, draft_hint_min_width, duplicate_values,
-        should_reconcile_selection, wrapped_step,
+        ClickKind, RowSelection, conditional_hint_min_width, draft_hint_min_width,
+        duplicate_values, should_reconcile_selection, wrapped_step,
     };
+    use gpui::Modifiers;
     use serde_json::{Value, json};
 
     #[test]
@@ -3881,6 +4026,77 @@ mod tests {
         assert!(should_reconcile_selection(None, Some(0), false));
         assert!(should_reconcile_selection(Some(1), Some(0), true));
         assert!(!should_reconcile_selection(Some(0), Some(0), false));
+    }
+
+    fn rows(sel: &RowSelection) -> Vec<usize> {
+        sel.rows.iter().copied().collect()
+    }
+
+    #[test]
+    fn a_plain_click_replaces_the_selection_and_moves_the_anchor() {
+        let mut sel = RowSelection::default();
+        assert_eq!(sel.click(4, ClickKind::Plain), Some(4));
+        sel.click(7, ClickKind::Toggle);
+        assert_eq!(sel.click(2, ClickKind::Plain), Some(2));
+        assert_eq!(rows(&sel), vec![2]);
+        assert_eq!(sel.anchor, Some(2));
+    }
+
+    #[test]
+    fn a_command_click_toggles_one_row_and_keeps_the_lead_unless_it_left() {
+        let mut sel = RowSelection::default();
+        sel.click(3, ClickKind::Plain);
+        assert_eq!(sel.click(6, ClickKind::Toggle), Some(6));
+        assert_eq!(sel.click(1, ClickKind::Toggle), Some(1));
+        assert_eq!(rows(&sel), vec![1, 3, 6]);
+        // Removing a row that is not the lead leaves the lead alone.
+        assert_eq!(sel.click(3, ClickKind::Toggle), Some(1));
+        // Removing the lead hands it to the last remaining row.
+        assert_eq!(sel.click(1, ClickKind::Toggle), Some(6));
+        assert_eq!(sel.anchor, Some(1));
+        // Emptying the selection leaves no lead and no anchor to span from.
+        assert_eq!(sel.click(6, ClickKind::Toggle), None);
+        assert!(rows(&sel).is_empty());
+        assert_eq!(sel.anchor, Some(6));
+    }
+
+    #[test]
+    fn a_shift_click_spans_from_the_anchor_in_either_direction() {
+        let mut sel = RowSelection::default();
+        sel.click(5, ClickKind::Plain);
+        assert_eq!(sel.click(8, ClickKind::Extend), Some(8));
+        assert_eq!(rows(&sel), vec![5, 6, 7, 8]);
+        // A second ⇧-click re-spans from the same anchor, replacing the first.
+        assert_eq!(sel.click(3, ClickKind::Extend), Some(3));
+        assert_eq!(rows(&sel), vec![3, 4, 5]);
+        assert_eq!(sel.anchor, Some(5));
+        // With nothing to span from, ⇧-click is a plain click.
+        let mut fresh = RowSelection::default();
+        assert_eq!(fresh.click(2, ClickKind::Extend), Some(2));
+        assert_eq!(rows(&fresh), vec![2]);
+    }
+
+    #[test]
+    fn a_lead_chosen_elsewhere_joins_or_replaces_the_selection() {
+        let mut sel = RowSelection::default();
+        sel.click(1, ClickKind::Plain);
+        sel.click(4, ClickKind::Extend);
+        sel.lead_on(Some(2));
+        assert_eq!(rows(&sel), vec![1, 2, 3, 4]);
+        assert_eq!(sel.lead, Some(2));
+        sel.lead_on(Some(9));
+        assert_eq!(rows(&sel), vec![9]);
+        sel.lead_on(None);
+        assert_eq!(sel, RowSelection::default());
+    }
+
+    #[test]
+    fn shift_outranks_command_and_a_bare_click_is_plain() {
+        let cmd = Modifiers { platform: true, ..Modifiers::default() };
+        let both = Modifiers { platform: true, shift: true, ..Modifiers::default() };
+        assert_eq!(ClickKind::of(&Modifiers::default()), ClickKind::Plain);
+        assert_eq!(ClickKind::of(&cmd), ClickKind::Toggle);
+        assert_eq!(ClickKind::of(&both), ClickKind::Extend);
     }
 
     #[test]

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -76,7 +76,7 @@ One meaning per key. No contextual double-agents.
 | ⌃⇧N | stages NULL explicitly, any type | — |
 | ⌘N | creates a new all-DEFAULT row and opens its first useful writable cell | — |
 | ⌘D | duplicates the lead selected persisted row as one staged INSERT | — |
-| ⌘⌫ | stages a DELETE for every selected row (ghost strikethrough; each its own change, reversible until commit) | — |
+| ⌘⌫ | stages a DELETE for every selected row (ghost strikethrough; one undo step, each row its own entry for review; reversible until commit) | — |
 | ⌘Z / ⌘⇧Z | un-stages / re-stages the most recent change | text undo / redo |
 | ⌘S | commits all staged changes — one transaction, all or nothing | confirms the cell, then commits (⌘Enter is its equal) |
 | ⌥Enter | — | newline (the Sheets-hand twin of ⇧Enter) |
@@ -90,7 +90,7 @@ mode names, no status chip, no mid-edit toggle.
 
 A click selects one row (and, in the body, seats the ring on the clicked cell). The macOS list grammar builds on it: ⌘-click toggles a row in or out, ⇧-click selects the span from the anchor through the clicked row, replacing whatever was selected. The anchor is the last row clicked without ⇧, so a second ⇧-click re-spans from the same place. The gutter and the body cells select the same way.
 
-The selection has a lead: the row the ring, the inspector, and ⌘D act on. It is the row last clicked into the selection; ⌘-clicking the lead away hands the role to the last remaining row. ⌘⌫ acts on every selected row. Esc, a page change, and a commit clear the selection whole.
+The selection has a lead: the row the ring, the inspector, and ⌘D act on. It is the row last clicked into the selection; ⌘-clicking the lead away hands the role to the last remaining row. ⌘⌫ acts on every selected row as one gesture: one ⌘Z brings them all back, while the review popover still lists and discards them one by one. Esc, a page change, and a commit clear the selection whole.
 
 ⇧-click in the body takes a seat that cell ranges would want (TablePro spans cells there and keeps row spans on its gutter); if cell ranges ship, body ⇧-click moves to them and the gutter keeps the row span.
 
@@ -110,7 +110,7 @@ combination has a deliberate answer:
 | PageUp / PageDown | one screenful up / down within the loaded page (Sheets' meaning), a row of overlap, clamped at the page edge |
 | ⌥↑ / ⌥↓ | previous / next DATABASE page (the pager) — the ring keeps its seat (same column, row clamped); when multiple grid tabs exist someday, these migrate to tab switching (Sheets' worksheet keys) |
 | ⌥← / ⌥→ | step the view switcher's segments left / right, rolling over at the ends (Data / Structure today; a carousel, ready for more segments) |
-| ⌘⇧⌫ | discard all staged changes (TablePlus's chord; every discard stays undoable) |
+| ⌘⇧⌫ | discard all staged changes (TablePlus's chord; one undo step, so even this is reversible) |
 | ⇧ + arrows | deliberately inert — range selection's seat, reserved until ranges ship; a ring that moved when you expected a range to grow would lie |
 | ⌃ + arrows | never bound — macOS owns them (Mission Control, Spaces) |
 

--- a/ducktable/docs/EDITING.md
+++ b/ducktable/docs/EDITING.md
@@ -69,12 +69,14 @@ One meaning per key. No contextual double-agents.
 | Tab / ⇧Tab | moves the ring right / left with row-local wraparound, arming the typewriter anchor | confirms, moves right / left with row-local wraparound, and immediately edits the destination cell; anchor kept |
 | arrows | move the ring | *replace entry:* confirm + move the ring · *kept-value entry:* move the caret |
 | double-click | opens the editor keeping the value, caret at the click | — |
+| ⌘-click | adds the row to the selection, or removes it | — |
+| ⇧-click | selects every row from the anchor through this one, replacing the selection | — |
 | Esc | clears the selection | cancels the edit, restores what was there, ring stays |
 | Delete / ⌫ | clears the cell: text → `''`, everything else → NULL (NOT NULL columns refuse, with the reason in the status line) | deletes text |
 | ⌃⇧N | stages NULL explicitly, any type | — |
 | ⌘N | creates a new all-DEFAULT row and opens its first useful writable cell | — |
-| ⌘D | duplicates the selected persisted row as one staged INSERT | — |
-| ⌘⌫ | stages a row DELETE (ghost strikethrough; reversible until commit) | — |
+| ⌘D | duplicates the lead selected persisted row as one staged INSERT | — |
+| ⌘⌫ | stages a DELETE for every selected row (ghost strikethrough; each its own change, reversible until commit) | — |
 | ⌘Z / ⌘⇧Z | un-stages / re-stages the most recent change | text undo / redo |
 | ⌘S | commits all staged changes — one transaction, all or nothing | confirms the cell, then commits (⌘Enter is its equal) |
 | ⌥Enter | — | newline (the Sheets-hand twin of ⇧Enter) |
@@ -83,6 +85,14 @@ One meaning per key. No contextual double-agents.
 The replace-vs-kept-value arrow split is Sheets' own physics, unnamed:
 the entry gesture *is* the state, your finger chose it a second ago. No
 mode names, no status chip, no mid-edit toggle.
+
+## Selecting rows
+
+A click selects one row (and, in the body, seats the ring on the clicked cell). The macOS list grammar builds on it: ⌘-click toggles a row in or out, ⇧-click selects the span from the anchor through the clicked row, replacing whatever was selected. The anchor is the last row clicked without ⇧, so a second ⇧-click re-spans from the same place. The gutter and the body cells select the same way.
+
+The selection has a lead: the row the ring, the inspector, and ⌘D act on. It is the row last clicked into the selection; ⌘-clicking the lead away hands the role to the last remaining row. ⌘⌫ acts on every selected row. Esc, a page change, and a commit clear the selection whole.
+
+⇧-click in the body takes a seat that cell ranges would want (TablePro spans cells there and keeps row spans on its gutter); if cell ranges ship, body ⇧-click moves to them and the gutter keeps the row span.
 
 ## Navigation
 

--- a/ducktable/docs/UI.md
+++ b/ducktable/docs/UI.md
@@ -62,8 +62,8 @@ a shutdown request to the database server.
 The Edit menu owns Data-grid row operations. **New Row** (Cmd+N) creates an
 all-DEFAULT draft and enters its first useful writable cell. **Duplicate Row**
 (Cmd+D) copies the selected persisted row into one staged insert, omitting its
-primary-key and generated columns. **Delete Row** (Cmd+Delete) stages the
-selected row for deletion. Inserts and deletes remain visible and undoable
+primary-key and generated columns. **Delete Row** (Cmd+Delete) stages every
+selected row for deletion (Cmd-click and Shift-click build the selection). Inserts and deletes remain visible and undoable
 until the final Cmd+S commit boundary.
 
 ## Sizing

--- a/ducktable/vendor/gpui-component/src/table/delegate.rs
+++ b/ducktable/vendor/gpui-component/src/table/delegate.rs
@@ -56,6 +56,14 @@ pub trait TableDelegate: Sized + 'static {
             .child(self.column(col_ix, cx).name.clone())
     }
 
+    /// DuckTable patch: whether the delegate counts this row as selected.
+    /// The table knows one selected row; a delegate keeping a multi-row
+    /// selection answers here so the hover wash stays off every selected
+    /// row, not only the table's own.
+    fn row_selected(&self, _row_ix: usize, _cx: &App) -> bool {
+        false
+    }
+
     /// Render the row at the given row and column.
     ///
     /// Not include the table head row.

--- a/ducktable/vendor/gpui-component/src/table/state.rs
+++ b/ducktable/vendor/gpui-component/src/table/state.rs
@@ -319,7 +319,13 @@ where
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.set_selected_row(row_ix, cx);
+        // DuckTable patch: a ⌘- or ⇧-click belongs to the delegate's own
+        // multi-row selection, decided on mouse down; re-selecting the
+        // row here on mouse up would undo a ⌘-click that deselected it.
+        let m = e.modifiers();
+        if !(m.platform || m.shift) {
+            self.set_selected_row(row_ix, cx);
+        }
 
         if e.click_count() == 2 {
             cx.emit(TableEvent::DoubleClickedRow(row_ix));
@@ -1001,7 +1007,11 @@ where
                 .when(is_stripe_row, |this| this.bg(cx.theme().table_even))
                 .refine_style(&style)
                 .hover(|this| {
-                    if is_selected || self.right_clicked_row == Some(row_ix) {
+                    // DuckTable patch: the delegate's selection counts too.
+                    if is_selected
+                        || self.delegate.row_selected(row_ix, cx)
+                        || self.right_clicked_row == Some(row_ix)
+                    {
                         this
                     } else {
                         this.bg(cx.theme().table_hover)


### PR DESCRIPTION
Row multi-select in DuckTable's data grid, the way macOS lists read clicks: a plain click selects one row, **⌘-click** toggles a row in or out, and **⇧-click** selects the span from the anchor through the clicked row, replacing what was selected. The anchor is the last row clicked without ⇧, so a second ⇧-click re-spans from the same place. The row-number gutter and the body cells select the same way. TablePro's row gutter uses the same grammar ([DataGridRowGutterView.swift](https://github.com/TableProApp/TablePro/blob/main/TablePro/Views/Results/DataGridRowGutterView.swift)).

**The selection has a lead.** It is the row the ring, the inspector, and ⌘D act on, and the one row the vendored table still knows as selected. ⌘-clicking the lead away hands the role to the last remaining row; deselecting any other row leaves the lead alone so nothing scrolls. A click that deselects the ring's row takes the ring with it, from the gutter or the body.

**⌘⌫ stages a DELETE for every selected row** as one gesture: one ⌘Z brings them all back and one ⌘⇧Z replays them, while the review popover still lists and discards the rows one by one. The undo stack now holds groups of row operations, usually of one, so every single-row path is unchanged. ⌘⇧⌫ discard-all is grouped the same way, where it used to leave one entry per discard. Esc clears the whole selection, including a lead whose staged edits keep it off the library's own selection (an Esc on such a row used to leave it selected).

**Two marked patches to the vendored table.** Its mouse-up click no longer re-selects a row on a ⌘- or ⇧-click, which undid a deselect that mouse-down had just made. Its hover wash now asks the delegate which rows are selected through a new `row_selected` hook, instead of sparing only the one row it holds; before that, hovering any selected row but the lead painted the hover color over its tint and the row read as deselected.

**Deliberate limits.** ⌘D still duplicates one row, the lead. ⇧-click in the body takes a seat cell ranges would want; EDITING.md records that if ranges ship, body ⇧-click moves to them and the gutter keeps the row span, as TablePro does.

**Evidence.** The selection arithmetic is a pure `RowSelection` type with five unit tests (plain, toggle, span, an externally chosen lead, modifier precedence); the span test was seen to fail on a deliberately broken rule. Two more tests cover grouped undo: three deletes over a cell edit come back in one undo and replay in one redo, and a group of one or no mutations adds nothing to the stack; the first was seen to fail with the fold disabled. The crate's 38 tests pass. The grouped ⌘Z was pressed in the installed build and brought a ⇧-selected span back whole. In the installed release build, ⇧-spans were driven by hand, and that is where a screen recording showed the hover defect the second patch fixes. ⌘-toggle, multi-row ⌘⌫, the ring drop, and the hover fix itself are verified by the tests and by reading, not by driving.



