### PR TITLE
Release Harbor 0.36.3

### DIFF
--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,6 +4,20 @@ Harbor release tags use `vX.Y.Z`. Entries are ordered by release date,
 newest first. Separately tagged DuckDB engine mirrors are build artifacts, not
 Harbor releases, and are not included here.
 
+## 0.36.3 — 2026-09-12
+
+- **A completion menu lets go of the statement it was opened for, however
+  fast it was typed.** The menu stands down when a typed character can no
+  longer extend the word it is completing, but it read only the first
+  character of each batch of edits, and consecutive keystrokes reach the
+  editor fused into one. Typing the tail of a statement at any speed
+  therefore hid the boundary inside the batch: `show tab`, Tab, `les;`,
+  Enter appended the highlighted `table` to a finished statement rather
+  than running it. Every character in a batch is now read, so the word ends
+  wherever its boundary falls.
+- Records the vendored reedline copy as carrying three patches rather than
+  two, with the upstream state of each and what un-vendoring will require.
+
 ## 0.36.2 — 2026-09-11
 
 - **A summoned server no longer leaves while a client is still there.** The

--- a/harbor/Cargo.lock
+++ b/harbor/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.36.2"
+version = "0.36.3"
 dependencies = [
  "crossterm",
  "getrandom 0.2.17",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "harbor-common"
-version = "0.36.2"
+version = "0.36.3"
 dependencies = [
  "libc",
  "serde",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "justhttp"
-version = "0.36.2"
+version = "0.36.3"
 dependencies = [
  "ascii",
  "chunked_transfer",
@@ -1083,7 +1083,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wire"
-version = "0.36.2"
+version = "0.36.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/harbor/Cargo.toml
+++ b/harbor/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 # archive would have shipped a `pilot --version` that disagreed with its own
 # filename. Inheriting removes the chance to forget one.
 [workspace.package]
-version = "0.36.2"
+version = "0.36.3"
 repository = "https://github.com/shreeve/duckdb-harbor"
 
 [profile.release]


### PR DESCRIPTION
Cuts 0.36.3 for the completion-menu fix already on main (`2117d74`).

The menu stands down when a typed character can no longer extend the word it is completing, but it read only the first command of each edit batch. Consecutive keystrokes reach the editor fused into one `ReedlineEvent::Edit`, so the tail of a statement typed at speed hid the boundary inside the batch: `show tab`, Tab, `les;`, Enter appended the highlighted `table` to a finished statement instead of running it. Every `InsertChar` in a batch is now read.

Version bump, lockfile, and changelog entry. Also records the vendored reedline copy as carrying three patches rather than two, with the upstream state of each.

Harbor builds and `cargo test -p harbor` is green; the vendor's own suite passes including the new `a_word_ends_inside_a_burst_of_typing` regression.