### PR TITLE
harbor 0.36.0: backup on one snapshot, connection replacement, locked operator settings

### DIFF
--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,53 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by signed tag date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.36.0 — 2026-09-11
+
+- **A backup reads one snapshot from its first pass to its last.** `backup`
+  walks a table more than once — the export, the blank-record scan, and the
+  quoted rewrite when the scan finds one — and inspects files in between, a
+  gap in which an ordinary session could idle out and hand the next pass a
+  newer snapshot. A session opened with `{"purpose":"backup"}` never idles
+  out; it lives in a 60-second window that `POST /sql/sessions/<id>/renew`
+  extends, and the client renews it from a heartbeat every twenty seconds,
+  through SQL and file work alike. Renewals travel the control path, so a busy
+  worker cannot starve them. Losing the lease aborts the backup, even
+  mid-response, rather than resuming on a snapshot the first pass never saw,
+  and an expired or released session cannot be revived. Ordinary sessions
+  cannot be renewed; `/sessions` reports `renewable`. An older server without
+  the route is refused with an explicit ask to upgrade.
+- **One statement per request, decided before any of it runs.** A body with
+  two statements used to run the leading ones and answer for the last; it is
+  now refused with `400` and nothing executes.
+- **A connection is replaced, not rolled back, before another caller sees
+  it.** `ROLLBACK` undoes a transaction and nothing else — a `SET VARIABLE`,
+  a temp table, a `PREPARE`, a `USE` all survived it onto the next request.
+  Any statement that can leave such state, including one wrapped in
+  `EXPLAIN ANALYZE`, now costs the worker a fresh engine connection, and a
+  released session gets the same treatment. The parsed-statement cache goes
+  with the connection.
+- **Operator settings are locked once the berth is up.** Memory, threads and
+  spill are fixed at `start`, and DuckDB's own `allowed_configs` and
+  `lock_configuration` now enforce it — a wrapped `SET threads` or a `SET
+  lock_configuration=false` is refused by the engine rather than by a keyword
+  check. Every other setting registered at startup stays changeable. Load
+  extensions whose settings must be tunable during `--init`; settings that
+  arrive later are outside the allowed list.
+- **Limits that answer instead of truncating.** A request body over the limit
+  is refused with `413` on both endpoints, chunked or not, where before the
+  excess was quietly cut off and parsed. The parsed-statement cache keeps at
+  most 64 texts and 1 MiB of SQL, and does not retain a statement over 64
+  KiB, so a one-off bulk `INSERT` runs but cannot pin every connection's cache.
+- **`config.toml` writes take a lock.** Concurrent membership updates each
+  land — an exclusive lock file, a per-writer temp file, no following of
+  symlinks — and a config directory exposed to group or world is refused
+  rather than written into.
+- The Windows banner prints `C:\...` rather than the `\\?\C:\...` that
+  `canonicalize` returns.
+- New `regressions` suite, run on an isolated one-worker server so connection
+  reuse is deterministic; `make test` now runs the workspace with all
+  features in release mode.
+
 ## 0.35.0 — 2026-09-09
 
 - Adds `harbor <db> backup [dir]` and `harbor <new.duckdb> restore <dir>`.

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]

--- a/harbor/Makefile
+++ b/harbor/Makefile
@@ -31,7 +31,7 @@ harbor:
 	cargo build -p harbor --release
 
 unit:
-	cargo test --release
+	cargo test --release --workspace --all-features
 
 test: harbor
 	test/scripts/check.sh

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -95,6 +95,7 @@ POST /sql                  run one statement, stream the result as NDJSON
 POST /sql/sessions         take a connection and hold it, for a transaction
 GET  /sql/sessions         list ALL open sessions — who holds each, how long
 DELETE /sql/sessions/<id>  give that one back
+POST /sql/sessions/<id>/renew  renew a backup lease
 DELETE /sql/queries/<id>   stop a statement the caller named when it sent it
 ```
 
@@ -204,7 +205,8 @@ under a client that still believed it was in a transaction.
 
 A transaction lives on a connection and HTTP requests do not, so one request
 per statement means no transaction can span two. A session bridges that: a
-connection pinned to you until you commit, roll back, or stop answering.
+connection pinned to you until you release it or its lease expires. COMMIT and
+ROLLBACK end the transaction; DELETE releases the session.
 
 ```console
 $ sid=$(curl -s -X POST 127.0.0.1:9495/sql/sessions | jq -r .sessionId)
@@ -226,13 +228,31 @@ pool serving both would run out of workers the moment enough clients held
 transactions open, and then answer nothing at all. With none free, opening a
 session is a `503` with `Retry-After` — queries keep working throughout.
 
-**Every session has a deadline.** HTTP has no reliable close signal, so a
+**Every session has a deadline.** Ordinary sessions have a fixed lifetime. HTTP has no reliable close signal, so a
 client that vanishes mid-transaction looks exactly like one that is thinking,
 and a timer is the only way that connection ever comes back. Ask for a lifetime
 with `{"ttlMs": N}`; harbor caps it at five minutes and answers with what it
 granted, alongside the thirty-second idle timeout it enforces regardless. When
 a session is reclaimed its transaction is rolled back, and so is one released
-with a transaction still open.
+with a transaction still open. Before reuse, Harbor replaces the engine
+connection, clearing temporary tables, variables, prepared statements, and
+connection-local settings. These remain available between requests within the
+same live session. One-shot requests also discard local state before the next
+caller; use a session whenever later statements depend on it.
+
+**Backup sessions renew their deadline.** Open one with `{"purpose":"backup"}`
+and require `"purpose":"backup"` in the response (older servers do not support
+this policy). Its `ttlMs` is a renewal window, default and maximum 60 seconds;
+`idleTtlMs` is zero. Send `POST /sql/sessions/<id>/renew` well before each deadline
+(the CLI uses 20-second intervals). Successful renewal returns `{"renewed":true}`
+and starts a fresh window, even while SQL is running. Heartbeats replace both
+the ordinary five-minute ceiling and the thirty-second statement-idle timeout.
+Expired or released leases return `404` and cannot be revived; ordinary leases
+cannot be renewed (`400`). `/sessions` reports `renewable` and `expiresInMs`.
+Renewals use the control path so a busy SQL worker cannot block them indefinitely.
+Custom shorter renewal windows must allow for network and scheduling delays,
+including up to five seconds before the control lane activates for forwarded
+lease work; the CLI uses the full 60-second window.
 
 **One statement at a time.** A second statement sent while the first is running
 gets a `409`: a transaction is a sequence, and two of them interleaving inside
@@ -483,8 +503,8 @@ row is a record, not always a line.
 | negative `INTERVAL` | ✅ | refused outright |
 | `TIMETZ` with an offset | ✅ | normalised to UTC, *silently* |
 
-Each hole is the other format's solid ground, so a table the chosen format
-cannot carry is written in the other one and said out loud:
+A table the chosen format cannot carry is written in the other format when
+that format can preserve all its types, and the change is reported:
 
 ```console
 $ harbor mydata.duckdb backup
@@ -498,14 +518,28 @@ every other table greppable. `--format parquet` asks for one format
 throughout — with the same swap running the other way for a `TIMETZ` column —
 and `--strict` refuses rather than swapping, for a backup that has to be one
 format or nothing. What no mode will do is write something that will not come
-back: a negative interval under `--format parquet` is an error, not a
-surprise six months from now.
+back: a negative interval under `--format parquet` is an error. A table
+combining UNION or VARIANT with TIMETZ is refused because neither whole-table
+format preserves it.
 
 The whole of this is a test suite rather than a claim: `test/scripts/roundtrip.py`
 backs up and restores every type in the shared corpus, a schema of constraints
 and indexes and views and sequences, the strings that attack the format, and a
 seeded fuzz of random tables — then attaches both databases and asks DuckDB
 whether anything differs.
+
+Backup holds one transaction for the initial export and every rewrite pass,
+so concurrent committed table changes cannot mix snapshots. It needs a free
+session connection. The CLI renews a 60-second lease every 20 seconds during
+both SQL and file inspection, so there is no fixed total backup lifetime.
+If the client disappears, missed renewals cause Harbor to cancel active work,
+roll back, and reclaim the connection. A renewal failure or failed pass aborts
+the backup and removes its incomplete directory; it never resumes on a newer
+snapshot. The operator's `--statement-timeout` still limits each SQL statement;
+configure it to accommodate the longest export pass. The server must support
+renewable backup sessions; older servers produce an explicit upgrade error. Exported data is scanned with a bounded buffer. Sequence counters
+are not transactional in DuckDB; quiesce sequence users when their exact
+position must correspond to the exported rows.
 
 The directory is self-contained. Each `COPY` in `load.sql` names its file and
 nothing more, so the backup can be moved, renamed, copied to another machine
@@ -543,6 +577,12 @@ remote host over ssh and uses the socket.
 Ordinary DuckDB SQL can read host files or load extensions. For a server whose
 callers should not receive those capabilities, `--sealed` disables host-file
 access and community extensions.
+After startup initialization, Harbor locks its memory, thread and spill settings
+inside DuckDB. SQL wrappers cannot override them or unlock configuration.
+Other settings registered at startup remain changeable unless `--init` imposed
+a stricter lock. Load extensions that need configurable settings during
+initialization; settings registered later are outside the allowed list.
+
 `--max-temp-size` bounds disk spill, and `--statement-timeout` places the
 hard statement ceiling described above. These are independent of Caddy's
 transport and HTTP policy.
@@ -638,7 +678,7 @@ TCP, 10-second `oha` runs, every response a 200:
 
 The HTTP layer is not the ceiling: `GET /ready` — the same plumbing with no
 SQL — measures ~99,000 req/s at 16 clients. Most of the per-request engine
-cost is amortized by the per-connection prepared-statement cache (below);
+cost is reduced by the per-connection parsed-statement cache (below);
 0.13.0 also coalesced each response head into a single buffered write, set
 `TCP_NODELAY`, and removed most per-request allocations from the HTTP layer.
 
@@ -665,14 +705,13 @@ fixed cost per execute — measured by driving each engine directly, no server:
 re-executing an already-prepared statement costs +11 µs on v2, while parsing
 fresh SQL text costs about 2× v1.5.5, growing with statement size. Execution
 itself is at parity or faster (bulk CTAS is quicker on v2 than on 1.5.5).
-Before 0.13.0 harbor parsed every request's SQL fresh, paying the parser on
-every statement; that was the whole gap. Since 0.13.0 each executor
-connection keeps an LRU of prepared statements keyed by statement text, so a
-repeated statement skips parse and plan entirely — which is why the pure-read
-numbers above sit where they do on a v2 engine. First-seen statement texts
-still pay the parser once; upstream is still optimizing it pre-GA, and real
-analytical queries never notice either way. Measure against the engine you
-deploy.
+The current v2 implementation caches parsed SQL, not bound execution plans.
+Each execution still binds against the current catalog. Each connection keeps
+at most 64 texts and 1 MiB of SQL text, skips caching individual statements
+larger than 64 KiB, and clears its cache when the connection is replaced. AST
+allocations are additional engine memory; these limits bound retained SQL text,
+not total process RSS. Historical benchmark figures above describe their stated
+versions; measure the current build against the engine you deploy.
 
 Every read in the mixed run was checked against an answer taken from the database
 file before the server opened it — a benchmark whose oracle is the server it is

--- a/harbor/crates/common/src/membership.rs
+++ b/harbor/crates/common/src/membership.rs
@@ -13,7 +13,10 @@
 //! same DOM either way.
 
 use crate::{paths, perms};
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use toml_edit::{value, DocumentMut, Item, Table};
 
 /// What an `attach` did, once the already-there case is resolved.
@@ -34,6 +37,7 @@ pub enum Attached {
 /// there — under whatever key already names this file. Returns the name it is
 /// filed under. Errors if the stem already belongs to a different file.
 pub fn attach(db: &Path) -> Result<(String, Attached), String> {
+    let _lock = lock_config()?;
     let canon = paths::canonical_db(db)?;
     if let Some(key) = listed_as(&canon) {
         return Ok((key, Attached::AlreadyThere));
@@ -45,10 +49,10 @@ pub fn attach(db: &Path) -> Result<(String, Attached), String> {
     if let Some((_, existing)) = find(&doc, &name)? {
         // Same file under the same name is idempotent success; a different file
         // wanting the same name is the collision only its author can resolve.
-        if let Some(p) = &existing {
-            if paths::canonical_db(&paths::expand(p)).ok() == Some(canon) {
-                return Ok((name, Attached::AlreadyThere));
-            }
+        if let Some(p) = &existing
+            && paths::canonical_db(&paths::expand(p)).ok() == Some(canon)
+        {
+            return Ok((name, Attached::AlreadyThere));
         }
         return Err(match existing {
             Some(p) => format!("'{name}' already names {p} — detach it first, or rename this one"),
@@ -67,6 +71,7 @@ pub fn attach(db: &Path) -> Result<(String, Attached), String> {
 /// section was actually there to remove; a missing file or absent name is a
 /// quiet `false`, never an error.
 pub fn detach(db: &Path) -> Result<(String, bool), String> {
+    let _lock = lock_config()?;
     let name = name_for(db)?;
     let mut doc = parse(&read()?)?;
 
@@ -82,6 +87,7 @@ pub fn detach(db: &Path) -> Result<(String, bool), String> {
 
 /// Add a named database reached through an existing Harbor TCP listener.
 pub fn add_remote(name: &str, url: &str) -> Result<String, String> {
+    let _lock = lock_config()?;
     let name = paths::normalize(name)?;
     let url = url.trim();
     if url.is_empty() {
@@ -101,6 +107,7 @@ pub fn add_remote(name: &str, url: &str) -> Result<String, String> {
 /// Remove a named connection without interpreting what kind it is. Front ends
 /// establish that policy before calling; this layer only preserves the TOML.
 pub fn remove_named(name: &str) -> Result<bool, String> {
+    let _lock = lock_config()?;
     let name = paths::normalize(name)?;
     let mut doc = parse(&read()?)?;
     let Some((key, _)) = find(&doc, &name)? else {
@@ -146,22 +153,67 @@ pub fn name_of(db: &Path) -> Result<String, String> {
     paths::normalize(stem)
 }
 
-fn read() -> Result<String, String> {
-    let file = paths::config_file()?;
-    Ok(std::fs::read_to_string(&file).unwrap_or_default())
-}
-
-/// Write the new config over the old, atomically and privately: a temp file in
-/// the same directory, then a rename, so a crash mid-write can never leave a
-/// half-config behind.
-fn write(text: &str) -> Result<(), String> {
+/// Hold this separate inode across the entire read-modify-rename operation.
+/// Never unlink the lock file: another process may already be waiting on it.
+fn lock_config() -> Result<File, String> {
     let root = paths::config_root()?;
     perms::ensure_private_dir(&root)?;
-    let file = root.join("config.toml");
-    let tmp = root.join("config.toml.tmp");
-    perms::write_private(&tmp, text).map_err(|e| format!("writing {}: {e}", tmp.display()))?;
-    std::fs::rename(&tmp, &file).map_err(|e| format!("replacing {}: {e}", file.display()))?;
-    Ok(())
+    let mut opts = OpenOptions::new();
+    opts.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = opts.open(root.join("config.toml.lock"))
+        .map_err(|e| format!("opening config lock: {e}"))?;
+    file.lock().map_err(|e| format!("locking config: {e}"))?;
+    Ok(file)
+}
+
+fn read() -> Result<String, String> {
+    let file = paths::config_file()?;
+    if perms::exposed(&file) {
+        return Err(format!("refusing to edit exposed config {}", file.display()));
+    }
+    match fs::read_to_string(&file) {
+        Ok(text) => Ok(text),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(format!("reading {}: {e}", file.display())),
+    }
+}
+
+/// Caller holds the config lock. Exclusive creation keeps even a stale temp
+/// file from a killed writer from being overwritten or followed as a symlink.
+fn write(text: &str) -> Result<(), String> {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let root = paths::config_root()?;
+    let (tmp, mut out) = loop {
+        let tmp = root.join(format!("config.toml.{}.{}.tmp",
+            std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed)));
+        let mut opts = OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        match opts.open(&tmp) {
+            Ok(out) => break (tmp, out),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("creating {}: {e}", tmp.display())),
+        }
+    };
+    let result = (|| {
+        out.write_all(text.as_bytes())?;
+        out.sync_all()?;
+        drop(out);
+        fs::rename(&tmp, root.join("config.toml"))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    result.map_err(|e| format!("writing config.toml: {e}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/harbor/crates/common/src/paths.rs
+++ b/harbor/crates/common/src/paths.rs
@@ -145,7 +145,7 @@ pub fn socket_for(runtime: &Path, db: &Path) -> Result<PathBuf, String> {
 /// its own name.
 pub fn canonical_db(db: &Path) -> Result<PathBuf, String> {
     if let Ok(c) = db.canonicalize() {
-        return Ok(c);
+        return Ok(without_verbatim_prefix(c));
     }
     let parent = match db.parent() {
         Some(p) if !p.as_os_str().is_empty() => p,
@@ -155,7 +155,24 @@ pub fn canonical_db(db: &Path) -> Result<PathBuf, String> {
     let parent = parent
         .canonicalize()
         .map_err(|e| format!("{}: {e}", parent.display()))?;
-    Ok(parent.join(name))
+    Ok(without_verbatim_prefix(parent.join(name)))
+}
+
+/// On Windows, `canonicalize` answers in the verbatim form — `\\?\C:\...`, or
+/// `\\?\UNC\host\share\...` — so that paths past 260 characters keep
+/// working. That prefix is for the kernel, not for a banner or for comparing
+/// against what someone typed, so the canonical identity drops it.
+fn without_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let Some(text) = path.to_str() else {
+        return path;
+    };
+    if let Some(rest) = text.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{rest}"));
+    }
+    if let Some(rest) = text.strip_prefix(r"\\?\") {
+        return PathBuf::from(rest);
+    }
+    path
 }
 
 pub fn sidecar_file(runtime: &Path, name: &str) -> PathBuf {
@@ -234,6 +251,14 @@ pub fn shorten(p: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn verbatim_prefix_is_dropped() {
+        let strip = |s: &str| super::without_verbatim_prefix(PathBuf::from(s));
+        assert_eq!(strip(r"\\?\C:\d\hb\hb.db"), PathBuf::from(r"C:\d\hb\hb.db"));
+        assert_eq!(strip(r"\\?\UNC\nas\share\hb.db"), PathBuf::from(r"\\nas\share\hb.db"));
+        assert_eq!(strip("/home/me/hb.db"), PathBuf::from("/home/me/hb.db"));
+    }
+
     use super::*;
 
     #[test]

--- a/harbor/crates/common/src/perms.rs
+++ b/harbor/crates/common/src/perms.rs
@@ -38,13 +38,15 @@ pub fn exposed(_path: &Path) -> bool {
 pub fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
-            .truncate(true)
+            .truncate(false) // secure an existing file before replacing its contents
             .mode(0o600)
             .open(path)?;
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        f.set_len(0)?;
         f.write_all(contents.as_bytes())
     }
     #[cfg(not(unix))]
@@ -88,6 +90,14 @@ pub fn ensure_private_dir(path: &Path) -> Result<(), String> {
     if !path.exists() {
         create_dir_private(path).map_err(|e| format!("cannot create {}: {e}", path.display()))?;
     }
-    let _ = chmod(path, 0o700);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let md = std::fs::metadata(path).map_err(|e| format!("{}: {e}", path.display()))?;
+        if md.uid() != unsafe { libc::getuid() } {
+            return Err(format!("{} is not owned by the current user", path.display()));
+        }
+    }
+    chmod(path, 0o700).map_err(|e| format!("securing {}: {e}", path.display()))?;
     Ok(())
 }

--- a/harbor/crates/harbor/src/backup.rs
+++ b/harbor/crates/harbor/src/backup.rs
@@ -64,8 +64,11 @@
 //! size can be chosen, since DuckDB fixes that when a file is created and
 //! offers no ALTER — so `--block-size` belongs here.
 
+use std::collections::HashMap;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use harbor::repl::{scan::{scan, Kind}, split_statements};
 
 /// The writer's dialect. Backup and restore must agree on it, so it is said
 /// once. `\t` is the two-character spelling DuckDB reads as a tab.
@@ -83,7 +86,7 @@ enum Format {
     /// Tab-separated: greppable, diffable, editable. The default, because the
     /// artifact outliving its engine is most of the point.
     Tsv,
-    /// Every table parquet: one format, every type, not readable by eye.
+    /// Binary columnar output, with the compatibility checks below.
     Parquet,
 }
 
@@ -226,23 +229,21 @@ pub fn backup(db: &Path, args: &[String]) -> Result<(), String> {
 /// here is an ordinary outcome rather than a surprise.
 fn write_backup(db: &Path, dir: &Path, format: Format, strict: bool) -> Result<(), String> {
     let target = db.display().to_string();
-    let sql = format!("EXPORT DATABASE {} ({})", quote(dir), format.options());
-    harbor::repl::exec_quiet(&target, &[&sql], &[])?;
-
-    // The loader is rewritten first, because reading it is how the tables
-    // text cannot carry are found — and rewriting it is how they are fixed.
-    let again = patch_loader(dir, format, strict)?;
-    if !again.statements.is_empty() {
-        let refs: Vec<&str> = again.statements.iter().map(String::as_str).collect();
-        harbor::repl::exec_quiet(&target, &refs, &[])?;
+    harbor::repl::with_snapshot(&target, |execute| {
+        let sql = format!("EXPORT DATABASE {} ({})", quote(dir), format.options());
+        execute(&sql)?;
+        let again = patch_loader(dir, format, strict)?;
+        for statement in &again.statements {
+            execute(statement)?;
+        }
         for stale in &again.replaced {
             fs::remove_file(stale).map_err(|e| format!("{}: {e}", stale.display()))?;
         }
         for note in &again.notes {
             eprintln!("harbor: {note}");
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// `harbor <db> restore <dir> [--block-size <s>]`.
@@ -362,26 +363,27 @@ struct Reformat {
 fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, String> {
     let path = dir.join("load.sql");
     let before = read(&path)?;
-    let schema = read(&dir.join("schema.sql"))?;
+    let schema = schema_types(&read(&dir.join("schema.sql"))?);
     let mut again = Reformat { statements: vec![], replaced: vec![], notes: vec![] };
 
     let mut lines: Vec<String> = Vec::new();
-    for line in before
-        .replace(&format!("'{}/", dir.display()), "'")
-        .replace("FORMAT 'csv'", "FORMAT 'csv', allow_quoted_nulls false")
-        .lines()
-    {
-        let swap = reformat(dir, line, &schema, format);
+    for original in split_statements(&before) {
+        let (table, _, name) = copy_parts(&original)
+            .ok_or_else(|| format!("unrecognized backup COPY statement: {original}"))?;
+        let file = Path::new(&name).file_name()
+            .ok_or_else(|| format!("invalid backup path: {name}"))?;
+        let line = format!("COPY {table} FROM {} ({})", quote(Path::new(file)), format.loader());
+        let swap = reformat(dir, &line, &schema, format)?;
         match swap {
-            Some((swapped, statement, stale, note)) if !strict => {
-                lines.push(swapped);
+            Some(TableRewrite { loader, statement, stale, note }) if !strict => {
+                lines.push(loader);
                 again.statements.push(statement);
                 again.replaced.push(stale);
                 again.notes.push(note);
             }
             // --strict: the answer to "text cannot hold this" is an error
             // rather than a change of format, however well announced.
-            Some((_, _, _, note)) => {
+            Some(TableRewrite { note, .. }) => {
                 let (head, why) = note.split_once(" — ").unwrap_or(("", ""));
                 let table = head.split(" is ").next().unwrap_or("");
                 return Err(format!(
@@ -397,7 +399,7 @@ fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, St
             // format — so it is checked here, on the file itself.
             None => {
                 if format == Format::Tsv
-                    && let Some((statement, note)) = requote(dir, line)?
+                    && let Some((statement, note)) = requote(dir, &line)?
                 {
                     again.statements.push(statement);
                     again.notes.push(note);
@@ -407,15 +409,16 @@ fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, St
         }
     }
 
-    let after = lines.join("\n") + "\n";
-    if after == before && !before.trim().is_empty() {
-        return Err(format!(
-            "{} was not in the shape this patch expects — see duckdb#25501",
-            path.display()
-        ));
-    }
+    let after = lines.iter().map(|s| format!("{};\n", s.trim_end_matches(';'))).collect::<String>();
     fs::write(&path, after).map_err(|e| format!("{}: {e}", path.display()))?;
     Ok(again)
+}
+
+struct TableRewrite {
+    loader: String,
+    statement: String,
+    stale: PathBuf,
+    note: String,
 }
 
 /// Is this `COPY` line loading a table the chosen format cannot hold? If so,
@@ -424,44 +427,37 @@ fn patch_loader(dir: &Path, format: Format, strict: bool) -> Result<Reformat, St
 fn reformat(
     dir: &Path,
     line: &str,
-    schema: &str,
+    schema: &HashMap<String, String>,
     format: Format,
-) -> Option<(String, String, PathBuf, String)> {
-    let (table, why) = schema.lines().find_map(|create| {
-        let why = format
-            .cannot_hold()
-            .iter()
-            .find(|(spelling, _)| create.contains(spelling))
-            .map(|(_, why)| *why)?;
-        let table = table_of(create)?;
-        line.starts_with(&format!("COPY {table} FROM '"))
-            .then_some((table.to_string(), why))
-    })?;
+) -> Result<Option<TableRewrite>, String> {
+    let (table, _, path) = copy_parts(line).ok_or("invalid backup COPY path")?;
+    let types = schema.get(table).ok_or_else(|| format!("no schema for backup table {table}"))?;
+    let Some((_, why)) = format.cannot_hold().iter().find(|(ty, _)| types.contains(ty)) else {
+        return Ok(None);
+    };
+    if let Some((_, why)) = format.other().cannot_hold().iter().find(|(ty, _)| types.contains(ty)) {
+        return Err(format!("{table} cannot round-trip in either backup format: {why}"));
+    }
 
-    // The file DuckDB chose, which is NOT always the table's name — a space
-    // in one becomes an underscore in the other.
-    let open = line.find('\'')? + 1;
-    let name = line[open..]
-        .split('\'')
-        .next()?
-        .strip_suffix(&format!(".{}", format.extension()))?
-        .to_string();
+    // The export filename need not match the table's SQL identifier.
+    let name = path.strip_suffix(&format!(".{}", format.extension()))
+        .ok_or("unexpected backup file extension")?;
     let instead = format.other();
 
-    Some((
-        format!(
-            "COPY {table} FROM '{name}.{}' ({});",
-            instead.extension(),
+    Ok(Some(TableRewrite {
+        loader: format!(
+            "COPY {table} FROM {} ({})",
+            quote(Path::new(&format!("{name}.{}", instead.extension()))),
             instead.loader()
         ),
-        format!(
+        statement: format!(
             "COPY {table} TO {} ({})",
             quote(&dir.join(format!("{name}.{}", instead.extension()))),
             instead.options()
         ),
-        dir.join(format!("{name}.{}", format.extension())),
-        format!("{table} is {}, not {} — {why}", instead.name(), format.name()),
-    ))
+        stale: dir.join(format!("{name}.{}", format.extension())),
+        note: format!("{table} is {}, not {} — {why}", instead.name(), format.name()),
+    }))
 }
 
 /// Does this table's export hold a record the reader would throw away? If so,
@@ -472,14 +468,14 @@ fn reformat(
 /// proxy for it: a blank line is what a CSV reader skips, so a file without
 /// one cannot lose a row and pays nothing.
 fn requote(dir: &Path, line: &str) -> Result<Option<(String, String)>, String> {
-    let Some(table) = line.strip_prefix("COPY ").and_then(|r| r.split(" FROM '").next()) else {
-        return Ok(None);
-    };
-    let Some(name) = line.split(" FROM '").nth(1).and_then(|r| r.split('\'').next()) else {
-        return Ok(None);
+    let Some((table, _, name)) = copy_parts(line) else {
+        return Err(format!("unrecognized backup COPY statement: {line}"));
     };
     let file = dir.join(name);
-    if !has_blank_record(&read(&file)?) {
+    let input = fs::File::open(&file).map_err(|e| format!("{}: {e}", file.display()))?;
+    if !has_blank_record(BufReader::new(input))
+        .map_err(|e| format!("{}: {e}", file.display()))?
+    {
         return Ok(None);
     }
     Ok(Some((
@@ -497,25 +493,32 @@ fn requote(dir: &Path, line: &str) -> Result<Option<(String, String)>, String> {
 /// lines, and a blank one INSIDE the quotes is part of the value and comes
 /// back fine. Only a blank line between records is lost, so the quotes have
 /// to be walked — which is the same thing the reader does.
-fn has_blank_record(text: &str) -> bool {
-    let (mut quoted, mut at_record_start) = (false, false);
-    for ch in text.chars() {
-        match ch {
-            '"' => {
-                quoted = !quoted;
-                at_record_start = false;
-            }
-            '\n' if !quoted => {
-                if at_record_start {
-                    return true;
-                }
-                at_record_start = true;
-            }
-            _ if !quoted => at_record_start = false,
-            _ => {}
+fn has_blank_record(mut input: impl BufRead) -> std::io::Result<bool> {
+    let (mut quoted, mut at_record_start) = (false, true);
+    loop {
+        let chunk = input.fill_buf()?;
+        if chunk.is_empty() {
+            return Ok(false);
         }
+        for &ch in chunk {
+            match ch {
+                b'"' => {
+                    quoted = !quoted;
+                    at_record_start = false;
+                }
+                b'\n' if !quoted => {
+                    if at_record_start {
+                        return Ok(true);
+                    }
+                    at_record_start = true;
+                }
+                _ if !quoted => at_record_start = false,
+                _ => {}
+            }
+        }
+        let n = chunk.len();
+        input.consume(n);
     }
-    false
 }
 
 /// The identifier after `CREATE TABLE`, spelled the way `load.sql` spells it
@@ -523,23 +526,43 @@ fn has_blank_record(text: &str) -> bool {
 /// walked rather than searched past.
 fn table_of(create: &str) -> Option<&str> {
     let rest = create.strip_prefix("CREATE TABLE ")?;
-    if !rest.starts_with('"') {
-        return rest.find('(').map(|end| &rest[..end]);
-    }
-    let bytes = rest.as_bytes();
-    let mut i = 1;
-    while i < bytes.len() {
-        if bytes[i] == b'"' {
-            if bytes.get(i + 1) == Some(&b'"') {
-                i += 2;
-                continue;
-            }
-            return Some(&rest[..=i]);
+    for span in scan(rest) {
+        if span.kind == Kind::Code
+            && let Some(end) = rest[span.start..span.end].find('(')
+        {
+            return Some(rest[..span.start + end].trim_end());
         }
-        i += 1;
     }
     None
 }
+
+/// Generated SQL still permits arbitrary quoted identifiers and string paths.
+/// Use the same scanner as the REPL, including escaped quotes and newlines.
+fn copy_parts(sql: &str) -> Option<(&str, std::ops::Range<usize>, String)> {
+    for span in scan(sql) {
+        if span.kind == Kind::Str && sql.as_bytes()[span.start] == b'\'' && span.terminated {
+            let table = sql[..span.start].trim_end().strip_prefix("COPY ")?
+                .strip_suffix(" FROM")?.trim_end();
+            let path = sql[span.start + 1..span.end - 1].replace("''", "'");
+            return Some((table, span.start..span.end, path));
+        }
+    }
+    None
+}
+
+fn unquoted_code(sql: &str) -> String {
+    scan(sql).iter().map(|span| {
+        if span.kind == Kind::Code { &sql[span.start..span.end] } else { " " }
+    }).collect()
+}
+
+/// Index the schema once, rather than rescanning every CREATE for each table.
+fn schema_types(sql: &str) -> HashMap<String, String> {
+    split_statements(sql).iter().filter_map(|create| {
+        Some((table_of(create)?.to_string(), unquoted_code(create)))
+    }).collect()
+}
+
 
 fn read(path: &Path) -> Result<String, String> {
     fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))
@@ -610,4 +633,44 @@ fn absolute(p: &str) -> Result<PathBuf, String> {
 /// A path as a SQL string literal.
 fn quote(p: &Path) -> String {
     format!("'{}'", p.display().to_string().replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_records_are_scanned_across_buffer_boundaries() {
+        for (text, expected) in [
+            ("x\n\n", true), ("x\n\"\"\n", false), ("x\n\"line\n\nend\"\n", false),
+            ("x\n\"a\"\"b\"\n\n", true), ("\n", true), ("x\nvalue\n", false),
+        ] {
+            for capacity in 1..8 {
+                let input = BufReader::with_capacity(capacity, text.as_bytes());
+                assert_eq!(has_blank_record(input).unwrap(), expected, "{text:?}, {capacity}");
+            }
+        }
+    }
+
+    #[test]
+    fn generated_sql_preserves_quoted_schemas_and_paths() {
+        let table = "\"odd schema\".\"a(\"\"b\n'c\"";
+        assert_eq!(table_of(&format!("CREATE TABLE {table}(v INTEGER);")), Some(table));
+        let sql = format!("COPY {table} FROM '/tmp/it''s here/a.csv' (FORMAT 'csv');");
+        let (got, span, path) = copy_parts(&sql).unwrap();
+        assert_eq!(got, table);
+        assert_eq!(path, "/tmp/it's here/a.csv");
+        assert_eq!(&sql[span], "'/tmp/it''s here/a.csv'");
+        assert_eq!(split_statements(&sql).len(), 1);
+    }
+
+    #[test]
+    fn incompatible_formats_fail_instead_of_losing_values() {
+        let schema = schema_types("CREATE TABLE t(u UNION(x INTEGER), z TIME WITH TIME ZONE)");
+        for (format, path) in [(Format::Tsv, "t.csv"), (Format::Parquet, "t.parquet")] {
+            assert!(reformat(Path::new("/tmp"), &format!("COPY t FROM '{path}'"), &schema, format).is_err());
+        }
+        let schema = schema_types("CREATE TABLE t(\"VARIANT\" VARCHAR DEFAULT 'UNION(x INT)')");
+        assert!(reformat(Path::new("/tmp"), "COPY t FROM 't.csv'", &schema, Format::Tsv).unwrap().is_none());
+    }
 }

--- a/harbor/crates/harbor/src/engine/conn.rs
+++ b/harbor/crates/harbor/src/engine/conn.rs
@@ -116,6 +116,10 @@ pub fn open(path: &Path, options: &[(&str, &str)]) -> Result<Conn, Error> {
 /// How many distinct statement texts each connection keeps parsed. Matches
 /// the v1 prepared-statement cache the executor relied on.
 const STMT_CACHE_CAP: usize = 64;
+// SQL bytes, not an estimate of the engine's AST allocations. Large one-off
+// imports still execute, but cannot fill every connection's retained cache.
+const STMT_CACHE_BYTES: usize = 1024 * 1024;
+const STMT_CACHE_MAX_SQL: usize = 64 * 1024;
 
 pub struct Conn {
     eng: &'static Engine,
@@ -127,6 +131,7 @@ pub struct Conn {
     interrupt: Arc<Mutex<ffi::connection_handle>>,
     /// Parsed-statement cache: SQL text → statements, LRU by tick.
     cache: HashMap<String, CacheEntry>,
+    cache_bytes: usize,
     tick: u64,
 }
 
@@ -152,6 +157,7 @@ impl Conn {
             conn,
             interrupt: Arc::new(Mutex::new(conn)),
             cache: HashMap::new(),
+            cache_bytes: 0,
             tick: 0,
         })
     }
@@ -159,6 +165,24 @@ impl Conn {
     /// Another connection to the same database — the pool's clone.
     pub fn try_clone(&self) -> Result<Conn, Error> {
         Conn::connect(self.db.clone())
+    }
+
+    /// Replace all connection-local state, including transactions, temporary
+    /// objects, variables and prepared statements. Keep the cancellation slot
+    /// stable: executor registrations already hold handles to this slot.
+    pub fn reset(&mut self) -> Result<(), Error> {
+        let mut fresh = Self::connect(self.db.clone())?;
+        let mut slot = self.interrupt.lock().unwrap();
+        // The old connection is dropped with its own slot after the swap.
+        // No caller can interrupt either handle during the replacement.
+        std::mem::swap(&mut self.conn, &mut fresh.conn);
+        *slot = self.conn;
+        *fresh.interrupt.lock().unwrap() = fresh.conn;
+        self.cache.clear();
+        self.cache_bytes = 0;
+        self.tick = 0;
+        drop(fresh);
+        Ok(())
     }
 
     pub fn engine_version(&self) -> &'static str {
@@ -256,7 +280,12 @@ impl Conn {
         self.tick += 1;
         if !self.cache.contains_key(sql) {
             let stmts = Arc::new(self.parse(sql)?);
-            if self.cache.len() >= STMT_CACHE_CAP {
+            if sql.len() > STMT_CACHE_MAX_SQL {
+                return Ok(stmts);
+            }
+            while self.cache.len() >= STMT_CACHE_CAP
+                || self.cache_bytes + sql.len() > STMT_CACHE_BYTES
+            {
                 if let Some(oldest) = self
                     .cache
                     .iter()
@@ -264,8 +293,10 @@ impl Conn {
                     .map(|(k, _)| k.clone())
                 {
                     self.cache.remove(&oldest);
+                    self.cache_bytes -= oldest.len();
                 }
             }
+            self.cache_bytes += sql.len();
             self.cache.insert(sql.to_string(), CacheEntry { stmts, used: self.tick });
         }
         let entry = self.cache.get_mut(sql).expect("just inserted");

--- a/harbor/crates/harbor/src/lib.rs
+++ b/harbor/crates/harbor/src/lib.rs
@@ -79,9 +79,9 @@ pub mod engine;
 //      123456789012345678901234567890 silently becomes 1.2345678901234568e+29
 //      in any JavaScript client.
 //
-// One statement per request, on purpose: it makes SQL injection through
-// string concatenation structurally impossible, and it keeps HTTP status
-// codes meaningful. Multi-statement work belongs on a session.
+// One statement per request keeps HTTP outcomes unambiguous. Bind parameters
+// for values: a single statement can still contain SQL injection if built by
+// concatenation. Multi-statement work belongs on a session.
 //
 // Concurrency: accept many connections, execute few queries. DuckDB
 // parallelises a single query across all cores, so running hundreds
@@ -123,20 +123,15 @@ const MAX_JSON_RESPONSE: usize = 32 << 20;
 // harbor IS DuckDB's process, so "the server" is a process singleton: one
 // listener, one worker pool.
 //
-// The pool is built up front, in one place: `start` opens the engine and
-// hands every connection harbor will ever use to `open_pool` before the
-// listener exists, and everything after draws from what is already there.
-// (The shape survives harbor's extension-era origin, where opening late was
-// impossible; it stays because a fixed pool makes concurrency arithmetic —
-// workers + leases — a boot-time fact instead of a runtime negotiation.)
+// Pool slots are allocated before the listener starts. Their number stays
+// fixed (workers + leases); a slot replaces its engine connection whenever
+// connection-local state must be discarded before reuse.
 //
 // One connection per worker, because a DuckDB connection is Send but not
 // Sync — two threads may not share one.
 // ---------------------------------------------------------------------------
 
-/// How many connections to open at load, when nothing says otherwise. Idle
-/// connections are nearly free; not being able to open one later is not, and
-/// "later" here means "ever" — see the note above.
+/// How many connection slots to allocate at load when nothing says otherwise.
 ///
 /// The default covers the default six workers with ten left over for leases.
 /// `HARBOR_POOL_SIZE` moves it, and has to, because this is the one number
@@ -531,7 +526,7 @@ struct Lease {
     conn: LeaseConn,
     opened: Instant,
     last: Instant,
-    deadline: Instant,
+    lifetime: LeaseLifetime,
     statements: u64,
     /// Whether the last transaction-control statement opened one. This is the
     /// field an operator actually wants: a lease sitting idle is a curiosity,
@@ -548,6 +543,31 @@ struct Lease {
     /// client that wanted to stop a long statement had no way to say so — the
     /// DELETE simply reported false and the lease ran on.
     doomed: bool,
+}
+
+/// Interactive leases have an absolute deadline. Backups instead prove client
+/// liveness with renewals; SQL activity alone never renews either kind.
+struct LeaseLifetime {
+    deadline: Instant,
+    renewal_ttl: Option<Duration>,
+}
+
+impl LeaseLifetime {
+    fn new(now: Instant, ttl: Duration, backup: bool) -> Self {
+        Self { deadline: now + ttl, renewal_ttl: backup.then_some(ttl) }
+    }
+
+    fn expired(&self, now: Instant, last: Instant, busy: bool, idle_ttl: Duration) -> bool {
+        now >= self.deadline
+            || (self.renewal_ttl.is_none() && !busy && now.duration_since(last) >= idle_ttl)
+    }
+
+    fn renew(&mut self, now: Instant) -> bool {
+        let Some(ttl) = self.renewal_ttl else { return false };
+        if now >= self.deadline { return false; }
+        self.deadline = now + ttl;
+        true
+    }
 }
 
 struct Leases {
@@ -570,12 +590,11 @@ impl Leases {
 
 static LEASES: Mutex<Option<Leases>> = Mutex::new(None);
 
-/// How long a lease may sit without a statement before it is reclaimed, and
-/// the longest life it may ask for. The idle timeout is what actually protects
-/// the checkpoint; the ceiling stops a client from asking for a lease that
-/// outlives the reason it was granted.
+/// Ordinary leases expire on statement inactivity or a fixed ceiling. Backup
+/// leases instead expire when the client stops renewing, even during SQL.
 const LEASE_IDLE_TTL: Duration = Duration::from_secs(30);
 const LEASE_MAX_TTL: Duration = Duration::from_secs(300);
+const BACKUP_RENEWAL_TTL: Duration = Duration::from_secs(60);
 const REAP_INTERVAL: Duration = Duration::from_millis(500);
 
 /// 18 bytes of CSPRNG, hex. Sessions are not a privilege boundary here —
@@ -593,9 +612,8 @@ fn new_lease_id() -> String {
     out
 }
 
-/// Run `ROLLBACK` on a lease connection and drain what it says. Called on
-/// every path that returns a connection to the free list, so a lease can never
-/// hand back a connection with a transaction still open on it.
+/// Replace the engine connection before returning a lease to the free list.
+/// This rolls back open work and discards all connection-local state.
 ///
 /// Outside the registry lock, always: this blocks on the executor, and holding
 /// the lock across it would serialise every other lease behind whatever this
@@ -623,7 +641,7 @@ fn quiesce(conn: &LeaseConn) {
 }
 
 /// Open a lease, or say why not. `Err` carries the status and body to send.
-fn lease_open(requested_ttl: Option<Duration>) -> Result<(String, Duration, Duration), Refusal> {
+fn lease_open(requested_ttl: Option<Duration>, backup: bool) -> Result<(String, Duration, Duration), Refusal> {
     let mut guard = LEASES.lock().unwrap();
     let Some(leases) = guard.as_mut() else {
         return Err(Refusal {
@@ -641,14 +659,9 @@ fn lease_open(requested_ttl: Option<Duration>) -> Result<(String, Duration, Dura
                 .to_string(),
         });
     }
-    // Two clocks, and they answer different questions. The deadline caps how
-    // long a lease may live at all, and the client may ask for less. The idle
-    // timeout is harbor's own and is not negotiable: it is what reclaims a
-    // client that stopped talking mid-transaction, which is the case that
-    // blocks checkpoints, and letting a client raise it would let a client
-    // disable it.
-    let ttl = requested_ttl.unwrap_or(leases.max_ttl).min(leases.max_ttl);
-    let idle_ttl = leases.idle_ttl;
+    let max_ttl = if backup { BACKUP_RENEWAL_TTL } else { leases.max_ttl };
+    let ttl = requested_ttl.unwrap_or(max_ttl).min(max_ttl);
+    let idle_ttl = if backup { Duration::ZERO } else { leases.idle_ttl };
     let Some(conn) = leases.free.pop() else {
         return Err(Refusal {
             status: 503,
@@ -660,7 +673,7 @@ fn lease_open(requested_ttl: Option<Duration>) -> Result<(String, Duration, Dura
         });
     };
     let now = Instant::now();
-    let deadline = now + ttl;
+    let lifetime = LeaseLifetime::new(now, ttl, backup);
     let id = new_lease_id();
     leases.live.insert(
         id.clone(),
@@ -668,7 +681,7 @@ fn lease_open(requested_ttl: Option<Duration>) -> Result<(String, Duration, Dura
             conn,
             opened: now,
             last: now,
-            deadline,
+            lifetime,
             statements: 0,
             in_transaction: false,
             busy: false,
@@ -676,6 +689,30 @@ fn lease_open(requested_ttl: Option<Duration>) -> Result<(String, Duration, Dura
         },
     );
     Ok((id, ttl, idle_ttl))
+}
+
+/// Renewals use only the registry lock, so the probe lane can serve them
+/// while SQL workers are occupied. Released or expired leases stay dead.
+fn lease_renew(id: &str) -> Result<(), Refusal> {
+    let missing = || Refusal {
+        status: 404, code: "no_such_session",
+        message: "backup session was released, expired, or never existed".into(),
+    };
+    let mut guard = LEASES.lock().unwrap();
+    let lease = guard.as_mut().and_then(|leases| leases.live.get_mut(id)).ok_or_else(missing)?;
+    let now = Instant::now();
+    if lease.doomed || now >= lease.lifetime.deadline { return Err(missing()); }
+    if !lease.lifetime.renew(now) {
+        return Err(Refusal {
+            status: 400, code: "bad_request", message: "only backup sessions can be renewed".into(),
+        });
+    }
+    Ok(())
+}
+
+fn renewal_session_id(path: &str) -> Option<&str> {
+    path.strip_prefix("/sql/sessions/")?.strip_suffix("/renew")
+        .filter(|id| !id.is_empty() && !id.contains('/'))
 }
 
 /// How long a statement will wait for a lease that is busy before refusing.
@@ -728,7 +765,8 @@ fn try_lease_claim(id: &str) -> Result<(mpsc::SyncSender<Job>, Arc<SlotState>), 
                 .to_string(),
         });
     };
-    if lease.doomed {
+    if lease.doomed || lease.lifetime.expired(Instant::now(), lease.last, lease.busy, leases.idle_ttl) {
+        lease.doomed = true;
         // The client asked for this lease's release; honoring new claims while
         // the cancel unwinds would let a "released" session that keeps sending
         // short statements stay busy at every reaper tick — held, with its
@@ -850,37 +888,35 @@ fn lease_reap() {
         Cancel(Arc<SlotState>, u64),
     }
     let actions: Vec<Action> = {
-        let guard = LEASES.lock().unwrap();
-        let Some(leases) = guard.as_ref() else { return };
+        let mut guard = LEASES.lock().unwrap();
+        let Some(leases) = guard.as_mut() else { return };
         let now = Instant::now();
         leases
             .live
-            .iter()
-            .filter_map(|(id, l)| match l.busy {
-                // Cancel once per tick while it is over its deadline. Repeating
-                // is deliberate: DuckDB checks the interrupt flag between
-                // pipeline steps, and a statement that swallowed the first one
-                // gets asked again rather than being left to run forever.
-                //
-                // The job id is captured with the decision. Between this
-                // snapshot and the fire below sit other actions, each a
-                // blocking quiesce — plenty of time for the doomed statement
-                // to finish and the connection to be reissued to an innocent.
-                // cancel(Some(job)) makes the late fire a no-op instead of a
-                // random casualty. A statement that has not begun yet (job 0)
-                // waits for the next tick.
-                true if now >= l.deadline || l.doomed => {
-                    let job = l.conn.state.current_job();
-                    (job != 0).then(|| Action::Cancel(Arc::clone(&l.conn.state), job))
+            .iter_mut()
+            .filter_map(|(id, l)| {
+                l.doomed |= l.lifetime.expired(now, l.last, l.busy, leases.idle_ttl);
+                match l.busy {
+                    // Cancel once per tick while it is over its deadline. Repeating
+                    // is deliberate: DuckDB checks the interrupt flag between
+                    // pipeline steps, and a statement that swallowed the first one
+                    // gets asked again rather than being left to run forever.
+                    //
+                    // The job id is captured with the decision. Between this
+                    // snapshot and the fire below sit other actions, each a
+                    // blocking quiesce — plenty of time for the doomed statement
+                    // to finish and the connection to be reissued to an innocent.
+                    // cancel(Some(job)) makes the late fire a no-op instead of a
+                    // random casualty. A statement that has not begun yet (job 0)
+                    // waits for the next tick.
+                    true if l.doomed => {
+                        let job = l.conn.state.current_job();
+                        (job != 0).then(|| Action::Cancel(Arc::clone(&l.conn.state), job))
+                    }
+                    true => None,
+                    false if l.doomed => Some(Action::Release(id.clone())),
+                    false => None,
                 }
-                true => None,
-                false if l.doomed
-                    || now >= l.deadline
-                    || now.duration_since(l.last) >= leases.idle_ttl =>
-                {
-                    Some(Action::Release(id.clone()))
-                }
-                false => None,
             })
             .collect()
     };
@@ -963,9 +999,8 @@ struct Running {
     addr: String,
 }
 
-/// Open every connection harbor will need. Called once, by `start` right
-/// after it opens the engine — see the note above on why the pool is fixed.
-pub fn open_pool(con: Connection) -> Result<(), String> {
+/// Allocate the fixed pool and lock operator settings after initialization.
+pub fn open_pool(mut con: Connection) -> Result<(), String> {
     let mut pool = POOL.lock().unwrap();
 
     // Once per process, not once per load. POOL and CONTROL are process-wide,
@@ -983,6 +1018,8 @@ pub fn open_pool(con: Connection) -> Result<(), String> {
                 .to_string(),
         );
     }
+
+    lock_operator_settings(&mut con)?;
 
     for _ in 0..configured_pool_size() {
         pool.push(con.try_clone().map_err(|e| format!("harbor: {e}"))?);
@@ -1720,6 +1757,18 @@ fn handle(
             // `/new` is the legacy 0.22-era spelling, kept until the next
             // deliberate break.
             (Method::Post, "/sql/sessions" | "/sql/sessions/new") => run_session_open(req),
+            (Method::Post, p) if renewal_session_id(p).is_some() => {
+                match lease_renew(renewal_session_id(p).unwrap()) {
+                    Ok(()) => {
+                        let _ = req.respond(json_response(200, r#"{"renewed":true}"#));
+                        (true, 200)
+                    }
+                    Err(e) => {
+                        let _ = req.respond(error_response(e.status, e.code, &e.message));
+                        (true, e.status)
+                    }
+                }
+            }
             // Release one. Idempotent by design: a client retrying a DELETE it
             // is not sure landed must not be able to free a connection twice.
             //
@@ -1785,23 +1834,12 @@ fn handle(
             },
             (Method::Post, "/sql") => match exec {
                 Some((jobs, state)) => {
-                    // Pre-size from the declared length, capped: the value is
-                    // client-chosen (up to MAX_BODY), so trust it only up to
-                    // 16KB and let anything larger grow normally.
-                    let mut body =
-                        String::with_capacity(req.body_length().unwrap_or(0).min(16 * 1024));
-                    // Not only UTF-8 any more: the socket carries a read
-                    // timeout, so a client that stops mid-body lands here too.
-                    if req.as_reader().take(MAX_BODY as u64).read_to_string(&mut body).is_err() {
-                        let _ = req.respond(error_response(
-                            400,
-                            "bad_request",
-                            "the request body could not be read: it is not valid UTF-8, or it \
-                             stopped arriving",
-                        ));
-                        (true, 400)
-                    } else {
-                        run_sql(req, jobs, state, &body)
+                    match read_request_body(&mut req) {
+                        Ok(body) => run_sql(req, jobs, state, &body),
+                        Err(e) => {
+                            let _ = req.respond(error_response(e.status, e.code, &e.message));
+                            (true, e.status)
+                        }
                     }
                 }
                 None => shed(req),
@@ -1892,7 +1930,8 @@ fn route_exists(method: &Method, path: &str) -> bool {
         (Method::Get, "/ready" | "/sql/sessions" | "/sessions" | "/info" | "/catalog")
             | (Method::Post | Method::Delete, "/shutdown")
             | (Method::Post, "/sql" | "/sql/sessions" | "/sql/sessions/new")
-    ) || (*method == Method::Delete
+    ) || (*method == Method::Post && renewal_session_id(path).is_some())
+      || (*method == Method::Delete
         && (path.starts_with("/sql/sessions/") || path.starts_with("/sql/queries/")))
 }
 
@@ -1990,21 +2029,6 @@ fn json_to_duckdb(v: &serde_json::Value) -> Result<Param, String> {
     })
 }
 
-/// Reject anything with a second statement in it.
-///
-/// This has to happen before the text reaches DuckDB, and it is not belt and
-/// braces. Multi-statement text runs everything up front: the executor runs
-/// every statement but the last to completion and streams the last (the
-/// contract v1 inherited from duckdb-rs's `prepare` and 0.21 keeps
-/// deliberately). So `SELECT 1; DROP TABLE orders` drops the table before a
-/// single row is fetched — the injection lands even if no result is read.
-///
-/// The scan is deliberately strict. It tracks the constructs in which a
-/// semicolon is data rather than a separator — string literals, quoted
-/// identifiers, dollar quotes, comments — and rejects a bare `;` with
-/// anything after it. Over-rejecting a statement someone could have written
-/// differently is a much smaller cost than under-rejecting one they should
-/// not have been able to write at all.
 /// A byte that can appear inside a DuckDB identifier. `$` is one of them,
 /// which is why a `$` after one does not open a dollar-quote; bytes >= 0x80
 /// are UTF-8 continuation or lead bytes and belong to whatever identifier
@@ -2013,6 +2037,9 @@ fn is_ident_byte(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'_' || c == b'$' || c >= 0x80
 }
 
+/// Early rejection for the public one-statement contract. The engine's parsed
+/// statement count is checked again before execution. This lexical scan keeps
+/// the existing strict handling of text following a trailing semicolon.
 fn ensure_single_statement(sql: &str) -> Result<(), String> {
     let b = sql.as_bytes();
     let mut i = 0;
@@ -2279,55 +2306,71 @@ const READY_MAX_AGE: Duration = Duration::from_secs(1);
 /// second.
 static LAST_READY: Mutex<Option<(Instant, bool)>> = Mutex::new(None);
 
+/// Read one extra byte to distinguish a complete body from a valid prefix
+/// of an oversized chunked request. Decode only after enforcing the byte cap.
+fn read_request_body(req: &mut Request) -> Result<String, Refusal> {
+    let capacity = req.body_length().unwrap_or(0).min(16 * 1024);
+    read_body(req.as_reader(), capacity)
+}
+
+fn read_body(reader: impl Read, capacity: usize) -> Result<String, Refusal> {
+    let mut body = Vec::with_capacity(capacity);
+    reader.take(MAX_BODY as u64 + 1).read_to_end(&mut body).map_err(|e| Refusal {
+        status: 400,
+        code: "bad_request",
+        message: format!("the request body could not be read: {e}"),
+    })?;
+    if body.len() > MAX_BODY {
+        return Err(Refusal {
+            status: 413,
+            code: "body_too_large",
+            message: format!("body exceeds the limit of {MAX_BODY} bytes"),
+        });
+    }
+    String::from_utf8(body).map_err(|_| Refusal {
+        status: 400,
+        code: "bad_request",
+        message: "the request body is not valid UTF-8".into(),
+    })
+}
+
 /// `POST /sql/sessions` — take a connection out of the pool and hold it.
 ///
-/// The body may ask for a lifetime (`{"ttlMs": N}`); harbor caps it at its own
-/// maximum and answers with the one it actually granted, alongside the idle
-/// timeout it enforces regardless. Both sides then know when the lease dies,
-/// which beats the client discovering it at COMMIT — the point at which the
-/// work is already done and cannot be redone cheaply.
+/// Interactive leases have a capped lifetime and idle timeout. A backup lease
+/// instead has a renewable liveness window, confirmed by `purpose` in the reply.
 fn run_session_open(mut req: Request) -> (bool, u16) {
-    let mut body = String::new();
-    if req.as_reader().take(MAX_BODY as u64).read_to_string(&mut body).is_err() {
-        let _ = req.respond(error_response(
-            400,
-            "bad_request",
-            "the request body could not be read: it is not valid UTF-8, or it stopped arriving",
-        ));
-        return (true, 400);
-    }
-    let requested = match body.trim().is_empty() {
-        true => None,
-        false => match serde_json::from_str::<serde_json::Value>(&body) {
-            Ok(v) => match v.get("ttlMs") {
-                None | Some(serde_json::Value::Null) => None,
-                Some(n) => match n.as_u64() {
-                    Some(ms) if ms > 0 => Some(Duration::from_millis(ms)),
-                    _ => {
-                        let _ = req.respond(error_response(
-                            400,
-                            "bad_request",
-                            "\"ttlMs\" must be a positive integer",
-                        ));
-                        return (true, 400);
-                    }
-                },
-            },
+    let body = match read_request_body(&mut req) {
+        Ok(body) => body,
+        Err(e) => {
+            let _ = req.respond(error_response(e.status, e.code, &e.message));
+            return (true, e.status);
+        }
+    };
+    let requested = if body.trim().is_empty() {
+        wire::SessionNewRequest::default()
+    } else {
+        match serde_json::from_str::<wire::SessionNewRequest>(&body) {
+            Ok(v) => v,
             Err(e) => {
                 let _ = req.respond(error_response(400, "bad_request", &e.to_string()));
                 return (true, 400);
             }
-        },
+        }
     };
+    if requested.ttl_ms == Some(0) {
+        let _ = req.respond(error_response(400, "bad_request", "\"ttlMs\" must be a positive integer"));
+        return (true, 400);
+    }
+    let backup = requested.purpose == Some(wire::SessionPurpose::Backup);
 
-    match lease_open(requested) {
+    match lease_open(requested.ttl_ms.map(Duration::from_millis), backup) {
         Ok((id, ttl, idle_ttl)) => {
-            let body = format!(
-                r#"{{"sessionId":"{}","ttlMs":{},"idleTtlMs":{}}}"#,
-                id,
-                ttl.as_millis(),
-                idle_ttl.as_millis()
-            );
+            let body = serde_json::to_string(&wire::SessionNewResponse {
+                session_id: id,
+                ttl_ms: ttl.as_millis() as u64,
+                idle_ttl_ms: idle_ttl.as_millis() as u64,
+                purpose: requested.purpose,
+            }).expect("session response serializes");
             let _ = req.respond(json_response(200, &body));
             (true, 200)
         }
@@ -2381,15 +2424,16 @@ fn sessions_report() -> String {
             out.push(',');
         }
         out.push_str(&format!(
-            r#"{{"sessionId":"{}","slot":{},"ageMs":{},"idleMs":{},"expiresInMs":{},"statements":{},"inTransaction":{},"busy":{}}}"#,
+            r#"{{"sessionId":"{}","slot":{},"ageMs":{},"idleMs":{},"expiresInMs":{},"statements":{},"inTransaction":{},"busy":{},"renewable":{}}}"#,
             id,
             lease.conn.slot,
             now.duration_since(lease.opened).as_millis(),
             now.duration_since(lease.last).as_millis(),
-            lease.deadline.saturating_duration_since(now).as_millis(),
+            lease.lifetime.deadline.saturating_duration_since(now).as_millis(),
             lease.statements,
             lease.in_transaction,
-            lease.busy
+            lease.busy,
+            lease.lifetime.renewal_ttl.is_some()
         ));
     }
     out.push_str("]}");
@@ -3271,9 +3315,8 @@ fn run_sql(
             400,
             "sql_error",
             &format!(
-                "{setting} is fixed when the berth starts (harbor start --memory-limit/--threads) \
-                 and cannot be changed over the wire: it is process-global, and this berth may \
-                 share its host with others"
+                "{setting} is protected by Harbor's startup configuration and cannot be \
+                 changed over the wire"
             ),
         ));
         return (true, 400);
@@ -3540,6 +3583,48 @@ pub fn parse_block_size(s: &str) -> Result<u64, String> {
     Ok(bytes)
 }
 
+const FENCED: &[&str] = &[
+    "memory_limit",
+    "max_memory",
+    "threads",
+    "worker_threads",
+    "external_threads",
+    // Disk spill is process-global too, and the operator caps it with
+    // `--max-temp-size` precisely so one query cannot fill the shared host
+    // disk. Left unfenced, `SET max_temp_directory_size='100TB'`
+    // over the wire erases that cap; `temp_directory` redirects the spill
+    // itself. Both are GLOBAL-scope in DuckDB — same class as the rest here.
+    "max_temp_directory_size",
+    "temp_directory",
+    "allowed_configs",
+    "lock_configuration",
+];
+
+/// Apply policy in the engine, so wrappers and future SQL forms cannot bypass
+/// the friendly request-time check. Initialization runs before this function.
+fn lock_operator_settings(conn: &mut Connection) -> Result<(), String> {
+    let locked = conn.query_strings("SELECT current_setting('lock_configuration')")
+        .map_err(|e| e.into_text())?;
+    if locked.first().map(String::as_str) == Some("true") {
+        // An operator may lock configuration during init, but must not leave
+        // any of Harbor's protected settings changeable.
+        let allowed = conn.query_strings("SELECT unnest(current_setting('allowed_configs'))")
+            .map_err(|e| e.into_text())?;
+        if allowed.iter().any(|s| FENCED.iter().any(|f| s.eq_ignore_ascii_case(f))) {
+            return Err("init locked configuration with protected settings in allowed_configs".into());
+        }
+        return Ok(());
+    }
+    let allowed = conn.query_strings("SELECT name FROM duckdb_settings() ORDER BY name")
+        .map_err(|e| e.into_text())?;
+    let allowed = allowed.iter()
+        .filter(|s| !FENCED.contains(&s.as_str()))
+        .map(|s| format!("'{}'", s.replace('\'', "''")))
+        .collect::<Vec<_>>().join(",");
+    conn.execute_batch(&format!("SET allowed_configs=[{allowed}]; SET lock_configuration=true"))
+        .map_err(|e| format!("cannot protect operator settings: {e}"))
+}
+
 /// Settings a client must not change: they are process-global in DuckDB, so
 /// one `SET memory_limit='100GB'` raises it for every neighbor berth on the
 /// host and defeats the fleet-safe cap the operator chose at berth start.
@@ -3548,20 +3633,6 @@ pub fn parse_block_size(s: &str) -> Result<u64, String> {
 /// Reads through comments, whitespace, and double-quoting via `next_word`, so
 /// neither `/*x*/ SET threads=8` nor `SET "memory_limit"=…` slips past.
 fn fenced_setting(sql: &str) -> Option<&'static str> {
-    const FENCED: &[&str] = &[
-        "memory_limit",
-        "max_memory",
-        "threads",
-        "worker_threads",
-        "external_threads",
-        // Disk spill is process-global too, and the operator caps it with
-        // `--max-temp-size` precisely so one query cannot fill the shared host
-        // disk. Left unfenced, `SET max_temp_directory_size='100TB'`
-        // over the wire erases that cap; `temp_directory` redirects the spill
-        // itself. Both are GLOBAL-scope in DuckDB — same class as the rest here.
-        "max_temp_directory_size",
-        "temp_directory",
-    ];
     let b = sql.as_bytes();
     let mut i = 0;
     if !matches!(next_word(b, &mut i).as_str(), "SET" | "RESET" | "PRAGMA") {
@@ -3574,10 +3645,8 @@ fn fenced_setting(sql: &str) -> Option<&'static str> {
     FENCED.iter().find(|f| name.eq_ignore_ascii_case(f)).copied()
 }
 
-/// Statements whose whole effect is connection-local, so a pooled connection
-/// discards it the moment the request ends. Companion to `fenced_setting`:
-/// that one refuses what would reach TOO far (process-global), this one
-/// refuses what would not reach far enough.
+/// Refuse USE outside a session: it cannot affect a later one-shot request.
+/// Other local changes are discarded by connection replacement before reuse.
 ///
 /// `USE` is the list. Reads through comments and whitespace via
 /// `first_keyword`, so `/*x*/ USE d` is caught with the bare form.
@@ -3590,78 +3659,37 @@ fn lost_without_session(sql: &str) -> bool {
 /// leaves it as it was. Used to report whether a lease is holding a
 /// transaction open, which is the thing an operator most needs to see.
 fn transaction_effect(sql: &str) -> Option<bool> {
-    match first_keyword(sql).as_str() {
+    match {
+        let b = sql.as_bytes();
+        let mut i = 0;
+        let word = next_word(b, &mut i);
+        if word == "EXPLAIN" && next_word(b, &mut i) == "ANALYZE" {
+            next_word(b, &mut i)
+        } else {
+            word
+        }
+    }.as_str() {
         "BEGIN" | "START" => Some(true),
         "COMMIT" | "END" | "ROLLBACK" | "ABORT" => Some(false),
         _ => None,
     }
 }
 
-/// Whether a statement could leave a transaction open behind it.
-///
-/// Only transaction-control statements can, because a statement that runs in
-/// autocommit commits or rolls back its own implicit transaction as it
-/// finishes. So the reset before the next job is only needed after one of
-/// these — or after a job that ended abnormally, which the caller tracks
-/// separately.
-///
-/// Fail-safe by construction: this answers true for anything it does not
-/// recognise, so a statement form nobody thought of costs one `ROLLBACK`
-/// rather than leaving a transaction open. Getting it wrong in the other
-/// direction is what took connections out of service permanently.
-fn may_leave_transaction_open(sql: &str) -> bool {
-    let word = first_keyword(sql);
-    if word.is_empty() {
-        return true;
-    }
-    // Statement kinds that run under autocommit and settle themselves. Anything
-    // absent from this list — BEGIN, START, COMMIT, ROLLBACK, ABORT, END, and
-    // whatever DuckDB adds next — takes the safe path.
+/// Statements that can leave connection-local state need a fresh connection
+/// before another caller uses this worker. Only known state-neutral statement
+/// forms keep their parse cache; wrappers, SET, temporary DDL and unknown forms
+/// take the conservative path. Pinned sessions reset only on release.
+fn needs_connection_reset(sql: &str) -> bool {
     !matches!(
-        word.as_str(),
+        first_keyword(sql).as_str(),
         "SELECT" | "WITH" | "FROM" | "VALUES" | "TABLE"
             | "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "TRUNCATE"
-            | "CREATE" | "DROP" | "ALTER" | "COMMENT"
-            | "COPY" | "EXPORT" | "IMPORT"
-            | "ATTACH" | "DETACH" | "USE"
-            | "PRAGMA" | "SET" | "RESET" | "CHECKPOINT" | "ANALYZE" | "VACUUM"
-            | "EXPLAIN" | "DESCRIBE" | "SHOW" | "SUMMARIZE" | "PIVOT" | "UNPIVOT"
-            | "CALL" | "PREPARE" | "EXECUTE" | "DEALLOCATE"
-            | "INSTALL" | "LOAD"
+            | "COPY" | "EXPORT" | "CHECKPOINT" | "ANALYZE" | "VACUUM"
+            | "DESCRIBE" | "SHOW" | "SUMMARIZE" | "PIVOT" | "UNPIVOT"
     )
 }
 
-/// Return a connection to autocommit before anything else runs on it.
-///
-/// Pooled connections are handed out per request and are never pinned to a
-/// client, so a transaction cannot usefully span two requests — but a client
-/// can still send `BEGIN`, and DuckDB will honour it. That leaves the
-/// connection inside a transaction for whoever gets it next, and if the
-/// transaction has already failed, every subsequent statement on it comes back
-/// `Current transaction is aborted` for the life of the process. One request
-/// from one careless client would otherwise take a worker out of service
-/// permanently, and with a pool of eight it takes eight such requests to stop
-/// the server answering at all.
-///
-/// Rolling back is the only correct choice here: the client that opened the
-/// transaction has no way to commit it, since its next request will land on a
-/// different connection.
-///
-/// When to run it is decided from the statement TEXT, not from asking the
-/// engine: `execute_jobs` calls this only when `may_leave_transaction_open`
-/// saw a transaction-shaped statement or the job ended abnormally (see the
-/// `needs_reset` widening in `run_statement`). History earned that design
-/// twice over: an engine-side `is_autocommit()` probe once turned out to be
-/// a stub that always said `true`, silently leaving `BEGIN`'s transaction
-/// open until some later job on the same connection happened to end badly —
-/// observable as `cannot start a transaction within a transaction`. And
-/// running it unconditionally afterward cost ~20% of small-statement
-/// throughput. The text-derived flag pays only when the risk exists.
-///
-/// A `ROLLBACK` on a connection that has nothing to roll back is cheap, and far
-/// cheaper than the failure it prevents — an open transaction also blocks
-/// `CHECKPOINT`, including the one `stop()` runs, which is how a WAL goes
-/// unfolded.
+/// Final rollback during server shutdown, before returning connections.
 fn reset_transaction(conn: &mut Connection) {
     let _ = conn.execute_batch("ROLLBACK");
 }
@@ -3699,7 +3727,7 @@ impl Drop for OnSlot<'_> {
 /// One statement, start to finish, on the executor's connection: prepare,
 /// stream (NDJSON) or buffer (one-shot JSON) the result, and report the
 /// outcome on `ready`/`body`. Returns whether the connection needs a
-/// `ROLLBACK` before the next job. Split out of `execute_jobs` so the whole
+/// fresh engine connection before the next job. Split out of `execute_jobs` so the whole
 /// thing runs under one `catch_unwind` there: a panic in the DuckDB client (a
 /// decoder that hits `unreachable!`, a metadata assert) must not take the
 /// executor thread — and with it a worker and a pool slot — down for good.
@@ -3720,7 +3748,7 @@ fn run_statement(
 ) -> bool {
     // Decided from the statement text before it runs, then widened below by
     // any path that ends the job early.
-    let mut needs_reset = may_leave_transaction_open(&sql);
+    let mut needs_reset = needs_connection_reset(&sql);
 
     // Parsed once, cached by SQL text (per-connection LRU) — a repeated
     // statement skips DuckDB's parse, the dominant engine cost for small
@@ -3745,17 +3773,17 @@ fn run_statement(
         return true;
     };
 
-    // Multi-statement text: everything before the last statement runs to
-    // completion first, parameterless, and the stream is the last one's —
-    // v1 behaved this way because duckdb-rs's prepare() executed the front
-    // and returned the tail prepared, and the contract stays.
-    for stmt in front {
-        // In place, no fetch thread: nobody reads these chunks, so the
-        // pipeline would be a spawn and a join per statement for nothing.
-        if let Err(e) = conn.drain(stmt) {
-            let _ = ready.send(Err(refusal_for(on_slot.finish(), e.into_text())));
-            return true;
-        }
+    // Parsing is side-effect free. Enforce the public one-statement contract
+    // with the engine's parser before executing anything, even if the lexical
+    // check at the HTTP boundary misses a new grammar form.
+    if !front.is_empty() {
+        on_slot.finish();
+        let _ = ready.send(Err(Refusal {
+            status: 400,
+            code: "bad_request",
+            message: "exactly one SQL statement is allowed per request".into(),
+        }));
+        return needs_reset;
     }
     let mut stream = match conn.execute(last, &params) {
         Ok(s) => s,
@@ -3984,46 +4012,40 @@ fn run_statement(
     needs_reset
 }
 
-/// The DuckDB side. Owns one connection for the life of the server and runs
+/// The DuckDB side. Owns a connection slot for the life of the server and runs
 /// one statement at a time; concurrency comes from there being several of
 /// these, not from any one of them interleaving work. `pinned` marks a lease
 /// connection: the per-job reset that stops one request's stray transaction
 /// from leaking into the next request on the same connection must not fire on
 /// a lease, because holding that transaction open is precisely what a lease is
-/// for — the rollback happens instead when the lease is released, by commit,
-/// by DELETE, or by the reaper.
+/// for. Connection replacement happens on DELETE or expiry; COMMIT alone
+/// keeps the session and its local state.
 fn execute_jobs(
     mut conn: Connection,
     jobs: mpsc::Receiver<Job>,
     pinned: bool,
     state: Arc<SlotState>,
 ) -> Connection {
-    // The parse cache (64 texts, in Conn itself) covers a working set of
-    // distinct statement texts — dashboards cycle through dozens.
-    // Set by the previous job when it could have left a transaction open: a
-    // transaction-control statement, or any exit other than running to
-    // completion. Resetting unconditionally is also correct, and was what this
-    // did for a while, but it puts a `ROLLBACK` in front of every request —
-    // measurably, about 20% of throughput at 16 clients. The flag has to be set
-    // from something real, though: it used to consult
-    // `Connection::is_autocommit()`, which duckdb-rs hardcodes to `true`, so
-    // that half of the condition never fired at all.
     let mut needs_reset = false;
+    // A failed replacement must never make the contaminated handle usable,
+    // including when a released lease is assigned to another caller.
+    let mut must_reset = false;
     for job in jobs {
-        // Before, not after: a job can leave the loop by several paths, and
-        // this way none of them can skip the reset.
-        if needs_reset && !pinned {
-            reset_transaction(&mut conn);
-        }
-
         let Job { sql, params, shape, id, deadline, reset, ready, body } = job;
-        if reset {
-            // Same call the workers make between requests, and unconditional:
-            // this runs once per lease release, not once per statement, so the
-            // throughput argument that made it conditional there does not
-            // apply here.
-            reset_transaction(&mut conn);
+        must_reset |= reset || (needs_reset && !pinned);
+        if must_reset {
+            if let Err(e) = conn.reset() {
+                let _ = ready.send(Err(Refusal {
+                    status: 503,
+                    code: "unavailable",
+                    message: format!("cannot reset connection: {e}"),
+                }));
+                continue;
+            }
             needs_reset = false;
+            must_reset = false;
+        }
+        if reset {
             let _ = ready.send(Ok(()));
             continue;
         }
@@ -4253,6 +4275,64 @@ mod tests {
     use crate::encode::varint_to_decimal;
     use super::{Cancel, SlotRun};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn delivered_body_limit_checks_the_extra_byte() {
+        let mut input = vec![b' '; super::MAX_BODY];
+        assert_eq!(super::read_body(input.as_slice(), 0).ok().unwrap().len(), super::MAX_BODY);
+        input.push(b'x');
+        assert_eq!(super::read_body(input.as_slice(), 0).err().unwrap().status, 413);
+        assert_eq!(super::read_body(&b"\xff"[..], 0).err().unwrap().status, 400);
+    }
+
+    #[test]
+    fn engine_policy_blocks_wrappers_and_cannot_be_unlocked() {
+        if crate::engine::engine().is_err() { return; }
+        let mut conn = crate::engine::conn::open(std::path::Path::new(":memory:"), &[]).unwrap();
+        super::lock_operator_settings(&mut conn).unwrap();
+        for sql in [
+            "EXPLAIN ANALYZE SET threads=2",
+            "EXPLAIN ANALYZE SET worker_threads=2",
+            "EXPLAIN ANALYZE SET max_memory='1GB'",
+            "EXPLAIN ANALYZE RESET memory_limit",
+            "EXPLAIN ANALYZE SET allowed_configs=['threads']",
+            "EXPLAIN ANALYZE SET lock_configuration=false",
+        ] {
+            assert!(conn.execute_batch(sql).is_err(), "policy bypass: {sql}");
+        }
+        conn.execute_batch("SET default_order='DESC'").unwrap();
+        // A pre-locked safe configuration remains valid on initialization.
+        super::lock_operator_settings(&mut conn).unwrap();
+    }
+
+    #[test]
+    fn engine_statement_count_is_checked_before_any_execution() {
+        if crate::engine::engine().is_err() { return; }
+        let mut conn = crate::engine::conn::open(std::path::Path::new(":memory:"), &[]).unwrap();
+        let state = super::SlotState {
+            interrupt: conn.interrupt_handle(), run: std::sync::Mutex::new(idle()),
+        };
+        state.begin(1, None);
+        let mut slot = super::OnSlot { slot: &state, done: false };
+        let (ready, result) = std::sync::mpsc::sync_channel(1);
+        let (body, _output) = std::sync::mpsc::sync_channel(1);
+        super::run_statement(&mut conn, &mut slot,
+            "CREATE TABLE must_not_exist(x INTEGER); SELECT 1".into(), vec![],
+            super::Shape::Json, ready, body, Instant::now());
+        assert_eq!(result.recv().unwrap().err().unwrap().status, 400);
+        assert!(conn.execute_batch("SELECT * FROM must_not_exist").is_err());
+    }
+
+    #[test]
+    fn wrappers_and_local_mutations_require_connection_reset() {
+        for sql in ["EXPLAIN ANALYZE BEGIN", "CALL f()", "EXECUTE s", "SET VARIABLE x=1",
+            "CREATE TEMP TABLE t(x INTEGER)", "PREPARE s AS SELECT 1", "BEGIN"] {
+            assert!(super::needs_connection_reset(sql), "{sql}");
+        }
+        assert!(!super::needs_connection_reset("INSERT INTO t VALUES (1)"));
+        assert_eq!(super::transaction_effect("EXPLAIN /* x */ ANALYZE BEGIN"), Some(true));
+        assert_eq!(super::transaction_effect("EXPLAIN BEGIN"), None);
+    }
 
     #[test]
     fn the_tcp_door_is_one_ipv4_listener() {
@@ -4671,6 +4751,28 @@ UNION ALL SELECT 1::UBIGINT AS table_ordinal, count(*)::UBIGINT AS row_count FRO
     }
 
     #[test]
+    fn backup_lifetime_renews_beyond_interactive_ceiling_but_cannot_revive() {
+        use super::{LeaseLifetime, BACKUP_RENEWAL_TTL, LEASE_MAX_TTL, LEASE_IDLE_TTL};
+        let start = Instant::now();
+        let mut backup = LeaseLifetime::new(start, BACKUP_RENEWAL_TTL, true);
+        let mut interactive = LeaseLifetime::new(start, LEASE_MAX_TTL, false);
+        assert!(!interactive.renew(start));
+        for seconds in (20..=600).step_by(20) {
+            let now = start + Duration::from_secs(seconds);
+            // No SQL activity: a long file scan does not consume the idle TTL.
+            assert!(!backup.expired(now, start, false, LEASE_IDLE_TTL));
+            assert!(backup.renew(now));
+        }
+        let end = start + Duration::from_secs(660);
+        assert!(backup.expired(end, start, true, LEASE_IDLE_TTL));
+        assert!(!backup.renew(end));
+        assert!(!backup.renew(end + Duration::from_secs(1)));
+        assert!(interactive.expired(start + LEASE_MAX_TTL, start, true, LEASE_IDLE_TTL));
+        assert!(interactive.expired(start + LEASE_IDLE_TTL, start, false, LEASE_IDLE_TTL));
+        assert!(!interactive.expired(start + LEASE_IDLE_TTL, start, true, LEASE_IDLE_TTL));
+    }
+
+    #[test]
     fn route_exists_matches_the_dispatch_table() {
         // Guards the hand-maintained coupling between `route_exists` and the
         // dispatch match in `handle`. Every real endpoint is a route; a known path
@@ -4688,11 +4790,14 @@ UNION ALL SELECT 1::UBIGINT AS table_ordinal, count(*)::UBIGINT AS row_count FRO
                 other => panic!("wire publishes an unmapped method: {other}"),
             }
         }
-        let ids = [wire::endpoint::session("abc"), wire::endpoint::query("xyz")];
+        let ids = [wire::endpoint::session("abc"), wire::endpoint::query("xyz"), wire::endpoint::session_renew("abc")];
         for r in wire::endpoint::FIXED.iter().chain(ids.iter()) {
             assert!(route_exists(&method(r.method), &r.path), "wire publishes {r}, harbor does not serve it");
         }
         let non_routes = [
+            (Method::Post, "/sql/sessions//renew"),
+            (Method::Post, "/sql/sessions/a/b/renew"),
+            (Method::Get, "/sql/sessions/abc/renew"),
             (Method::Get, "/sql"),      // method matters
             (Method::Post, "/ready"),   // method matters
             (Method::Get, "/health"),   // never existed

--- a/harbor/crates/harbor/src/repl/http.rs
+++ b/harbor/crates/harbor/src/repl/http.rs
@@ -6,7 +6,7 @@
 //! a time, so an async stack would be pure weight.
 
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 #[cfg(unix)]
@@ -80,11 +80,12 @@ pub fn request(
 /// Like `request`, but built for long-running /sql streams: the socket gets a
 /// short read timeout so the caller's read loop ticks (and can notice a
 /// Ctrl-C), while status and header reads here retry through those ticks.
+/// A callback error aborts the request, including before any headers arrive.
 pub fn request_streaming(
     transport: &Transport,
     route: &Route,
     body: Option<&str>,
-    on_tick: &dyn Fn(),
+    on_tick: &dyn Fn() -> io::Result<()>,
 ) -> io::Result<Response> {
     request_inner(transport, route, body, Some(Duration::from_millis(250)), Some(on_tick))
 }
@@ -94,18 +95,29 @@ fn request_inner(
     route: &Route,
     body: Option<&str>,
     timeout: Option<Duration>,
-    on_tick: Option<&dyn Fn()>,
+    on_tick: Option<&dyn Fn() -> io::Result<()>>,
 ) -> io::Result<Response> {
     let (stream, host): (Box<dyn Stream>, String) = match transport {
         #[cfg(unix)]
         Transport::Unix(p) => {
             let s = UnixStream::connect(p)?;
             s.set_read_timeout(timeout)?;
+            s.set_write_timeout(timeout.map(|t| t.max(Duration::from_secs(5))))?;
             (Box::new(s), "harbor".to_string())
         }
         Transport::Tcp(addr) => {
-            let s = TcpStream::connect(addr)?;
+            let s = if let Some(timeout) = timeout {
+                let mut result = Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "no server address"));
+                for address in addr.to_socket_addrs()? {
+                    result = TcpStream::connect_timeout(&address, timeout.max(Duration::from_secs(5)));
+                    if result.is_ok() { break; }
+                }
+                result?
+            } else {
+                TcpStream::connect(addr)?
+            };
             s.set_read_timeout(timeout)?;
+            s.set_write_timeout(timeout.map(|t| t.max(Duration::from_secs(5))))?;
             (Box::new(s), addr.clone())
         }
     };
@@ -133,11 +145,9 @@ fn request_inner(
     // a query that has not sent a byte yet.
     let read_line = |reader: &mut BufReader<Box<dyn Stream>>, line: &mut String| -> io::Result<usize> {
         loop {
+            if let Some(f) = on_tick { f()?; }
             match reader.read_line(line) {
                 Err(e) if on_tick.is_some() && matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut) => {
-                    if let Some(f) = on_tick {
-                        f();
-                    }
                     continue;
                 }
                 other => return other,

--- a/harbor/crates/harbor/src/repl/mod.rs
+++ b/harbor/crates/harbor/src/repl/mod.rs
@@ -20,10 +20,13 @@ mod highlight;
 mod http;
 mod interactive;
 mod keywords;
-mod scan;
+pub mod scan;
 mod theme;
+mod snapshot;
+pub use snapshot::with_snapshot;
 
 pub use http::Transport;
+pub use interactive::split_statements;
 
 use wire::{Event, SqlRequest, endpoint};
 use render::{Mode, RenderOpts, Renderer};
@@ -864,6 +867,13 @@ fn list() -> Result<(), String> {
 }
 
 fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
+    run_sql_in_session(conn, sql, opts, None, None)
+}
+
+fn run_sql_in_session(
+    conn: &Conn, sql: &str, opts: &RenderOpts, session: Option<&str>,
+    health: Option<&snapshot::Health>,
+) -> Outcome {
     let wall = std::time::Instant::now();
     let qid = format!("cli-{}-{}", std::process::id(), QUERY_SEQ.fetch_add(1, Ordering::Relaxed));
     // A Ctrl-C that landed between statements (say, while the pager showed
@@ -875,6 +885,7 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
     let body = serde_json::to_string(&SqlRequest {
         sql: sql.to_string(),
         query_id: Some(qid.clone()),
+        session_id: session.map(str::to_string),
         ..Default::default()
     })
     .expect("request serializes");
@@ -886,7 +897,8 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
         let spun = AtomicU64::new(0);
         let conn = conn.clone();
         let qid = qid.clone();
-        move || {
+        move || -> std::io::Result<()> {
+            if let Some(health) = health { health.check()?; }
             // The spinner rides the same ticks as cancellation: half-second
             // updates on stderr, only at a terminal, erased when data lands.
             if std::io::stderr().is_terminal() {
@@ -910,6 +922,7 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
                     std::process::exit(130);
                 }
             }
+            Ok(())
         }
     };
     let resp = match http::request_streaming(&conn.transport, &endpoint::SQL, Some(&body), &on_tick) {
@@ -921,7 +934,10 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
     // the streaming read timeout, so ride the ticks until the body lands.
     if resp.status >= 300 {
         let status = resp.status;
-        let text = read_patient(resp.body, &on_tick);
+        let text = match read_patient(resp.body, &on_tick) {
+            Ok(text) => text,
+            Err(e) => return err(&format!("reading response: {e}")),
+        };
         clear_spinner();
         return match Event::parse(text.trim()) {
             Ok(Event::Error { code, .. }) if code == wire::code::CANCELLED => {
@@ -946,6 +962,9 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
     let mut scanned = 0usize;
     let mut chunk = [0u8; 8192];
     loop {
+        if let Some(health) = health && let Err(e) = health.check() {
+            return err(&e.to_string());
+        }
         // Reading bytes, not read_line: the socket ticks every 250ms
         // (request_streaming) and a tick can land mid-line. read_line decodes
         // UTF-8 as it goes, so a tick arriving in the middle of a multi-byte
@@ -965,7 +984,7 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
                         std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                     ) =>
                 {
-                    on_tick();
+                    if let Err(e) = on_tick() { return err(&e.to_string()); }
                 }
                 Err(e) => return err(&format!("stream died: {e}")),
             }
@@ -1019,7 +1038,7 @@ fn run_sql(conn: &Conn, sql: &str, opts: &RenderOpts) -> Outcome {
 
 /// Read a whole (small) body over a socket that has the streaming tick
 /// timeout, retrying through the ticks with a hard 5s ceiling.
-fn read_patient(mut body: Box<dyn BufRead>, on_tick: &dyn Fn()) -> String {
+fn read_patient(mut body: Box<dyn BufRead>, on_tick: &dyn Fn() -> std::io::Result<()>) -> std::io::Result<String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     let mut buf = Vec::new();
     let mut chunk = [0u8; 4096];
@@ -1028,7 +1047,7 @@ fn read_patient(mut body: Box<dyn BufRead>, on_tick: &dyn Fn()) -> String {
             Ok(0) => break,
             Ok(n) => buf.extend_from_slice(&chunk[..n]),
             Err(e) if matches!(e.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut) => {
-                on_tick();
+                on_tick()?;
                 if std::time::Instant::now() > deadline {
                     break;
                 }
@@ -1036,7 +1055,7 @@ fn read_patient(mut body: Box<dyn BufRead>, on_tick: &dyn Fn()) -> String {
             Err(_) => break,
         }
     }
-    String::from_utf8_lossy(&buf).into_owned()
+    Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
 /// Erase a spinner remnant before printing anything else on stderr. The

--- a/harbor/crates/harbor/src/repl/snapshot.rs
+++ b/harbor/crates/harbor/src/repl/snapshot.rs
@@ -1,0 +1,339 @@
+//! A snapshot whose lifetime follows the backup client, including file work
+//! between SQL requests. Losing its renewal aborts rather than reopening it.
+
+use super::{Conn, Mode, Outcome, RenderOpts, endpoint, http, resolve, run_sql_in_session};
+use std::io;
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Default)]
+pub(super) struct Health(Arc<Mutex<Option<String>>>);
+
+impl Health {
+    pub(super) fn check(&self) -> io::Result<()> {
+        match self.0.lock().unwrap().as_ref() {
+            Some(message) => Err(io::Error::other(message.clone())),
+            None => Ok(()),
+        }
+    }
+}
+
+struct Heartbeat {
+    stop: mpsc::Sender<()>,
+    thread: Option<JoinHandle<()>>,
+    health: Health,
+}
+
+impl Heartbeat {
+    fn start(conn: &Conn, id: &str, ttl: Duration) -> Result<Self, String> {
+        if ttl < Duration::from_millis(30) {
+            return Err("backup renewal window is too short".into());
+        }
+        let (stop, rx) = mpsc::channel();
+        let health = Health::default();
+        let failure = health.clone();
+        let transport = conn.transport.clone();
+        let route = endpoint::session_renew(id);
+        let interval = ttl / 3;
+        let timeout = interval.min(Duration::from_secs(5));
+        let thread = thread::Builder::new()
+            .name("backup-heartbeat".into())
+            .spawn(move || {
+                while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(interval) {
+                    let deadline = Instant::now() + timeout;
+                    let tick = || {
+                        if Instant::now() >= deadline {
+                            Err(io::Error::new(io::ErrorKind::TimedOut, "renewal timed out"))
+                        } else {
+                            Ok(())
+                        }
+                    };
+                    let result = http::request_streaming(&transport, &route, None, &tick).and_then(
+                        |response| {
+                            tick()?;
+                            if response.status == 200 {
+                                Ok(())
+                            } else {
+                                Err(io::Error::other(format!("HTTP {}", response.status)))
+                            }
+                        },
+                    );
+                    if let Err(e) = result {
+                        *failure.0.lock().unwrap() = Some(format!(
+                            "backup lease renewal failed: {e}; the snapshot was abandoned"
+                        ));
+                        break;
+                    }
+                }
+            })
+            .map_err(|e| format!("starting backup heartbeat: {e}"))?;
+        Ok(Self {
+            stop,
+            thread: Some(thread),
+            health,
+        })
+    }
+}
+
+impl Drop for Heartbeat {
+    fn drop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+struct Release<'a>(&'a Conn, String);
+
+impl Drop for Release<'_> {
+    fn drop(&mut self) {
+        // DELETE cancels active work and rolls back on errors and unwind.
+        let _ = http::request(
+            &self.0.transport,
+            &endpoint::session(&self.1),
+            None,
+            Some(Duration::from_secs(5)),
+        );
+    }
+}
+
+/// Run a multi-pass export on one renewable snapshot. Heartbeats continue
+/// during both SQL and the closure's file inspection. A lost lease or failed
+/// statement aborts; the operation never resumes on a newer snapshot.
+pub fn with_snapshot<T>(
+    target: &str,
+    work: impl FnOnce(&dyn Fn(&str) -> Result<(), String>) -> Result<T, String>,
+) -> Result<T, String> {
+    let (conn, _) = resolve(target, &[])?;
+    let _anchor = http::hold(&conn.transport);
+    let response = http::request(
+        &conn.transport,
+        &endpoint::SESSIONS_CREATE,
+        Some(r#"{"purpose":"backup"}"#),
+        Some(Duration::from_secs(10)),
+    )
+    .map_err(|e| format!("opening backup session: {e}"))?;
+    let status = response.status;
+    let text = response
+        .body_string()
+        .map_err(|e| format!("reading backup session: {e}"))?;
+    if status != 200 {
+        return Err(format!("opening backup session: HTTP {status}: {text}"));
+    }
+    let lease: wire::SessionNewResponse =
+        serde_json::from_str(&text).map_err(|e| format!("invalid backup session response: {e}"))?;
+    // Construct this first: stop the heartbeat before releasing the lease.
+    let release = Release(&conn, lease.session_id);
+    if lease.purpose != Some(wire::SessionPurpose::Backup) {
+        return Err(
+            "server does not support renewable backup sessions; upgrade the Harbor server".into(),
+        );
+    }
+    let heartbeat = Heartbeat::start(&conn, &release.1, Duration::from_millis(lease.ttl_ms))?;
+    let opts = RenderOpts {
+        mode: Mode::Trash,
+        ..RenderOpts::default()
+    };
+    let execute = |sql: &str| {
+        heartbeat.health.check().map_err(|e| e.to_string())?;
+        let outcome =
+            run_sql_in_session(&conn, sql, &opts, Some(&release.1), Some(&heartbeat.health));
+        heartbeat.health.check().map_err(|e| e.to_string())?;
+        match outcome {
+            Outcome::Done => Ok(()),
+            Outcome::Cancelled => Err("backup interrupted".into()),
+            Outcome::Failed => Err("backup statement failed; the snapshot was abandoned".into()),
+        }
+    };
+    execute("BEGIN")?;
+    let value = work(&execute)?;
+    execute("COMMIT")?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct Server {
+        target: String,
+        log: Arc<Mutex<Vec<String>>>,
+        stop: Arc<AtomicBool>,
+        thread: Option<JoinHandle<()>>,
+    }
+
+    impl Server {
+        fn new(supports_backup: bool, renew_status: u16) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let target = format!("http://{}", listener.local_addr().unwrap());
+            listener.set_nonblocking(true).unwrap();
+            let stop = Arc::new(AtomicBool::new(false));
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let stopping = stop.clone();
+            let requests = log.clone();
+            let thread = thread::spawn(move || {
+                let mut handlers = Vec::new();
+                while !stopping.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            let requests = requests.clone();
+                            handlers.push(thread::spawn(move || {
+                                serve(stream, requests, supports_backup, renew_status);
+                            }));
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(2));
+                        }
+                        Err(e) => panic!("accept: {e}"),
+                    }
+                }
+                for handler in handlers {
+                    handler.join().unwrap();
+                }
+            });
+            Self {
+                target,
+                log,
+                stop,
+                thread: Some(thread),
+            }
+        }
+
+        fn requests(&self) -> Vec<String> {
+            self.log.lock().unwrap().clone()
+        }
+    }
+
+    impl Drop for Server {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            self.thread.take().unwrap().join().unwrap();
+        }
+    }
+
+    fn serve(stream: TcpStream, log: Arc<Mutex<Vec<String>>>, supported: bool, renew: u16) {
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        // The anchor deliberately sends no HTTP request.
+        if !matches!(reader.read_line(&mut line), Ok(n) if n > 0) {
+            return;
+        }
+        let route = line
+            .split_whitespace()
+            .take(2)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mut len = 0;
+        loop {
+            line.clear();
+            reader.read_line(&mut line).unwrap();
+            if line == "\r\n" {
+                break;
+            }
+            if let Some((key, value)) = line.split_once(':')
+                && key.eq_ignore_ascii_case("content-length")
+            {
+                len = value.trim().parse().unwrap();
+            }
+        }
+        let mut body = vec![0; len];
+        reader.read_exact(&mut body).unwrap();
+        let (status, body) = if route == "POST /sql/sessions" {
+            let request: wire::SessionNewRequest = serde_json::from_slice(&body).unwrap();
+            assert_eq!(request.purpose, Some(wire::SessionPurpose::Backup));
+            let purpose = if supported {
+                r#", "purpose":"backup""#
+            } else {
+                ""
+            };
+            (
+                200,
+                format!(r#"{{"sessionId":"test","ttlMs":300,"idleTtlMs":0{purpose}}}"#),
+            )
+        } else if route.ends_with("/renew") {
+            (renew, r#"{"renewed":true}"#.into())
+        } else if route == "POST /sql" {
+            let request: wire::SqlRequest = serde_json::from_slice(&body).unwrap();
+            assert_eq!(request.session_id.as_deref(), Some("test"));
+            log.lock().unwrap().push(request.sql.clone());
+            if request.sql == "STALL" {
+                // No headers: only a failed heartbeat can unblock this client.
+                let _ = reader.read(&mut [0]);
+                return;
+            }
+            (
+                200,
+                "{\"type\":\"end\",\"rowCount\":0,\"timeMs\":0}\n".into(),
+            )
+        } else {
+            assert_eq!(route, "DELETE /sql/sessions/test");
+            (200, r#"{"released":true}"#.into())
+        };
+        log.lock().unwrap().push(route);
+        let mut stream = reader.into_inner();
+        let _ = write!(
+            stream,
+            "HTTP/1.1 {status} Test\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+    }
+
+    #[test]
+    fn renews_during_file_work_and_stops_before_release() {
+        let server = Server::new(true, 200);
+        with_snapshot(&server.target, |_| {
+            thread::sleep(Duration::from_millis(850));
+            Ok(())
+        })
+        .unwrap();
+        let log = server.requests();
+        assert!(
+            log.iter().filter(|r| r.ends_with("/renew")).count() >= 3,
+            "{log:?}"
+        );
+        assert!(log.contains(&"BEGIN".into()) && log.contains(&"COMMIT".into()));
+        assert_eq!(log.last().unwrap(), "DELETE /sql/sessions/test");
+        thread::sleep(Duration::from_millis(150));
+        assert_eq!(log, server.requests());
+    }
+
+    #[test]
+    fn failed_renewal_aborts_before_headers_and_never_commits() {
+        let server = Server::new(true, 404);
+        let start = Instant::now();
+        let error = with_snapshot(&server.target, |execute| execute("STALL")).unwrap_err();
+        assert!(
+            error.contains("renewal failed"),
+            "{error}; {:?}",
+            server.requests()
+        );
+        assert!(start.elapsed() < Duration::from_secs(2));
+        let log = server.requests();
+        assert!(log.contains(&"STALL".into()));
+        assert!(!log.contains(&"COMMIT".into()));
+        assert_eq!(log.last().unwrap(), "DELETE /sql/sessions/test");
+    }
+
+    #[test]
+    fn old_server_is_rejected_and_its_lease_released() {
+        let server = Server::new(false, 200);
+        let error = with_snapshot(&server.target, |_| -> Result<(), String> {
+            panic!("must not export on a legacy lease");
+        })
+        .unwrap_err();
+        assert!(error.contains("upgrade"), "{error}");
+        assert_eq!(
+            server.requests(),
+            ["POST /sql/sessions", "DELETE /sql/sessions/test"]
+        );
+    }
+}

--- a/harbor/crates/harbor/tests/engine.rs
+++ b/harbor/crates/harbor/tests/engine.rs
@@ -268,10 +268,46 @@ mod conn {
     }
 
     #[test]
+    fn reset_discards_local_state_and_rolls_back() {
+        let Some(_) = v2_engine() else { return };
+        let mut c = conn::open(Path::new(":memory:"), &[]).unwrap();
+        c.execute_batch("CREATE TABLE durable(x INTEGER); CREATE TEMP TABLE private(x INTEGER); \
+            SET VARIABLE secret=42; PREPARE private_stmt AS SELECT 1; BEGIN; \
+            INSERT INTO durable VALUES (7)").unwrap();
+        c.reset().unwrap();
+        assert_eq!(rows(&mut c, "SELECT count(*) FROM durable", &[]).unwrap(), ["0"]);
+        assert_eq!(rows(&mut c, "SELECT getvariable('secret')", &[]).unwrap(), ["null"]);
+        assert!(rows(&mut c, "SELECT * FROM private", &[]).is_err());
+        assert!(rows(&mut c, "EXECUTE private_stmt", &[]).is_err());
+    }
+
+    #[test]
+    fn cache_has_a_byte_budget_and_skips_large_text() {
+        use std::sync::Arc;
+        let Some(_) = v2_engine() else { return };
+        let mut c = conn::open(Path::new(":memory:"), &[]).unwrap();
+        let small = c.statements("SELECT 1").unwrap();
+        assert!(Arc::ptr_eq(&small, &c.statements("SELECT 1").unwrap()));
+        let large = format!("SELECT 1 /*{}*/", "x".repeat(65_536));
+        let parsed = c.statements(&large).unwrap();
+        assert!(!Arc::ptr_eq(&parsed, &c.statements(&large).unwrap()));
+        // Fewer than 64 entries, but more than 1 MiB: byte pressure must evict.
+        let first = format!("SELECT 1 /*{}*/", "y".repeat(60_000));
+        let parsed = c.statements(&first).unwrap();
+        for i in 2..22 {
+            c.statements(&format!("SELECT {i} /*{}*/", "y".repeat(60_000))).unwrap();
+        }
+        assert!(!Arc::ptr_eq(&parsed, &c.statements(&first).unwrap()));
+    }
+
+    #[test]
     fn interrupt_crosses_threads() {
         let Some(_) = v2_engine() else { return };
         let mut c = conn::open(Path::new(":memory:"), &[]).expect("open");
         let handle = c.interrupt_handle();
+
+        // The executor keeps this handle across connection replacements.
+        c.reset().unwrap();
 
         // Fire the interrupt shortly after the query starts, from another
         // thread.

--- a/harbor/crates/harbor/tests/snapshot.rs
+++ b/harbor/crates/harbor/tests/snapshot.rs
@@ -1,0 +1,132 @@
+//! A multi-pass backup must retain its snapshot when another caller commits
+//! between export and re-export. Exercise the real HTTP session helper.
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct Server {
+    child: Child,
+    dir: PathBuf,
+}
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn export_passes_share_a_snapshot_and_failures_rollback() {
+    if harbor::engine::engine().is_err() {
+        return;
+    }
+    let base = if cfg!(unix) {
+        PathBuf::from("/tmp")
+    } else {
+        std::env::temp_dir()
+    };
+    let dir = base.join(format!("hb-snapshot-{}", std::process::id()));
+    std::fs::create_dir(&dir).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    let child = Command::new(env!("CARGO_BIN_EXE_harbor"))
+        .args([
+            dir.join("source.duckdb").to_str().unwrap(),
+            "start",
+            "--port",
+            &address.port().to_string(),
+            "--workers",
+            "1",
+            "--statement-timeout",
+            "1s",
+        ])
+        .env("HARBOR_HOME", dir.join("home"))
+        .env("HARBOR_POOL_SIZE", "2")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut server = Server { child, dir };
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(mut stream) = TcpStream::connect(address) {
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            stream
+                .write_all(b"GET /ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            let mut response = String::new();
+            if stream.read_to_string(&mut response).is_ok() && response.starts_with("HTTP/1.1 200")
+            {
+                break;
+            }
+        }
+        assert!(
+            server.child.try_wait().unwrap().is_none(),
+            "server exited during startup"
+        );
+        assert!(Instant::now() < deadline, "server never became ready");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let target = format!("http://{address}");
+    let quiet = |sql: &[&str]| harbor::repl::exec_quiet(&target, sql, &[]).unwrap();
+    quiet(&["CREATE TABLE t(x INTEGER)", "INSERT INTO t VALUES (1)"]);
+    let path = |name: &str| {
+        format!(
+            "'{}'",
+            server
+                .dir
+                .join(name)
+                .display()
+                .to_string()
+                .replace('\'', "''")
+        )
+    };
+    harbor::repl::with_snapshot(&target, |execute| {
+        execute(&format!("EXPORT DATABASE {} (FORMAT CSV)", path("export")))?;
+        quiet(&["INSERT INTO t VALUES (2)"]);
+        execute(&format!(
+            "COPY t TO {} (FORMAT CSV, HEADER true)",
+            path("again.csv")
+        ))
+    })
+    .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(server.dir.join("again.csv")).unwrap(),
+        "x\n1\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(server.dir.join("export/t.csv")).unwrap(),
+        "x\n1\n"
+    );
+
+    let started = Instant::now();
+    let timed_out = harbor::repl::with_snapshot(&target, |execute| {
+        execute("SELECT sum(sin(i)) FROM range(1000000000000) t(i)")
+    });
+    assert!(
+        timed_out.is_err(),
+        "backup must respect the operator statement timeout"
+    );
+    assert!(started.elapsed() < Duration::from_secs(5));
+
+    let failed: Result<(), String> = harbor::repl::with_snapshot(&target, |execute| {
+        execute("INSERT INTO t VALUES (3)")?;
+        Err("simulated file inspection failure".into())
+    });
+    assert!(failed.is_err());
+    quiet(&[&format!(
+        "COPY (SELECT x FROM t ORDER BY x) TO {} (FORMAT CSV, HEADER true)",
+        path("current.csv")
+    )]);
+    assert_eq!(
+        std::fs::read_to_string(server.dir.join("current.csv")).unwrap(),
+        "x\n1\n2\n"
+    );
+}

--- a/harbor/crates/wire/src/lib.rs
+++ b/harbor/crates/wire/src/lib.rs
@@ -78,13 +78,17 @@ pub mod endpoint {
     pub const INFO: Route = Route::fixed("GET", "/info");
 
     /// Every fixed route, so a client (or a test on harbor's side) can walk
-    /// the contract instead of transcribing it. The two builders below are
+    /// the contract instead of transcribing it. The builders below are
     /// not here: their paths carry an id, so there is nothing to enumerate.
     pub const FIXED: &[Route] =
         &[SQL, SESSIONS_CREATE, SESSIONS, CATALOG, SHUTDOWN, READY, INFO];
 
-    /// DELETE — release the session `id` holds, rolling back any open
-    /// transaction. A builder, since the id rides in the path.
+    /// Renew a backup lease, including while its statement is running.
+    pub fn session_renew(id: &str) -> Route {
+        Route::built("POST", format!("/sql/sessions/{id}/renew"))
+    }
+
+    /// DELETE — release the session, rolling back any open transaction.
     pub fn session(id: &str) -> Route {
         Route::built("DELETE", format!("/sql/sessions/{id}"))
     }
@@ -142,10 +146,24 @@ pub struct SqlRequest {
     pub timeout_ms: Option<u64>,
 }
 
+/// Lease lifetime policy. Interactive leases have a fixed maximum lifetime;
+/// backup leases survive while the client renews them before each deadline.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionPurpose {
+    Interactive,
+    Backup,
+}
+
 /// POST /sql/sessions request body (may be empty / absent).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionNewRequest {
+    /// Absent means interactive. Backup clients must verify this in the response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<SessionPurpose>,
+    /// Positive milliseconds: total lifetime for interactive sessions (max 300s),
+    /// renewal window for backups (max 60s). Absent uses the relevant maximum.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_ms: Option<u64>,
 }
@@ -153,8 +171,11 @@ pub struct SessionNewRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionNewResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<SessionPurpose>,
     pub session_id: String,
     pub ttl_ms: u64,
+    /// Zero for backups: renewal replaces statement-idle expiry.
     pub idle_ttl_ms: u64,
 }
 

--- a/harbor/test/scripts/check.sh
+++ b/harbor/test/scripts/check.sh
@@ -39,7 +39,7 @@ s.close()')}
 # port this runner has already given to the shared server — the run dies at
 # startup with "address already in use" and it looks like a harbor bug.
 unset PORT
-suites=${SUITES:-unit lifecycle roundtrip types asserts spec fuzz hostile deployment stress catalog sessions cancel}
+suites=${SUITES:-unit regressions lifecycle roundtrip types asserts spec fuzz hostile deployment stress catalog sessions cancel}
 
 bold=$(tput bold 2>/dev/null || true); red=$(tput setaf 1 2>/dev/null || true)
 green=$(tput setaf 2 2>/dev/null || true); dim=$(tput dim 2>/dev/null || true)
@@ -114,6 +114,7 @@ skip() { skipped+=("$1"); printf '%s— %s skipped: %s%s\n' "$dim" "$1" "$2" "$o
 # reader either. Between them that left 101 tests — every justhttp test and
 # every config test — building fine and running nowhere.
 run unit     cargo test --release --workspace --all-features
+run regressions python3 "$here/test/scripts/regressions.py"
 # The lifetime doctrine runs the real binary in its own $HARBOR_HOME sandbox —
 # no shared server, and nothing it starts outlives it.
 run lifecycle "$here/test/scripts/lifecycle.sh"

--- a/harbor/test/scripts/regressions.py
+++ b/harbor/test/scripts/regressions.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Review regressions: request isolation, settings policy, body limits and config writes.
+
+Runs an isolated one-worker/two-connection server so connection reuse is deterministic.
+"""
+import concurrent.futures
+import http.client
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+BINARY = ROOT / "target/release/harbor"
+LIMIT = 8 << 20
+
+
+class Regressions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.work = tempfile.TemporaryDirectory(prefix="hb-reg-", dir="/tmp")
+        cls.root = Path(cls.work.name)
+        cls.env = dict(os.environ, HARBOR_HOME=str(cls.root / "home"), HARBOR_POOL_SIZE="2")
+        cls.db = cls.root / "source.duckdb"
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            cls.port = s.getsockname()[1]
+        cls.log = open(cls.root / "server.log", "w")
+        cls.server = subprocess.Popen(
+            [str(BINARY), str(cls.db), "start", "--port", str(cls.port), "--workers", "1"],
+            env=cls.env, stdout=cls.log, stderr=cls.log,
+        )
+        for _ in range(100):
+            try:
+                if cls.request("GET", "/ready")[0] == 200:
+                    return
+            except OSError:
+                pass
+            if cls.server.poll() is not None:
+                break
+            time.sleep(.1)
+        cls.tearDownClass()
+        raise RuntimeError("regression server failed to start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.terminate()
+        try:
+            cls.server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            cls.server.kill()
+            cls.server.wait()
+        cls.log.close()
+        cls.work.cleanup()
+
+    @classmethod
+    def request(cls, method, path, data=None, chunked=False):
+        body = json.dumps(data).encode() if isinstance(data, dict) else data
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if chunked:
+            headers["Transfer-Encoding"] = "chunked"
+            body = [body]
+        conn = http.client.HTTPConnection("127.0.0.1", cls.port, timeout=20)
+        try:
+            conn.request(method, path, body, headers, encode_chunked=chunked)
+            response = conn.getresponse()
+            return response.status, json.loads(response.read())
+        finally:
+            conn.close()
+
+    def sql(self, sql, session=None, status=200):
+        body = {"sql": sql}
+        if session:
+            body["sessionId"] = session
+        actual, doc = self.request("POST", "/sql", body)
+        self.assertEqual(actual, status, (sql, doc))
+        return doc
+
+    def session(self):
+        status, doc = self.request("POST", "/sql/sessions", {})
+        self.assertEqual(status, 200, doc)
+        return doc["sessionId"]
+
+    def release(self, sid):
+        self.assertEqual(self.request("DELETE", "/sql/sessions/" + sid)[0], 200)
+
+    def test_backup_lease_policy_and_expiry(self):
+        for data in ({"purpose": "unknown"}, {"ttlMs": 0}, {"ttlMs": -1}):
+            self.assertEqual(self.request("POST", "/sql/sessions", data)[0], 400)
+        status, ordinary = self.request("POST", "/sql/sessions", {"ttlMs": 999999})
+        self.assertEqual(status, 200)
+        self.assertEqual(ordinary["ttlMs"], 300000)
+        self.assertEqual(ordinary["idleTtlMs"], 30000)
+        sid = ordinary["sessionId"]
+        try:
+            self.assertEqual(self.request("POST", f"/sql/sessions/{sid}/renew")[0], 400)
+        finally:
+            self.release(sid)
+        status, backup = self.request("POST", "/sql/sessions", {"purpose": "backup", "ttlMs": 999999})
+        self.assertEqual(status, 200)
+        self.assertEqual((backup["purpose"], backup["ttlMs"], backup["idleTtlMs"]), ("backup", 60000, 0))
+        self.release(backup["sessionId"])
+        status, backup = self.request("POST", "/sql/sessions", {"purpose": "backup", "ttlMs": 600})
+        self.assertEqual(status, 200)
+        sid = backup["sessionId"]
+        renew = f"/sql/sessions/{sid}/renew"
+        try:
+            self.sql("BEGIN", sid)
+            for _ in range(5):
+                time.sleep(.2)
+                self.assertEqual(self.request("POST", renew), (200, {"renewed": True}))
+            self.sql("SELECT 1", sid)
+            time.sleep(.7)
+            self.assertEqual(self.request("POST", renew)[0], 404)
+            self.sql("COMMIT", sid, status=404)
+        finally:
+            self.release(sid)
+        self.assertEqual(self.request("POST", renew)[0], 404)
+
+    def test_backup_heartbeats_work_during_busy_query_then_expiry_cancels(self):
+        status, backup = self.request("POST", "/sql/sessions", {"purpose": "backup", "ttlMs": 6000})
+        self.assertEqual(status, 200)
+        sid = backup["sessionId"]
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                query = executor.submit(self.request, "POST", "/sql", {
+                    "sql": "SELECT sum(sin(i)) FROM range(1000000000000) t(i)", "sessionId": sid,
+                })
+                # Forwarded lease work activates the probe after the worker's
+                # five-second request threshold; allow that initial handoff.
+                for _ in range(6):
+                    time.sleep(.35)
+                    self.assertEqual(self.request("POST", f"/sql/sessions/{sid}/renew")[0], 200)
+                    self.assertFalse(query.done(), "query ended despite timely renewals")
+                # Stop renewing: expiration must interrupt a busy executor too.
+                status, body = query.result(timeout=10)
+                self.assertNotEqual(status, 200, body)
+            self.assertEqual(self.request("POST", f"/sql/sessions/{sid}/renew")[0], 404)
+        finally:
+            self.release(sid)
+        for _ in range(30):
+            status, report = self.request("GET", "/sessions")
+            if report["connections"]["free"] == 1:
+                break
+            time.sleep(.1)
+        self.assertTrue(report["connections"]["balanced"])
+        self.assertEqual(report["connections"]["free"], 1)
+        self.assertEqual(self.sql("SELECT 42")["data"], [[42]])
+
+    def test_wrapped_begin_cannot_capture_another_callers_write(self):
+        self.sql("CREATE TABLE acknowledged(x INTEGER)")
+        self.sql("EXPLAIN ANALYZE BEGIN")
+        self.sql("INSERT INTO acknowledged VALUES (42)")
+        sid = self.session()
+        try:
+            self.assertEqual(self.sql("SELECT * FROM acknowledged", sid)["data"], [[42]])
+        finally:
+            self.release(sid)
+        self.sql("ROLLBACK", status=400)
+        self.assertEqual(self.sql("SELECT * FROM acknowledged")["data"], [[42]])
+
+    def test_worker_discards_connection_local_state(self):
+        self.sql("SET VARIABLE secret='previous caller'")
+        self.assertEqual(self.sql("SELECT getvariable('secret')")["data"], [[None]])
+        self.sql("CREATE TEMP TABLE private_worker AS SELECT 1 x")
+        self.sql("SELECT * FROM private_worker", status=400)
+        self.sql("PREPARE private_stmt AS SELECT 42")
+        self.sql("EXECUTE private_stmt", status=400)
+
+    def test_released_session_discards_all_local_state(self):
+        first = self.session()
+        try:
+            self.sql("CREATE TEMP TABLE private_lease AS SELECT 42 x", first)
+            self.sql("SET VARIABLE secret='first lease'", first)
+            self.assertEqual(self.sql("SELECT * FROM private_lease", first)["data"], [[42]])
+        finally:
+            self.release(first)
+        second = self.session()
+        try:
+            self.sql("SELECT * FROM private_lease", second, status=400)
+            self.assertEqual(self.sql("SELECT getvariable('secret')", second)["data"], [[None]])
+        finally:
+            self.release(second)
+
+    def test_wrapped_settings_cannot_override_operator_policy(self):
+        before = self.sql("SELECT current_setting('threads')")["data"]
+        for sql in ["EXPLAIN ANALYZE SET threads=2", "EXPLAIN ANALYZE SET worker_threads=2",
+                    "EXPLAIN ANALYZE SET allowed_configs=['threads']",
+                    "EXPLAIN ANALYZE SET lock_configuration=false"]:
+            self.sql(sql, status=400)
+        self.assertEqual(self.sql("SELECT current_setting('threads')")["data"], before)
+        self.sql("SET default_order='DESC'")
+        self.sql("RESET default_order")
+
+    def test_chunked_limit_applies_to_both_body_endpoints(self):
+        for path, data in [("/sql", {"sql": "CREATE TABLE oversized(x INTEGER)"}),
+                           ("/sql/sessions", {})]:
+            prefix = json.dumps(data).encode()
+            body = prefix + b" " * (LIMIT - len(prefix)) + b"not JSON"
+            status, doc = self.request("POST", path, body, chunked=True)
+            self.assertEqual(status, 413, doc)
+        self.sql("SELECT * FROM oversized", status=400)
+        sid = self.session()  # the rejected body must not have consumed the only lease
+        self.release(sid)
+        prefix = b'{"sql":"SELECT 42"}'
+        status, doc = self.request("POST", "/sql", prefix + b" " * (LIMIT - len(prefix)), chunked=True)
+        self.assertEqual(status, 200, doc)
+        self.assertEqual(doc["data"], [[42]])
+
+    def test_concurrent_membership_updates_keep_every_success(self):
+        home = self.root / "config-writers"
+        env = dict(self.env, HARBOR_HOME=str(home))
+        files = [self.root / ("item%d.duckdb" % i) for i in range(32)]
+        for path in files:
+            path.touch()
+        def attach(path):
+            return subprocess.run([str(BINARY), str(path), "attach"], env=env,
+                                  capture_output=True, text=True, timeout=20)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            for result in pool.map(attach, files):
+                self.assertEqual(result.returncode, 0, result.stderr)
+        config = (home / "config.toml").read_text()
+        for i in range(len(files)):
+            self.assertIn("[connection.item%d]" % i, config)
+        self.assertEqual(list(home.glob("*.tmp")), [])
+        if os.name == "posix":
+            self.assertEqual((home / "config.toml").stat().st_mode & 0o777, 0o600)
+
+    def test_backup_quoted_paths_and_identifiers_restore_after_move(self):
+        self.sql('CREATE SCHEMA "odd schema"')
+        self.sql('CREATE TABLE "odd schema"."a\'b\nname"(v VARCHAR)')
+        self.sql('INSERT INTO "odd schema"."a\'b\nname" VALUES (\'\'), (\'hello\')')
+        backup = self.root / "it's a backup"
+        result = subprocess.run([str(BINARY), str(self.db), "backup", str(backup)],
+                                env=self.env, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        moved = self.root / "moved"
+        backup.rename(moved)
+        restored = self.root / "restored.duckdb"
+        result = subprocess.run([str(BINARY), str(restored), "restore", str(moved)],
+                                env=self.env, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        result = subprocess.run([str(BINARY), str(restored), "--mode", "json", "-c",
+                                 'SELECT count(*) AS n FROM "odd schema"."a\'b\nname"'],
+                                env=self.env, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), [{"n": 2}])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Release branch for harbor 0.36.0. See `harbor/CHANGELOG.md` for the entry.

- Renewable backup sessions (`{"purpose":"backup"}`, `POST /sql/sessions/<id>/renew`) so `backup` reads one snapshot across every pass; a lost lease aborts rather than resuming on a newer snapshot.
- One statement per request, refused before any of it runs.
- Connections are replaced, not rolled back, after any statement that can leave connection-local state; released sessions too.
- Memory, threads and spill locked at startup through `allowed_configs` and `lock_configuration`.
- `413` for oversized bodies on both endpoints; parsed-statement cache bounded to 64 texts, 1 MiB, 64 KiB per statement.
- `config.toml` writes take an exclusive lock and refuse exposed directories.
- Windows banner prints `C:\...` without the verbatim prefix (#55).
- New `regressions` suite; `make test` runs all features in release mode.

Full local run: `cargo test --workspace` and all 14 `check.sh` suites pass.
